### PR TITLE
Fix: Set COOP to same-origin-allow-popups

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,15 @@
 {
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Cross-Origin-Opener-Policy",
+          "value": "same-origin-allow-popups"
+        }
+      ]
+    }
+  ],
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
Set the Cross-Origin-Opener-Policy to 'same-origin-allow-popups' in vercel.json. This is to address an issue where the COOP policy would block window.close calls, likely occurring with cross-origin popups (e.g., OAuth) that attempt to close themselves after an action.