### PR TITLE
feat: Implement OpenGraph and Twitter metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,13 +10,13 @@
     <title>Fuelog</title>
     <meta property="og:title" content="Fuelog" />
     <meta property="og:description" content="Track your fuel consumption and vehicle maintenance." />
-    <meta property="og:image" content="/public/logo.png" />
+    <meta property="og:image" content="https://fuelog.paddez.com/public/logo.png" />
     <meta property="og:url" content="https://fuelog.paddez.com" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Fuelog" />
     <meta name="twitter:description" content="Track your fuel consumption and vehicle maintenance." />
-    <meta name="twitter:image" content="/public/logo.png" />
+    <meta name="twitter:image" content="https://fuelog.paddez.com/public/logo.png" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
I've added OpenGraph and Twitter-specific metadata tags to `index.html` to improve social media sharing and SEO for you.

The following tags were added:
- og:title
- og:description
- og:image
- og:url
- og:type
- twitter:card
- twitter:title
- twitter:description
- twitter:image