### PR TITLE
feat: add Codecov Test Analytics

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -46,6 +46,13 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
           fail_ci_if_error: false
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./test-results/junit.xml
+          report_type: test_results
 
   build:
     name: Build Verification

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -180,6 +180,10 @@ export default defineConfig({
     setupFiles: ['./src/test/setup.ts'],
     globals: true,
     exclude: ['**/node_modules/**', '**/dist/**', '**/e2e/**'],
+    reporters: ['default', 'junit'],
+    outputFile: {
+      junit: './test-results/junit.xml',
+    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],


### PR DESCRIPTION
## Summary
- Configures vitest to output a JUnit XML report to `test-results/junit.xml` alongside the existing coverage run
- Adds a second Codecov upload step in the `test` CI job using `codecov/codecov-action@v5` with `report_type: test_results`, enabling the Test Analytics dashboard

## Notes
- The upload step uses `if: ${{ !cancelled() }}` so test results are still uploaded even when some tests fail
- No new dependencies required — vitest's junit reporter is built-in

## Test plan
- [ ] Verify CI passes and both Codecov upload steps succeed
- [ ] Check Codecov dashboard for Test Analytics data after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)