### PR TITLE
feat(i18n): add pseudolocalization (en-XA) for dev/staging only

### DIFF
--- a/src/components/LanguageSelector.test.tsx
+++ b/src/components/LanguageSelector.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import LanguageSelector from './LanguageSelector';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const mockChangeLanguage = vi.fn();
 
@@ -23,7 +23,7 @@ vi.mock('lucide-react', () => ({
   Languages: () => <svg data-testid="languages-icon" />,
 }));
 
-const EXPECTED_LANGUAGES = [
+const BASE_LANGUAGES = [
   { code: 'en', label: 'English' },
   { code: 'ga', label: 'Gaeilge' },
   { code: 'es', label: 'Español' },
@@ -33,21 +33,28 @@ const EXPECTED_LANGUAGES = [
   { code: 'ko', label: '한국어' },
 ];
 
-describe('LanguageSelector', () => {
-  it('renders all languages in the dropdown', () => {
+describe('LanguageSelector (pseudolocale disabled)', () => {
+  it('renders all 7 base languages in the dropdown', () => {
     render(<LanguageSelector />);
     const select = screen.getByRole('combobox', { name: 'Language' });
     const options = Array.from(select.querySelectorAll('option'));
 
-    expect(options).toHaveLength(EXPECTED_LANGUAGES.length);
-    for (const lang of EXPECTED_LANGUAGES) {
+    expect(options).toHaveLength(BASE_LANGUAGES.length);
+    for (const lang of BASE_LANGUAGES) {
       const option = options.find(o => o.value === lang.code);
       expect(option, `Option for language code "${lang.code}" should exist`).toBeTruthy();
       expect(option?.textContent).toBe(lang.label);
     }
   });
 
-  it.each(EXPECTED_LANGUAGES)(
+  it('does not show en-XA option when pseudolocale is disabled', () => {
+    render(<LanguageSelector />);
+    const select = screen.getByRole('combobox', { name: 'Language' });
+    const options = Array.from(select.querySelectorAll('option'));
+    expect(options.find(o => o.value === 'en-XA')).toBeUndefined();
+  });
+
+  it.each(BASE_LANGUAGES)(
     'selecting "$label" calls changeLanguage with "$code"',
     ({ code }) => {
       mockChangeLanguage.mockClear();
@@ -57,4 +64,35 @@ describe('LanguageSelector', () => {
       expect(mockChangeLanguage).toHaveBeenCalledWith(code);
     }
   );
+});
+
+describe('LanguageSelector (pseudolocale enabled)', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_ENABLE_PSEUDOLOCALE', 'true');
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('includes en-XA option when pseudolocale is enabled', async () => {
+    const { default: LanguageSelectorWithPseudo } = await import('./LanguageSelector');
+    render(<LanguageSelectorWithPseudo />);
+    const select = screen.getByRole('combobox', { name: 'Language' });
+    const options = Array.from(select.querySelectorAll('option'));
+
+    expect(options).toHaveLength(BASE_LANGUAGES.length + 1);
+    const pseudoOption = options.find(o => o.value === 'en-XA');
+    expect(pseudoOption, 'en-XA option should exist').toBeTruthy();
+  });
+
+  it('selecting en-XA calls changeLanguage with "en-XA"', async () => {
+    mockChangeLanguage.mockClear();
+    const { default: LanguageSelectorWithPseudo } = await import('./LanguageSelector');
+    render(<LanguageSelectorWithPseudo />);
+    const select = screen.getByRole('combobox', { name: 'Language' });
+    fireEvent.change(select, { target: { value: 'en-XA' } });
+    expect(mockChangeLanguage).toHaveBeenCalledWith('en-XA');
+  });
 });

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -2,7 +2,7 @@ import { JSX } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Languages } from 'lucide-react';
 
-const LANGUAGES = [
+const BASE_LANGUAGES = [
   { code: 'en', label: 'English' },
   { code: 'ga', label: 'Gaeilge' },
   { code: 'es', label: 'Español' },
@@ -11,6 +11,13 @@ const LANGUAGES = [
   { code: 'ja', label: '日本語' },
   { code: 'ko', label: '한국어' },
 ];
+
+const PSEUDOLOCALE = { code: 'en-XA', label: '[[ Þšéûðö ]]' };
+
+const LANGUAGES =
+  import.meta.env.VITE_ENABLE_PSEUDOLOCALE === 'true'
+    ? [...BASE_LANGUAGES, PSEUDOLOCALE]
+    : BASE_LANGUAGES;
 
 function LanguageSelector(): JSX.Element {
   const { i18n, t } = useTranslation();
@@ -23,7 +30,13 @@ function LanguageSelector(): JSX.Element {
     <div className="flex items-center gap-2">
       <Languages size={16} className="text-gray-400 shrink-0" />
       <select
-        value={LANGUAGES.find(lang => i18n.language.startsWith(lang.code))?.code || LANGUAGES[0].code}
+        value={
+          (
+            LANGUAGES.find(lang => i18n.language === lang.code) ??
+            LANGUAGES.find(lang => i18n.language.startsWith(lang.code)) ??
+            LANGUAGES[0]
+          ).code
+        }
         onChange={(e) => handleChange(e.target.value)}
         aria-label={t('language.label')}
         className="text-xs font-bold bg-transparent border-none focus:ring-0 text-gray-600 dark:text-gray-300 cursor-pointer pr-1"

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -9,6 +9,12 @@ import fr from './locales/fr.json';
 import de from './locales/de.json';
 import ja from './locales/ja.json';
 import ko from './locales/ko.json';
+import { pseudolocalizeResources } from './pseudolocalize';
+
+const isPseudolocaleEnabled = import.meta.env.VITE_ENABLE_PSEUDOLOCALE === 'true';
+
+const supportedLngs = ['en', 'ga', 'es', 'fr', 'de', 'ja', 'ko'];
+if (isPseudolocaleEnabled) supportedLngs.push('en-XA');
 
 i18n
   .use(LanguageDetector)
@@ -22,9 +28,12 @@ i18n
       de: { translation: de },
       ja: { translation: ja },
       ko: { translation: ko },
+      ...(isPseudolocaleEnabled && {
+        'en-XA': { translation: pseudolocalizeResources(en) },
+      }),
     },
     fallbackLng: 'en',
-    supportedLngs: ['en', 'ga', 'es', 'fr', 'de', 'ja', 'ko'],
+    supportedLngs,
     detection: {
       order: ['localStorage', 'navigator'],
       caches: ['localStorage'],

--- a/src/i18n/pseudolocalize.test.ts
+++ b/src/i18n/pseudolocalize.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { pseudolocalizeString, pseudolocalizeResources } from './pseudolocalize';
+
+describe('pseudolocalizeString', () => {
+  it('wraps output in [[ ]] brackets', () => {
+    const result = pseudolocalizeString('Hello');
+    expect(result).toMatch(/^\[\[ .+ \]\]$/);
+  });
+
+  it('transforms ASCII letters to accented equivalents', () => {
+    const result = pseudolocalizeString('abc');
+    expect(result).toBe('[[ àƀć ]]');
+  });
+
+  it('preserves uppercase mapping', () => {
+    const result = pseudolocalizeString('ABC');
+    expect(result).toBe('[[ ÀƁĆ ]]');
+  });
+
+  it('preserves {{interpolation}} placeholders unchanged', () => {
+    const result = pseudolocalizeString('Hello {{name}}, you have {{count}} items');
+    expect(result).toContain('{{name}}');
+    expect(result).toContain('{{count}}');
+  });
+
+  it('transforms text around placeholders', () => {
+    const result = pseudolocalizeString('Cost: {{amount}}');
+    // 'Cost: ' should be transformed, {{amount}} preserved
+    expect(result).toContain('{{amount}}');
+    expect(result).not.toContain('Cost:');
+  });
+
+  it('preserves non-ASCII characters unchanged', () => {
+    const result = pseudolocalizeString('Café 日本語');
+    expect(result).toContain('é');
+    expect(result).toContain('日本語');
+  });
+
+  it('handles empty string', () => {
+    const result = pseudolocalizeString('');
+    expect(result).toBe('[[  ]]');
+  });
+});
+
+describe('pseudolocalizeResources', () => {
+  it('transforms all string values in a flat object', () => {
+    const input = { greeting: 'Hello', farewell: 'Bye' };
+    const result = pseudolocalizeResources(input);
+    expect(result.greeting).toBe('[[ Ĥëļļö ]]');
+    expect(result.farewell).toBe('[[ Ɓŷë ]]');
+  });
+
+  it('recursively transforms nested objects', () => {
+    const input = { nav: { home: 'Home', about: 'About' } };
+    const result = pseudolocalizeResources(input);
+    expect((result.nav as Record<string, string>).home).toBe('[[ Ĥöɱë ]]');
+    expect((result.nav as Record<string, string>).about).toBe('[[ Àƀöüţ ]]');
+  });
+
+  it('leaves non-string values unchanged', () => {
+    const input = { count: 42, flag: true, nothing: null } as any;
+    const result = pseudolocalizeResources(input);
+    expect(result.count).toBe(42);
+    expect(result.flag).toBe(true);
+    expect(result.nothing).toBeNull();
+  });
+
+  it('preserves placeholders in nested translations', () => {
+    const input = { msg: { rate: 'Rate: {{value}}' } };
+    const result = pseudolocalizeResources(input);
+    expect((result.msg as Record<string, string>).rate).toContain('{{value}}');
+  });
+});

--- a/src/i18n/pseudolocalize.ts
+++ b/src/i18n/pseudolocalize.ts
@@ -1,0 +1,77 @@
+/**
+ * Pseudolocalization (en-XA) utilities.
+ *
+ * Transforms English strings into visually distinct accented characters so
+ * layout issues, hard-coded strings, and missing translations are easy to spot
+ * during development/staging. Interpolation placeholders ({{…}}) are preserved
+ * unchanged so the app still functions correctly.
+ *
+ * Only loaded when VITE_ENABLE_PSEUDOLOCALE=true — never in production.
+ */
+
+const CHAR_MAP: Record<string, string> = {
+  a: 'à', A: 'À',
+  b: 'ƀ', B: 'Ɓ',
+  c: 'ć', C: 'Ć',
+  d: 'ď', D: 'Ď',
+  e: 'ë', E: 'Ë',
+  f: 'ƒ', F: 'Ƒ',
+  g: 'ĝ', G: 'Ĝ',
+  h: 'ĥ', H: 'Ĥ',
+  i: 'ï', I: 'Ï',
+  j: 'ĵ', J: 'Ĵ',
+  k: 'ķ', K: 'Ķ',
+  l: 'ļ', L: 'Ļ',
+  m: 'ɱ', M: 'Ɱ',
+  n: 'ñ', N: 'Ñ',
+  o: 'ö', O: 'Ö',
+  p: 'þ', P: 'Þ',
+  q: 'q', Q: 'Q',
+  r: 'ŗ', R: 'Ŗ',
+  s: 'š', S: 'Š',
+  t: 'ţ', T: 'Ţ',
+  u: 'ü', U: 'Ü',
+  v: 'v', V: 'V',
+  w: 'ŵ', W: 'Ŵ',
+  x: 'x', X: 'X',
+  y: 'ŷ', Y: 'Ŷ',
+  z: 'ž', Z: 'Ž',
+};
+
+// Matches i18next interpolation tokens like {{foo}} or {{foo, format}}
+const PLACEHOLDER_RE = /(\{\{[^}]+\}\})/g;
+
+export function pseudolocalizeString(input: string): string {
+  // Split on placeholders so we only transform the text segments
+  const parts = input.split(PLACEHOLDER_RE);
+  const transformed = parts.map((part) => {
+    if (PLACEHOLDER_RE.test(part)) {
+      PLACEHOLDER_RE.lastIndex = 0; // reset stateful regex
+      return part; // leave {{…}} tokens intact
+    }
+    return part
+      .split('')
+      .map((ch) => CHAR_MAP[ch] ?? ch)
+      .join('');
+  });
+  // Wrap in [[ ]] so untranslated strings stand out
+  return `[[ ${transformed.join('')} ]]`;
+}
+
+type JsonValue = string | number | boolean | null | JsonObject | JsonValue[];
+type JsonObject = { [key: string]: JsonValue };
+
+/** Recursively pseudolocalize every string value in a translation resource. */
+export function pseudolocalizeResources(obj: JsonObject): JsonObject {
+  const result: JsonObject = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (typeof value === 'string') {
+      result[key] = pseudolocalizeString(value);
+    } else if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      result[key] = pseudolocalizeResources(value as JsonObject);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary

- Adds a `en-XA` pseudolocale that transforms English strings into accented lookalike characters (e.g. `Hello` → `[[ Ĥëļļö ]]`) so untranslated strings, layout overflows, and hardcoded text are immediately visible during development and QA.
- Pseudolocale is generated **at runtime** from `en.json` via `pseudolocalizeResources()` — no extra JSON file to keep in sync.
- Gated behind `VITE_ENABLE_PSEUDOLOCALE=true`: **not available in Production**.

## How to enable

| Environment | Action |
|---|---|
| Local dev | Add `VITE_ENABLE_PSEUDOLOCALE=true` to `.env.development` |
| Vercel Preview / Staging | Add `VITE_ENABLE_PSEUDOLOCALE=true` in Vercel → Project Settings → Environment Variables → **Preview** scope |
| Vercel Production | Leave the variable **unset** — `en-XA` will not appear |

## Changes

- **`src/i18n/pseudolocalize.ts`** — character-map transform that preserves `{{interpolation}}` placeholders and wraps output in `[[ ]]`
- **`src/i18n/index.ts`** — conditionally registers `en-XA` translation resources
- **`src/components/LanguageSelector.tsx`** — conditionally exposes `en-XA` in the dropdown; fixes value derivation to prefer exact code match before `startsWith` (so `en-XA` isn't treated as `en`)
- **`src/i18n/pseudolocalize.test.ts`** — 11 unit tests for the transform utility
- **`src/components/LanguageSelector.test.tsx`** — tests for pseudolocale enabled/disabled states using `vi.stubEnv` + `vi.resetModules`

## Test plan

- [ ] All 55 unit tests pass (`npx vitest run`)
- [ ] TypeScript check clean (`npx tsc --noEmit`)
- [ ] With `VITE_ENABLE_PSEUDOLOCALE=true`: `[[ Þšéûðö ]]` option appears in language selector; selecting it pseudolocalizes all UI strings
- [ ] Without the env var (production build): `en-XA` option is absent from the dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)