### PR TITLE
🧪 test: add missing tests for BASE_LANGUAGES exported constant

### DIFF
--- a/src/i18n/languages.test.ts
+++ b/src/i18n/languages.test.ts
@@ -16,6 +16,21 @@ describe('BASE_LANGUAGES', () => {
     });
   });
 
+  it('should contain the exact expected base languages', () => {
+    expect(BASE_LANGUAGES).toEqual([
+      { code: 'en', label: 'English' },
+      { code: 'ga', label: 'Gaeilge' },
+      { code: 'es', label: 'Español' },
+      { code: 'fr', label: 'Français' },
+      { code: 'de', label: 'Deutsch' },
+      { code: 'ja', label: '日本語' },
+      { code: 'ko', label: '한국어' },
+      { code: 'sv', label: 'Svenska' },
+      { code: 'no', label: 'Norsk' },
+      { code: 'fi', label: 'Suomi' },
+    ]);
+  });
+
   it('should include English (en)', () => {
     const en = BASE_LANGUAGES.find((lang) => lang.code === 'en');
     expect(en).toBeDefined();


### PR DESCRIPTION
🎯 **What:** Added comprehensive unit test to verify the `BASE_LANGUAGES` constant in `src/i18n/languages.ts`.
📊 **Coverage:** Specifically asserts the exact length, structure, and values (code and label) matches the expected hardcoded data ensuring it covers what's specified exactly without allowing omissions.
✨ **Result:** Test correctly asserts and fully covers `BASE_LANGUAGES`.

---
*PR created automatically by Jules for task [12387928777446299801](https://jules.google.com/task/12387928777446299801) started by @Irishsmurf*