### PR TITLE
🧪 [testing improvement] Add tests for BASE_LANGUAGES constant

### DIFF
--- a/src/i18n/languages.test.ts
+++ b/src/i18n/languages.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { BASE_LANGUAGES, PSEUDOLOCALE } from './languages';
+
+describe('BASE_LANGUAGES', () => {
+  it('should be an array with 10 items', () => {
+    expect(Array.isArray(BASE_LANGUAGES)).toBe(true);
+    expect(BASE_LANGUAGES).toHaveLength(10);
+  });
+
+  it('should have correct structure for each language', () => {
+    BASE_LANGUAGES.forEach((lang) => {
+      expect(lang).toHaveProperty('code');
+      expect(lang).toHaveProperty('label');
+      expect(typeof lang.code).toBe('string');
+      expect(typeof lang.label).toBe('string');
+    });
+  });
+
+  it('should include English (en)', () => {
+    const en = BASE_LANGUAGES.find((lang) => lang.code === 'en');
+    expect(en).toBeDefined();
+    expect(en?.label).toBe('English');
+  });
+
+  it('should have unique codes', () => {
+    const codes = BASE_LANGUAGES.map((lang) => lang.code);
+    const uniqueCodes = new Set(codes);
+    expect(uniqueCodes.size).toBe(codes.length);
+  });
+});
+
+describe('PSEUDOLOCALE', () => {
+  it('should have correct structure', () => {
+    expect(PSEUDOLOCALE).toHaveProperty('code');
+    expect(PSEUDOLOCALE).toHaveProperty('label');
+    expect(typeof PSEUDOLOCALE.code).toBe('string');
+    expect(typeof PSEUDOLOCALE.label).toBe('string');
+  });
+
+  it('should have a specific code', () => {
+    expect(PSEUDOLOCALE.code).toBe('en-XA');
+  });
+});


### PR DESCRIPTION
- 🎯 **What:** Added unit tests for the `BASE_LANGUAGES` exported constant in `src/i18n/languages.ts`.
- 📊 **Coverage:**
    - Verifies `BASE_LANGUAGES` array length and structure (code and label fields).
    - Ensures language codes are unique.
    - Confirms English ('en') is present in the list.
    - Verifies `PSEUDOLOCALE` structure and code.
- ✨ **Result:** Improved reliability and coverage of internationalization configuration, ensuring that language definitions remain consistent and valid.

---
*PR created automatically by Jules for task [437078345875787782](https://jules.google.com/task/437078345875787782) started by @Irishsmurf*