### PR TITLE
Resolve #98: Surface Firestore errors to the user instead of swallowing them

### DIFF
--- a/src/firebase/__tests__/firestoreService.test.ts
+++ b/src/firebase/__tests__/firestoreService.test.ts
@@ -101,15 +101,12 @@ describe('firestoreService', () => {
             expect(result).toEqual(mockLogs);
         });
 
-        it('should return an empty array if no user is logged in', async () => {
+        it('should throw if no user is logged in', async () => {
             mockCurrentUser = null; // Set to null for this test
 
-            const result = await fetchFuelLogsByStationId(mockStationId);
-
-            expect(result).toEqual([]);
+            await expect(fetchFuelLogsByStationId(mockStationId)).rejects.toThrow('No user logged in');
             expect(collection).not.toHaveBeenCalled();
             expect(getDocs).not.toHaveBeenCalled();
-            expect(console.error).toHaveBeenCalledWith("No user logged in");
         });
 
         it('should return an empty array if no logs are found for the stationId', async () => {
@@ -124,14 +121,20 @@ describe('firestoreService', () => {
             expect(getDocs).toHaveBeenCalled();
         });
 
-        it('should return an empty array and log an error if fetching fails', async () => {
+        it('should propagate the error if fetching fails', async () => {
             const mockError = new Error('Firestore error');
             vi.mocked(getDocs).mockRejectedValueOnce(mockError);
 
-            const result = await fetchFuelLogsByStationId(mockStationId);
-
-            expect(result).toEqual([]);
+            await expect(fetchFuelLogsByStationId(mockStationId)).rejects.toThrow('Firestore error');
             expect(console.error).toHaveBeenCalledWith(`Error fetching fuel logs for station ${mockStationId}:`, mockError);
+        });
+
+        it('should throw a FirestoreOfflineError when the browser is offline', async () => {
+            const mockError = new Error('Firestore error');
+            vi.mocked(getDocs).mockRejectedValueOnce(mockError);
+            vi.spyOn(navigator, 'onLine', 'get').mockReturnValueOnce(false);
+
+            await expect(fetchFuelLogsByStationId(mockStationId)).rejects.toThrow('You are offline');
         });
     });
 });

--- a/src/firebase/firestoreService.ts
+++ b/src/firebase/firestoreService.ts
@@ -4,10 +4,24 @@ import { db, auth } from './config'; // db and auth from your config file
 import { Log, FuelLogData, Station } from '../utils/types'; // Adjust path as needed
 import { OSMStation } from '../utils/locationService';
 
+export class FirestoreOfflineError extends Error {
+  constructor(message = 'You are offline. Please check your connection and try again.') {
+    super(message);
+    this.name = 'FirestoreOfflineError';
+  }
+}
+
+const rethrowFirestoreError = (error: unknown, context: string): never => {
+  console.error(context, error);
+  if (!navigator.onLine) {
+    throw new FirestoreOfflineError();
+  }
+  throw error instanceof Error ? error : new Error(String(error));
+};
+
 export const fetchFuelLocations = async (): Promise<Log[]> => {
   if (!auth.currentUser) {
-    console.error("No user logged in");
-    return [];
+    throw new Error('No user logged in');
   }
 
   const logsCollection = collection(db, 'fuelLogs');
@@ -29,16 +43,17 @@ export const fetchFuelLocations = async (): Promise<Log[]> => {
     // Additional filtering just in case Firestore rules change or for robustness
     return locations.filter(p => p.latitude !== undefined && p.longitude !== undefined);
   } catch (error) {
-    console.error("Error fetching fuel locations:", error);
-    return [];
+    return rethrowFirestoreError(error, 'Error fetching fuel locations:');
   }
 };
 
 // You could add other Firestore-related functions here later (e.g., addFuelLog, updateFuelLog)
 
 export const getLastOdometerReading = async (vehicleId: string): Promise<number | null> => {
-    if (!auth.currentUser) return null;
-    
+    if (!auth.currentUser) {
+        throw new Error('No user logged in');
+    }
+
     const q = query(
         collection(db, 'fuelLogs'),
         where('userId', '==', auth.currentUser.uid),
@@ -46,15 +61,14 @@ export const getLastOdometerReading = async (vehicleId: string): Promise<number 
         orderBy('timestamp', 'desc'),
         limit(1)
     );
-    
+
     try {
         const querySnapshot = await getDocs(q);
         if (querySnapshot.empty) return null;
         const lastLog = querySnapshot.docs[0].data() as FuelLogData;
         return lastLog.odometerKm ?? null;
     } catch (error) {
-        console.error("Error fetching last odometer reading:", error);
-        return null;
+        return rethrowFirestoreError(error, 'Error fetching last odometer reading:');
     }
 };
 
@@ -145,8 +159,7 @@ export const fetchUserStations = async (logs: Log[]): Promise<Station[]> => {
  */
 export const fetchFuelLogsByStationId = async (stationId: string): Promise<Log[]> => {
     if (!auth.currentUser) {
-        console.error("No user logged in");
-        return [];
+        throw new Error('No user logged in');
     }
 
     const logsCollection = collection(db, 'fuelLogs');
@@ -165,7 +178,6 @@ export const fetchFuelLogsByStationId = async (stationId: string): Promise<Log[]
         }));
         return logs;
     } catch (error) {
-        console.error(`Error fetching fuel logs for station ${stationId}:`, error);
-        return [];
+        return rethrowFirestoreError(error, `Error fetching fuel logs for station ${stationId}:`);
     }
 };

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -147,7 +147,11 @@ function HistoryPage(): JSX.Element {
         }, (err) => {
             // Handle Firestore errors
             console.error("Error fetching fuel logs:", err);
-            setError(t('history.loadError', { defaultValue: 'Failed to load fuel history. Please check your connection and try again.' }));
+            setError(
+                !navigator.onLine
+                    ? t('history.offlineError', { defaultValue: 'You are offline. Please check your connection and try again.' })
+                    : t('history.loadError', { defaultValue: 'Failed to load fuel history. Please check your connection and try again.' })
+            );
             setIsLoading(false);
         });
 
@@ -158,7 +162,14 @@ function HistoryPage(): JSX.Element {
     // --- Fetch Stations Effect ---
     useEffect(() => {
         if (logs.length > 0) {
-            fetchUserStations(logs).then(setStations).catch(console.error);
+            fetchUserStations(logs).then(setStations).catch(err => {
+                console.error('Error fetching stations:', err);
+                setError(
+                    !navigator.onLine
+                        ? t('history.offlineError', { defaultValue: 'You are offline. Please check your connection and try again.' })
+                        : t('history.loadError', { defaultValue: 'Failed to load fuel history. Please check your connection and try again.' })
+                );
+            });
         } else {
             setStations([]);
         }

--- a/src/pages/QuickLogPage.tsx
+++ b/src/pages/QuickLogPage.tsx
@@ -137,8 +137,18 @@ function QuickLogPage(): JSX.Element {
       return;
     }
     const fetchLastOdometer = async () => {
-      const reading = await getLastOdometerReading(selectedVehicleId);
-      setLastOdometerReading(reading);
+      try {
+        const reading = await getLastOdometerReading(selectedVehicleId);
+        setLastOdometerReading(reading);
+      } catch (error) {
+        console.error('Error fetching last odometer reading:', error);
+        setMessage({
+          type: 'error',
+          text: !navigator.onLine
+            ? t('quickLog.messages.offline', { defaultValue: 'You are offline. Please check your connection and try again.' })
+            : t('quickLog.messages.fetchOdometerError', { defaultValue: 'Failed to load last odometer reading.' }),
+        });
+      }
     };
     fetchLastOdometer();
   }, [selectedVehicleId]);


### PR DESCRIPTION
Closes #98

## Changes
- `firestoreService.ts`: `fetchFuelLocations`, `getLastOdometerReading`, and `fetchFuelLogsByStationId` now throw instead of logging-and-swallowing. Added a `FirestoreOfflineError` that's thrown when `navigator.onLine` is false at failure time, so the UI can show an offline-specific message.
- `HistoryPage`: the realtime listener and station-fetch error paths now distinguish offline vs. generic failure in the existing error banner.
- `QuickLogPage`: fetching the last odometer reading now catches and surfaces errors via the existing message banner instead of throwing an unhandled rejection.
- Updated `firestoreService.test.ts` to assert error propagation (including the offline case) instead of asserting swallowed empty results.

## Testing
- `npx vitest run` — 121/121 passing
- `npx tsc --noEmit` — clean