### PR TITLE
Resolve #106: Receipt upload gives no feedback when image exceeds size limit

### DIFF
--- a/src/pages/QuickLogPage.tsx
+++ b/src/pages/QuickLogPage.tsx
@@ -79,7 +79,8 @@ function QuickLogPage(): JSX.Element {
       setMessage({ type: '', text: '' });
     } catch (error) {
       console.error("Extraction error:", error);
-      setMessage({ type: 'error', text: t('receipt.extractionFailed') });
+      const text = error instanceof Error ? error.message : t('receipt.extractionFailed');
+      setMessage({ type: 'error', text });
     } finally {
       setIsExtracting(false);
     }

--- a/src/utils/gemini.test.ts
+++ b/src/utils/gemini.test.ts
@@ -131,4 +131,36 @@ describe('gemini utility', () => {
 
     await expect(gemini.extractDataFromReceipt(mockFile)).rejects.toThrow('Failed to extract data from receipt.');
   });
+
+  it('rejects unsupported file types before processing', async () => {
+    const gemini = await import('./gemini');
+    const mockFile = new File(['mock content'], 'receipt.pdf', { type: 'application/pdf' });
+
+    await expect(gemini.extractDataFromReceipt(mockFile)).rejects.toThrow(
+      'Unsupported file type. Please use JPEG, PNG, or WebP.'
+    );
+    expect(global.createImageBitmap).not.toHaveBeenCalled();
+  });
+
+  it('rejects files larger than 10MB before processing', async () => {
+    const gemini = await import('./gemini');
+    const bigContent = new Uint8Array(10 * 1024 * 1024 + 1);
+    const mockFile = new File([bigContent], 'big.jpg', { type: 'image/jpeg' });
+
+    await expect(gemini.extractDataFromReceipt(mockFile)).rejects.toThrow(
+      'File too large (max 10 MB). Please compress the image.'
+    );
+    expect(global.createImageBitmap).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a friendly error when the image cannot be decoded', async () => {
+    global.createImageBitmap = vi.fn().mockRejectedValue(new Error('decode failed'));
+
+    const gemini = await import('./gemini');
+    const mockFile = new File(['mock content'], 'corrupt.jpg', { type: 'image/jpeg' });
+
+    await expect(gemini.extractDataFromReceipt(mockFile)).rejects.toThrow(
+      'Could not process image — please try a different photo.'
+    );
+  });
 });

--- a/src/utils/gemini.ts
+++ b/src/utils/gemini.ts
@@ -12,8 +12,26 @@ export interface ReceiptData {
 const MAX_DIMENSION = import.meta.env.DEV ? 768 : 1600;
 const JPEG_QUALITY = import.meta.env.DEV ? 0.7 : 0.9;
 
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
+const SUPPORTED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+
+export function validateReceiptFile(file: File): void {
+  if (!SUPPORTED_MIME_TYPES.includes(file.type)) {
+    throw new Error('Unsupported file type. Please use JPEG, PNG, or WebP.');
+  }
+  if (file.size > MAX_FILE_SIZE_BYTES) {
+    throw new Error('File too large (max 10 MB). Please compress the image.');
+  }
+}
+
 async function resizeAndEncode(file: File): Promise<{ base64Data: string; mimeType: string }> {
-  const bitmap = await createImageBitmap(file);
+  let bitmap: ImageBitmap;
+  try {
+    bitmap = await createImageBitmap(file);
+  } catch (error) {
+    console.error('Failed to decode image:', error);
+    throw new Error('Could not process image — please try a different photo.');
+  }
   const { width, height } = bitmap;
 
   const scale = Math.min(1, MAX_DIMENSION / Math.max(width, height));
@@ -49,6 +67,8 @@ export async function extractDataFromReceipt(file: File): Promise<ReceiptData> {
     throw new Error('User is not authenticated.');
   }
   const idToken = await user.getIdToken();
+
+  validateReceiptFile(file);
 
   analytics.then(a => { if (a) logEvent(a, 'receipt_scan_started'); });
 


### PR DESCRIPTION
Closes #106

Stacked on #111 (issue-98 branch).

## Changes
- `gemini.ts`: added `validateReceiptFile` — rejects unsupported MIME types (anything but JPEG/PNG/WebP) and files over 10MB before any processing. Wrapped `createImageBitmap` in a try/catch with a friendly "Could not process image" message.
- `QuickLogPage`: `handleExtractData` now shows the specific thrown error message instead of a generic "extraction failed" string.
- Added unit tests in `gemini.test.ts` for the type guard, size guard, and decode-failure paths.

## Testing
- `npx vitest run` — 124/124 passing
- `npx tsc --noEmit` — clean