### PR TITLE
Fix: Configure Vercel rewrites for SPA routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
Added a vercel.json file with rewrite rules to ensure that all paths are directed to index.html, allowing the client-side router to handle navigation and prevent 404 errors on page refresh.