### PR TITLE
eature: Control Dark Mode via Firebase Remote Config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "leaflet": "^1.9.4",
         "leaflet.heat": "^0.2.0",
         "leaflet.markercluster": "^1.5.3",
+        "lucide-react": "^0.507.0",
         "postcss-cli": "^11.0.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -5096,6 +5097,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.507.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.507.0.tgz",
+      "integrity": "sha512-XfgE6gvAHwAtnbUvWiTTHx4S3VGR+cUJHEc0vrh9Ogu672I1Tue2+Cp/8JJqpytgcBHAB1FVI297W4XGNwc2dQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/mdast-util-from-markdown": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "leaflet": "^1.9.4",
     "leaflet.heat": "^0.2.0",
     "leaflet.markercluster": "^1.5.3",
+    "lucide-react": "^0.507.0",
     "postcss-cli": "^11.0.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@
 import { JSX } from 'react';
 import { BrowserRouter, Routes, Route, Link, Navigate, useLocation } from 'react-router-dom';
 // Import Theme context provider and hook
-import { ThemeProvider, useTheme } from './context/ThemeContext';
+import { ThemeProvider } from './context/ThemeContext';
 import { AuthProvider, useAuth } from './context/AuthContext';
 import Login from './components/Login';
 import QuickLogPage from './pages/QuickLogPage';
@@ -11,34 +11,11 @@ import ImportPage from './pages/ImportPage';
 import { Analytics } from '@vercel/analytics/react';
 import PrivacyPolicyPage from './pages/PrivacyPolicyPage';
 import FuelMapPage from './components/FuelMapPage';
-
-/**
- * Simple Sun/Moon Icon component for the toggle button
- */
-function ThemeIcon({ theme }: { theme: 'light' | 'dark' }) {
-    if (theme === 'dark') {
-        // Moon Icon (Example using SVG)
-        return (
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z" />
-            </svg>
-        );
-    } else {
-        // Sun Icon (Example using SVG)
-        return (
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M12 6.75V4.5" />
-                <path strokeLinecap="round" strokeLinejoin="round" d="M12 18a6 6 0 1 0 0-12 6 6 0 0 0 0 12Z" />
-            </svg>
-        );
-    }
-}
-
+import ThemeToggle from './components/ThemeToggle';
 
 /** Component shown when the user IS authenticated */
 function AuthenticatedApp(): JSX.Element {
   const { user, logout } = useAuth();
-  const { theme, toggleTheme } = useTheme(); // Use the theme context
   const location = useLocation();
 
   const getNavLinkClass = (path: string): string => {
@@ -65,13 +42,7 @@ function AuthenticatedApp(): JSX.Element {
             <Link to="/map" className={getNavLinkClass("/map")}>Map</Link>
 
             {/* Theme Toggle Button */}
-            <button
-                onClick={toggleTheme}
-                className="p-1.5 rounded-md text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800 transition duration-150 ease-in-out"
-                title={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
-            >
-                <ThemeIcon theme={theme} /> {/* Display Sun or Moon icon */}
-            </button>
+            <ThemeToggle />
 
             <span className="text-sm text-gray-600 dark:text-gray-400 hidden sm:inline">
               Hi, {user?.displayName?.split(' ')[0] || 'User'}!

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,25 @@
+// Example: src/components/ThemeToggle.tsx
+import React from 'react';
+import { useTheme } from '../context/ThemeContext'; // Adjust path
+import { Sun, Moon } from 'lucide-react'; // Example icons
+
+const ThemeToggle: React.FC = () => {
+  const { theme, toggleTheme, isDarkModeEnabledRemotely } = useTheme();
+
+  // Don't render the toggle if the feature is disabled via Remote Config
+  if (!isDarkModeEnabledRemotely) {
+    return null;
+  }
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="p-2 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+      aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
+    >
+      {theme === 'light' ? <Moon size={20} /> : <Sun size={20} />}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,6 +1,6 @@
 // src/context/ThemeContext.tsx
 import React, { createContext, useState, useEffect, useContext, ReactNode } from 'react';
-import { remoteConfig, activateRemoteConfig, getValue, isDarkModeEnabled } from '../firebase/remoteConfigService';
+import { activateRemoteConfig, isDarkModeEnabled } from '../firebase/remoteConfigService';
 
 type Theme = 'light' | 'dark';
 
@@ -29,7 +29,7 @@ export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) =
   useEffect(() => {
     const initializeThemeFromRC = async () => {
       await activateRemoteConfig(); // Fetch and activate
-      const enabled = getValue(remoteConfig, "darkModeEnabled").asBoolean();
+      const enabled = isDarkModeEnabled();
       setIsDarkModeEnabledRemotely(enabled);
       console.log("Remote Config - darkModeEnabled:", enabled);
 

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,6 +1,6 @@
 // src/context/ThemeContext.tsx
 import React, { createContext, useState, useEffect, useContext, ReactNode } from 'react';
-import { remoteConfig, activateRemoteConfig, getValue } from '../firebase/remoteConfigService';
+import { remoteConfig, activateRemoteConfig, getValue, isDarkModeEnabled } from '../firebase/remoteConfigService';
 
 type Theme = 'light' | 'dark';
 

--- a/src/firebase/config.ts
+++ b/src/firebase/config.ts
@@ -89,6 +89,7 @@ const logout = async (): Promise<void> => { try { await signOut(auth); console.l
 
 // Export the necessary instances and functions (db is now initialized above)
 export {
+  app,
   auth,
   db, // Export the initialized db instance
   googleProvider,

--- a/src/firebase/remoteConfigService.ts
+++ b/src/firebase/remoteConfigService.ts
@@ -1,0 +1,54 @@
+// src/firebase/remoteConfigService.ts
+import { getRemoteConfig, fetchAndActivate, getValue, RemoteConfig } from "firebase/remote-config";
+import { app } from './config'; // Import the initialized Firebase app instance
+
+// --- Initialize Remote Config ---
+const remoteConfig: RemoteConfig = getRemoteConfig(app);
+
+// Set default values (match console defaults)
+// Fetching happens infrequently, so defaults are important for first load or offline scenarios
+remoteConfig.settings.minimumFetchIntervalMillis = 3600000; // Cache for 1 hour (adjust as needed for development/production)
+remoteConfig.defaultConfig = {
+  "darkModeEnabled": false, // Default value if fetch fails or before first fetch
+  // Add other remote config defaults here if needed
+};
+console.log("Remote Config initialized with defaults.");
+// --- End Remote Config Initialization ---
+
+
+/**
+ * Fetches the latest Remote Config values from the Firebase backend and activates them.
+ * Activation makes the fetched values available to the app via `getValue`.
+ * It respects the `minimumFetchIntervalMillis` setting to avoid excessive fetching.
+ */
+const activateRemoteConfig = async (): Promise<boolean> => {
+  try {
+    const fetched = await fetchAndActivate(remoteConfig);
+    if (fetched) {
+      console.log("Remote Config fetched and activated.");
+    } else {
+      console.log("Remote Config using cached values (or defaults - within fetch interval).");
+    }
+    return fetched; // Indicates if new values were fetched and activated
+  } catch (error) {
+    console.error("Remote Config fetch failed:", error);
+    return false; // Fetch or activation failed
+  }
+};
+
+/**
+ * Gets the boolean value for the 'darkModeEnabled' parameter from Remote Config.
+ * Uses the activated value (or default if activation hasn't happened/failed).
+ * @returns {boolean} The value of the 'darkModeEnabled' parameter.
+ */
+const isDarkModeEnabled = (): boolean => {
+    return getValue(remoteConfig, "darkModeEnabled").asBoolean();
+};
+
+// Export the functions and the instance if needed elsewhere (though usually functions are preferred)
+export {
+  remoteConfig, // Export instance if direct access is needed (less common)
+  activateRemoteConfig,
+  isDarkModeEnabled,
+  getValue // Re-export getValue for accessing other parameters if necessary
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client'; // Import the client-specific entry point
 import App from './App.tsx'; // Import the main App component (ensure extension is .tsx)
 import './index.css'; // Import the global CSS file (where Tailwind directives are)
+import { ThemeProvider } from './context/ThemeContext.tsx';
 
 // Get the root element from index.html where the React app will be mounted
 const rootElement = document.getElementById('root');
@@ -20,6 +21,8 @@ root.render(
   // React.StrictMode helps identify potential problems in an application
   // It activates additional checks and warnings for its descendants.
   <React.StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Feature: Control Dark Mode via Firebase Remote Config

**Description:**

This pull request implements Firebase Remote Config to dynamically enable or disable the dark mode feature and its associated toggle button within the Fuelog application. This allows administrators to control the feature's availability without requiring a new front-end deployment.

**Changes Implemented:**

* **Remote Config Service (`src/firebase/remoteConfigService.ts`):**
    * Created a dedicated service to initialize Firebase Remote Config.
    * Sets default values (e.g., `darkModeEnabled: false`).
    * Includes a function `activateRemoteConfig` to fetch and activate the latest config values from Firebase.
    * Provides a helper function `isDarkModeEnabled` to easily retrieve the boolean value of the `darkModeEnabled` parameter.
* **Firebase Core Config (`src/firebase/config.ts`):**
    * Removed Remote Config initialization logic to keep the file focused on core Firebase setup (Auth, Firestore).
    * Exports the initialized Firebase `app` instance for use by the `remoteConfigService`.
* **Theme Context (`src/context/ThemeContext.tsx`):**
    * Created `ThemeContext` and `ThemeProvider` to manage the application's theme state (`light` or `dark`).
    * The `ThemeProvider` now:
        * Calls `activateRemoteConfig` on initialization.
        * Reads the `darkModeEnabled` value using `isDarkModeEnabled`.
        * Stores whether the feature is remotely enabled (`isDarkModeEnabledRemotely`).
        * Applies the theme (`light` or `dark`) to the root HTML element based on both the remote config flag and the user's preference (stored in `localStorage`).
        * Forces light mode if `darkModeEnabled` is false in Remote Config.
* **Application Wrapper (`src/main.tsx`):**
    * Wrapped the root `App` component with the `ThemeProvider` to make the theme context available globally.
* **Theme Toggle Component (e.g., `src/components/ThemeToggle.tsx`):**
    * Modified the component to use the `useTheme` hook.
    * Conditionally renders the toggle button only if `isDarkModeEnabledRemotely` from the context is `true`.
    * Calls the `toggleTheme` function from the context on click, which now respects the remote flag.
* **Tailwind Config (`tailwind.config.js`):**
    * Re-enabled `darkMode: 'class'` to ensure Tailwind generates the necessary `dark:` utility classes required when the feature *is* enabled.

**Purpose:**

* To provide a mechanism for remotely controlling the availability of the dark mode feature.
* To decouple the feature's UI presence from the codebase deployment cycle.
* To maintain a clean separation of concerns by isolating Remote Config logic.

**Setup Notes:**

* A parameter with the key `darkModeEnabled` (Data type: `Boolean`) must be created in the Firebase Remote Config console for this project.
* Set the default value for `darkModeEnabled` in the Firebase console (e.g., `false` to disable by default).
* Remember to **Publish changes** in the Remote Config console after setting the parameter.

**Testing:**

* Verified app loads correctly with Remote Config fetching enabled.
* Tested toggling the `darkModeEnabled` parameter in the Firebase console:
    * When `false`: Theme toggle button is hidden, app forces light mode regardless of localStorage.
    * When `true`: Theme toggle button is visible, toggling works, theme persists based on localStorage.
* Checked console logs for successful Remote Config activation or cache usage messages.
* Ensured no theme flashing occurs during initial load.

**(Optional) Closes:** #issue_number (if applicable)
