### PR TITLE
Resolve #96: Add unit tests for AuthContext auth flow

### DIFF
--- a/src/context/AuthContext.test.tsx
+++ b/src/context/AuthContext.test.tsx
@@ -1,0 +1,163 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { onAuthStateChanged, User } from 'firebase/auth';
+import { onSnapshot } from 'firebase/firestore';
+import { AuthProvider, useAuth } from './AuthContext';
+
+vi.mock('firebase/auth', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('firebase/auth')>();
+    return {
+        ...actual,
+        onAuthStateChanged: vi.fn(),
+    };
+});
+
+vi.mock('firebase/firestore', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('firebase/firestore')>();
+    return {
+        ...actual,
+        doc: vi.fn(),
+        setDoc: vi.fn(),
+        onSnapshot: vi.fn(),
+    };
+});
+
+vi.mock('firebase/analytics', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('firebase/analytics')>();
+    return {
+        ...actual,
+        setUserProperties: vi.fn(),
+    };
+});
+
+vi.mock('../firebase/config', () => ({
+    auth: {},
+    db: {},
+    analytics: Promise.resolve(null),
+    signInWithGoogle: vi.fn(),
+    logout: vi.fn(),
+}));
+
+import { signInWithGoogle as mockSignInWithGoogle } from '../firebase/config';
+
+const TestComponent = () => {
+    const { loading, user, profile, login } = useAuth();
+    if (loading) return <div data-testid="loading">Loading...</div>;
+    return (
+        <div data-testid="content">
+            <span data-testid="user">{user ? user.uid : 'none'}</span>
+            <span data-testid="profile">{profile ? profile.homeCurrency : 'none'}</span>
+            <button onClick={() => login()}>Sign in</button>
+        </div>
+    );
+};
+
+describe('AuthContext', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('sets loading false and exposes the user once signed in with a profile', async () => {
+        const mockUser = { uid: 'user-1' } as User;
+
+        vi.mocked(onAuthStateChanged).mockImplementation((_auth, callback) => {
+            (callback as (user: User | null) => void)(mockUser);
+            return vi.fn();
+        });
+
+        vi.mocked(onSnapshot).mockImplementation((_ref, onNext) => {
+            (onNext as (snap: { exists: () => boolean; data: () => unknown }) => void)({
+                exists: () => true,
+                data: () => ({ homeCurrency: 'USD', tester_group: false }),
+            });
+            return vi.fn();
+        });
+
+        render(
+            <AuthProvider>
+                <TestComponent />
+            </AuthProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId('content')).toBeInTheDocument();
+        });
+
+        expect(screen.getByTestId('user').textContent).toBe('user-1');
+        expect(screen.getByTestId('profile').textContent).toBe('USD');
+    });
+
+    it('clears the user and profile, and stops loading, when signed out', async () => {
+        vi.mocked(onAuthStateChanged).mockImplementation((_auth, callback) => {
+            (callback as (user: User | null) => void)(null);
+            return vi.fn();
+        });
+
+        render(
+            <AuthProvider>
+                <TestComponent />
+            </AuthProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId('content')).toBeInTheDocument();
+        });
+
+        expect(screen.getByTestId('user').textContent).toBe('none');
+        expect(screen.getByTestId('profile').textContent).toBe('none');
+    });
+
+    it('clears loading even if the profile snapshot errors out', async () => {
+        vi.mocked(onAuthStateChanged).mockImplementation((_auth, callback) => {
+            (callback as (user: User | null) => void)({ uid: 'user-1' } as User);
+            return vi.fn();
+        });
+
+        vi.mocked(onSnapshot).mockImplementation((_ref, _onNext, onError) => {
+            (onError as (error: { code: string; message: string }) => void)({
+                code: 'permission-denied',
+                message: 'Missing permissions',
+            });
+            return vi.fn();
+        });
+
+        render(
+            <AuthProvider>
+                <TestComponent />
+            </AuthProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId('content')).toBeInTheDocument();
+        });
+
+        expect(screen.getByTestId('profile').textContent).toBe('none');
+    });
+
+    it('login() calls signInWithGoogle', async () => {
+        vi.mocked(onAuthStateChanged).mockImplementation((_auth, callback) => {
+            (callback as (user: User | null) => void)(null);
+            return vi.fn();
+        });
+
+        render(
+            <AuthProvider>
+                <TestComponent />
+            </AuthProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId('content')).toBeInTheDocument();
+        });
+
+        screen.getByText('Sign in').click();
+
+        expect(mockSignInWithGoogle).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws when useAuth is used outside of an AuthProvider', () => {
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        expect(() => render(<TestComponent />)).toThrow('useAuth must be used within an AuthProvider');
+        consoleSpy.mockRestore();
+    });
+});

--- a/src/context/AuthContext.test.tsx
+++ b/src/context/AuthContext.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { onAuthStateChanged, User } from 'firebase/auth';
 import { onSnapshot } from 'firebase/firestore';
 import { AuthProvider, useAuth } from './AuthContext';
+import { signInWithGoogle as mockSignInWithGoogle, logout as mockLogout } from '../firebase/config';
 
 vi.mock('firebase/auth', async (importOriginal) => {
     const actual = await importOriginal<typeof import('firebase/auth')>();
@@ -38,16 +39,15 @@ vi.mock('../firebase/config', () => ({
     logout: vi.fn(),
 }));
 
-import { signInWithGoogle as mockSignInWithGoogle } from '../firebase/config';
-
 const TestComponent = () => {
-    const { loading, user, profile, login } = useAuth();
+    const { loading, user, profile, login, logout } = useAuth();
     if (loading) return <div data-testid="loading">Loading...</div>;
     return (
         <div data-testid="content">
             <span data-testid="user">{user ? user.uid : 'none'}</span>
             <span data-testid="profile">{profile ? profile.homeCurrency : 'none'}</span>
             <button onClick={() => login()}>Sign in</button>
+            <button onClick={() => logout()}>Sign out</button>
         </div>
     );
 };
@@ -108,13 +108,16 @@ describe('AuthContext', () => {
     });
 
     it('clears loading even if the profile snapshot errors out', async () => {
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
         vi.mocked(onAuthStateChanged).mockImplementation((_auth, callback) => {
             (callback as (user: User | null) => void)({ uid: 'user-1' } as User);
             return vi.fn();
         });
 
         vi.mocked(onSnapshot).mockImplementation((_ref, _onNext, onError) => {
-            (onError as (error: { code: string; message: string }) => void)({
+            (onError as unknown as (error: { code: string; message: string }) => void)({
                 code: 'permission-denied',
                 message: 'Missing permissions',
             });
@@ -132,6 +135,11 @@ describe('AuthContext', () => {
         });
 
         expect(screen.getByTestId('profile').textContent).toBe('none');
+        expect(consoleErrorSpy).toHaveBeenCalled();
+        expect(consoleWarnSpy).toHaveBeenCalled();
+
+        consoleErrorSpy.mockRestore();
+        consoleWarnSpy.mockRestore();
     });
 
     it('login() calls signInWithGoogle', async () => {
@@ -150,9 +158,30 @@ describe('AuthContext', () => {
             expect(screen.getByTestId('content')).toBeInTheDocument();
         });
 
-        screen.getByText('Sign in').click();
+        fireEvent.click(screen.getByText('Sign in'));
 
         expect(mockSignInWithGoogle).toHaveBeenCalledTimes(1);
+    });
+
+    it('logout() calls logout from config', async () => {
+        vi.mocked(onAuthStateChanged).mockImplementation((_auth, callback) => {
+            (callback as (user: User | null) => void)({ uid: 'user-1' } as User);
+            return vi.fn();
+        });
+
+        render(
+            <AuthProvider>
+                <TestComponent />
+            </AuthProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId('content')).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByText('Sign out'));
+
+        expect(mockLogout).toHaveBeenCalledTimes(1);
     });
 
     it('throws when useAuth is used outside of an AuthProvider', () => {

--- a/src/firebase/aggregationService.test.ts
+++ b/src/firebase/aggregationService.test.ts
@@ -69,7 +69,7 @@ describe('aggregationService', () => {
         expect(where).toHaveBeenCalledTimes(1);
     });
 
-    it('defaults missing aggregate fields to zero rather than negative or undefined', async () => {
+    it('defaults missing aggregate fields to zero when undefined', async () => {
         vi.mocked(getAggregateFromServer).mockResolvedValue({
             data: () => ({}),
         } as never);
@@ -84,7 +84,7 @@ describe('aggregationService', () => {
         });
     });
 
-    it('reflects a reduced count and totals after a log is deleted, never going negative', async () => {
+    it('reflects a reduced count and totals after a log is deleted', async () => {
         // Before deletion: 3 logs
         vi.mocked(getAggregateFromServer).mockResolvedValueOnce({
             data: () => ({ totalCost: 150, totalLitres: 75, totalDistanceKm: 900, logCount: 3 }),
@@ -100,7 +100,5 @@ describe('aggregationService', () => {
 
         expect(after.logCount).toBe(2);
         expect(after.totalCost).toBeLessThan(before.totalCost);
-        expect(after.logCount).toBeGreaterThanOrEqual(0);
-        expect(after.totalCost).toBeGreaterThanOrEqual(0);
     });
 });

--- a/src/firebase/aggregationService.test.ts
+++ b/src/firebase/aggregationService.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { collection, query, where, getAggregateFromServer } from 'firebase/firestore';
+import { getLifetimeStats } from './aggregationService';
+
+vi.mock('firebase/firestore', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('firebase/firestore')>();
+    return {
+        ...actual,
+        collection: vi.fn(),
+        query: vi.fn(),
+        where: vi.fn(),
+        getAggregateFromServer: vi.fn(),
+    };
+});
+
+vi.mock('./config', () => ({
+    db: {},
+}));
+
+describe('aggregationService', () => {
+    const mockUserId = 'testUserId';
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(collection).mockReturnValue({} as never);
+        vi.mocked(query).mockReturnValue({} as never);
+        vi.mocked(where).mockReturnValue({} as never);
+    });
+
+    it('computes lifetime stats from aggregate fixture data', async () => {
+        vi.mocked(getAggregateFromServer).mockResolvedValue({
+            data: () => ({
+                totalCost: 245.5,
+                totalLitres: 120.25,
+                totalDistanceKm: 1800,
+                logCount: 12,
+            }),
+        } as never);
+
+        const result = await getLifetimeStats(mockUserId);
+
+        expect(result).toEqual({
+            totalCost: 245.5,
+            totalLitres: 120.25,
+            totalDistanceKm: 1800,
+            logCount: 12,
+        });
+    });
+
+    it('filters by vehicleId when provided', async () => {
+        vi.mocked(getAggregateFromServer).mockResolvedValue({
+            data: () => ({ totalCost: 50, totalLitres: 25, totalDistanceKm: 400, logCount: 2 }),
+        } as never);
+
+        await getLifetimeStats(mockUserId, 'vehicle-1');
+
+        expect(where).toHaveBeenCalledWith('userId', '==', mockUserId);
+        expect(where).toHaveBeenCalledWith('vehicleId', '==', 'vehicle-1');
+    });
+
+    it('does not filter by vehicleId when omitted', async () => {
+        vi.mocked(getAggregateFromServer).mockResolvedValue({
+            data: () => ({ totalCost: 0, totalLitres: 0, totalDistanceKm: 0, logCount: 0 }),
+        } as never);
+
+        await getLifetimeStats(mockUserId);
+
+        expect(where).toHaveBeenCalledWith('userId', '==', mockUserId);
+        expect(where).toHaveBeenCalledTimes(1);
+    });
+
+    it('defaults missing aggregate fields to zero rather than negative or undefined', async () => {
+        vi.mocked(getAggregateFromServer).mockResolvedValue({
+            data: () => ({}),
+        } as never);
+
+        const result = await getLifetimeStats(mockUserId);
+
+        expect(result).toEqual({
+            totalCost: 0,
+            totalLitres: 0,
+            totalDistanceKm: 0,
+            logCount: 0,
+        });
+    });
+
+    it('reflects a reduced count and totals after a log is deleted, never going negative', async () => {
+        // Before deletion: 3 logs
+        vi.mocked(getAggregateFromServer).mockResolvedValueOnce({
+            data: () => ({ totalCost: 150, totalLitres: 75, totalDistanceKm: 900, logCount: 3 }),
+        } as never);
+        const before = await getLifetimeStats(mockUserId);
+        expect(before.logCount).toBe(3);
+
+        // After deleting one log: server-side aggregate recomputes from remaining logs
+        vi.mocked(getAggregateFromServer).mockResolvedValueOnce({
+            data: () => ({ totalCost: 100, totalLitres: 50, totalDistanceKm: 600, logCount: 2 }),
+        } as never);
+        const after = await getLifetimeStats(mockUserId);
+
+        expect(after.logCount).toBe(2);
+        expect(after.totalCost).toBeLessThan(before.totalCost);
+        expect(after.logCount).toBeGreaterThanOrEqual(0);
+        expect(after.totalCost).toBeGreaterThanOrEqual(0);
+    });
+});

--- a/src/firebase/messagingService.test.ts
+++ b/src/firebase/messagingService.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { getMessaging, getToken, onMessage } from 'firebase/messaging';
 import { isSupported } from 'firebase/analytics';
 
@@ -41,7 +41,11 @@ describe('messagingService', () => {
             configurable: true,
         });
 
-        import.meta.env.VITE_FIREBASE_VAPID_KEY = 'test-vapid-key';
+        vi.stubEnv('VITE_FIREBASE_VAPID_KEY', 'test-vapid-key');
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
     });
 
     it('requests a token from getToken when permission is granted', async () => {

--- a/src/firebase/messagingService.test.ts
+++ b/src/firebase/messagingService.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getMessaging, getToken, onMessage } from 'firebase/messaging';
+import { isSupported } from 'firebase/analytics';
+
+vi.mock('firebase/messaging', () => ({
+    getMessaging: vi.fn(),
+    getToken: vi.fn(),
+    onMessage: vi.fn(),
+}));
+
+vi.mock('firebase/analytics', () => ({
+    isSupported: vi.fn(),
+}));
+
+vi.mock('./config', () => ({
+    app: {},
+}));
+
+const setNotificationPermission = (requestPermission: () => Promise<NotificationPermission>) => {
+    Object.defineProperty(global, 'Notification', {
+        value: { requestPermission },
+        writable: true,
+        configurable: true,
+    });
+};
+
+describe('messagingService', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        vi.clearAllMocks();
+        vi.mocked(isSupported).mockResolvedValue(true);
+        vi.mocked(getMessaging).mockReturnValue({} as never);
+
+        Object.defineProperty(window, 'PushManager', { value: {}, writable: true, configurable: true });
+        Object.defineProperty(navigator, 'serviceWorker', {
+            value: {
+                getRegistration: vi.fn().mockResolvedValue(undefined),
+                ready: Promise.resolve({ active: { postMessage: vi.fn() } }),
+            },
+            writable: true,
+            configurable: true,
+        });
+
+        import.meta.env.VITE_FIREBASE_VAPID_KEY = 'test-vapid-key';
+    });
+
+    it('requests a token from getToken when permission is granted', async () => {
+        setNotificationPermission(() => Promise.resolve('granted'));
+        vi.mocked(getToken).mockResolvedValue('mock-fcm-token');
+
+        const { requestNotificationPermission } = await import('./messagingService');
+        const token = await requestNotificationPermission();
+
+        expect(getToken).toHaveBeenCalled();
+        expect(token).toBe('mock-fcm-token');
+    });
+
+    it('returns null without throwing when permission is denied', async () => {
+        setNotificationPermission(() => Promise.resolve('denied'));
+
+        const { requestNotificationPermission } = await import('./messagingService');
+        const token = await requestNotificationPermission();
+
+        expect(token).toBeNull();
+        expect(getToken).not.toHaveBeenCalled();
+    });
+
+    it('returns null when messaging is unsupported in this environment', async () => {
+        vi.mocked(isSupported).mockResolvedValue(false);
+        setNotificationPermission(() => Promise.resolve('granted'));
+
+        const { requestNotificationPermission } = await import('./messagingService');
+        const token = await requestNotificationPermission();
+
+        expect(token).toBeNull();
+        expect(getToken).not.toHaveBeenCalled();
+    });
+
+    it('returns null and does not throw when getToken rejects', async () => {
+        setNotificationPermission(() => Promise.resolve('granted'));
+        vi.mocked(getToken).mockRejectedValue(new Error('token fetch failed'));
+
+        const { requestNotificationPermission } = await import('./messagingService');
+        await expect(requestNotificationPermission()).resolves.toBeNull();
+    });
+
+    it('registers a foreground message handler via onMessage', async () => {
+        const unsubscribe = vi.fn();
+        vi.mocked(onMessage).mockReturnValue(unsubscribe);
+
+        const { onForegroundMessage } = await import('./messagingService');
+        const handler = vi.fn();
+        const unsub = await onForegroundMessage(handler);
+
+        expect(onMessage).toHaveBeenCalledWith({}, handler);
+        expect(unsub).toBe(unsubscribe);
+    });
+
+    it('returns a no-op unsubscribe when messaging is unsupported', async () => {
+        vi.mocked(isSupported).mockResolvedValue(false);
+
+        const { onForegroundMessage } = await import('./messagingService');
+        const unsub = await onForegroundMessage(vi.fn());
+
+        expect(() => unsub()).not.toThrow();
+        expect(onMessage).not.toHaveBeenCalled();
+    });
+});

--- a/src/pages/QuickLogPage.tsx
+++ b/src/pages/QuickLogPage.tsx
@@ -12,12 +12,12 @@ import { uploadReceipt } from '../firebase/storageService';
 import { getLastOdometerReading, getOrCreateStation, updateStationMetrics } from '../firebase/firestoreService';
 import { extractDataFromReceipt, ReceiptData } from '../utils/gemini';
 import { calculateDistance } from '../utils/calculations';
-import { findNearestStation } from '../utils/locationService';
+import { findNearestStation, isAccurateEnoughForStationMatch, GPS_ACCURACY_THRESHOLD_METERS } from '../utils/locationService';
 import ReceiptAISection from '../components/ReceiptAISection';
 import { useTranslation } from 'react-i18next';
 
 // Types
-type MessageType = 'success' | 'error' | 'info' | '';
+type MessageType = 'success' | 'error' | 'info' | 'warning' | '';
 interface MessageState {
   type: MessageType;
   text: string;
@@ -275,24 +275,35 @@ function QuickLogPage(): JSX.Element {
 
     // --- Get Location ---
     const locationData = await getCurrentLocation();
-    
+
     // --- Find Station ---
     let linkedStationId: string | undefined;
     let stationName: string | undefined;
 
     if (locationData) {
-        try {
-            const nearest = await findNearestStation(locationData.latitude, locationData.longitude);
-            if (nearest) {
-                linkedStationId = await getOrCreateStation(nearest);
-                stationName = nearest.name;
-                // If brand is empty, auto-fill it with station name
-                if (!brand.trim()) {
-                    setBrand(nearest.name);
+        if (!isAccurateEnoughForStationMatch(locationData.locationAccuracy)) {
+            console.warn(
+                `GPS accuracy (${locationData.locationAccuracy.toFixed(0)}m) exceeds threshold ` +
+                `(${GPS_ACCURACY_THRESHOLD_METERS}m); skipping automatic station association.`
+            );
+            setMessage({ type: 'warning', text: t('quickLog.messages.lowAccuracySkippedStation', {
+                accuracy: locationData.locationAccuracy.toFixed(0),
+                defaultValue: 'GPS accuracy is low ({{accuracy}}m); skipping station detection.',
+            }) });
+        } else {
+            try {
+                const nearest = await findNearestStation(locationData.latitude, locationData.longitude);
+                if (nearest) {
+                    linkedStationId = await getOrCreateStation(nearest);
+                    stationName = nearest.name;
+                    // If brand is empty, auto-fill it with station name
+                    if (!brand.trim()) {
+                        setBrand(nearest.name);
+                    }
                 }
+            } catch (err) {
+                console.error("Station lookup failed:", err);
             }
-        } catch (err) {
-            console.error("Station lookup failed:", err);
         }
     }
 
@@ -383,7 +394,9 @@ function QuickLogPage(): JSX.Element {
     ? 'text-red-700 bg-red-100 border-red-200 dark:bg-red-900/30 dark:text-red-300 dark:border-red-800'
     : message.type === 'success'
       ? 'text-green-700 bg-green-100 border-green-200 dark:bg-green-900/30 dark:text-green-300 dark:border-green-800'
-      : 'text-blue-700 bg-blue-100 border-blue-200 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-800';
+      : message.type === 'warning'
+        ? 'text-yellow-700 bg-yellow-100 border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-300 dark:border-yellow-800'
+        : 'text-blue-700 bg-blue-100 border-blue-200 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-800';
 
   const homeCurrencySymbol = COMMON_CURRENCIES.find(c => c.code === homeCurrency)?.symbol || homeCurrency;
 

--- a/src/pages/QuickLogPage.tsx
+++ b/src/pages/QuickLogPage.tsx
@@ -46,6 +46,7 @@ function QuickLogPage(): JSX.Element {
   const [isSaving, setIsSaving] = useState<boolean>(false);
   const [savingStep, setSavingStep] = useState<'locating' | 'saving'>('saving');
   const [message, setMessage] = useState<MessageState>({ type: '', text: '' });
+  const [stationWarning, setStationWarning] = useState<string>('');
   const [knownBrands, setKnownBrands] = useState<string[]>([]);
   const [isLoadingBrands, setIsLoadingBrands] = useState<boolean>(false);
 
@@ -271,6 +272,7 @@ function QuickLogPage(): JSX.Element {
 
     setIsSaving(true);
     setSavingStep('locating');
+    setStationWarning('');
     setMessage({ type: 'info', text: t('quickLog.messages.gettingLocation') });
 
     // --- Get Location ---
@@ -286,10 +288,10 @@ function QuickLogPage(): JSX.Element {
                 `GPS accuracy (${locationData.locationAccuracy.toFixed(0)}m) exceeds threshold ` +
                 `(${GPS_ACCURACY_THRESHOLD_METERS}m); skipping automatic station association.`
             );
-            setMessage({ type: 'warning', text: t('quickLog.messages.lowAccuracySkippedStation', {
+            setStationWarning(t('quickLog.messages.lowAccuracySkippedStation', {
                 accuracy: locationData.locationAccuracy.toFixed(0),
                 defaultValue: 'GPS accuracy is low ({{accuracy}}m); skipping station detection.',
-            }) });
+            }));
         } else {
             try {
                 const nearest = await findNearestStation(locationData.latitude, locationData.longitude);
@@ -533,6 +535,13 @@ function QuickLogPage(): JSX.Element {
                     {isSaving && <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle><path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>}
                     {isSaving ? t(`quickLog.submit.${savingStep}`) : t('quickLog.submit.save')}
                 </button>
+
+                {/* Station Detection Warning (persists independently of the transient save status message) */}
+                {stationWarning && (
+                  <div className="mt-4 p-4 rounded-xl border text-sm font-medium text-center shadow-sm text-yellow-700 bg-yellow-100 border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-300 dark:border-yellow-800">
+                    {stationWarning}
+                  </div>
+                )}
 
                 {/* Feedback Message */}
                 {message.text && (

--- a/src/utils/locationService.test.ts
+++ b/src/utils/locationService.test.ts
@@ -1,5 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { findNearestStation } from './locationService';
+import { findNearestStation, isAccurateEnoughForStationMatch, GPS_ACCURACY_THRESHOLD_METERS } from './locationService';
+
+describe('isAccurateEnoughForStationMatch', () => {
+    it('returns true when accuracy is within the threshold', () => {
+        expect(isAccurateEnoughForStationMatch(50)).toBe(true);
+        expect(isAccurateEnoughForStationMatch(GPS_ACCURACY_THRESHOLD_METERS)).toBe(true);
+    });
+
+    it('returns false when accuracy exceeds the threshold', () => {
+        expect(isAccurateEnoughForStationMatch(GPS_ACCURACY_THRESHOLD_METERS + 1)).toBe(false);
+        expect(isAccurateEnoughForStationMatch(500)).toBe(false);
+    });
+});
 
 describe('locationService', () => {
     beforeEach(() => {

--- a/src/utils/locationService.ts
+++ b/src/utils/locationService.ts
@@ -34,6 +34,19 @@ interface OverpassElement {
 const OVERPASS_URL = 'https://overpass-api.de/api/interpreter';
 
 /**
+ * GPS accuracy (in metres) beyond which we no longer trust a position
+ * fix to reliably resolve the correct nearby station.
+ */
+export const GPS_ACCURACY_THRESHOLD_METERS = 100;
+
+/**
+ * Whether a GPS fix is accurate enough to attempt automatic station matching.
+ */
+export function isAccurateEnoughForStationMatch(locationAccuracy: number): boolean {
+    return locationAccuracy <= GPS_ACCURACY_THRESHOLD_METERS;
+}
+
+/**
  * Find the nearest petrol station within a radius (default 150m) of the given coordinates.
  */
 export async function findNearestStation(lat: number, lon: number, radiusMeters: number = 150): Promise<OSMStation | null> {


### PR DESCRIPTION
Closes #96

Stacked on #114 (issue-97 branch).

## Important scope note
Issue #96 was written against a `signInWithRedirect`/`getRedirectResult` flow. That flow was implemented and then **reverted back to `signInWithPopup`** within the same merged PR (#103, commits 3904088→80ea6e7) before this sprint started — `AuthContext.tsx` has no redirect logic on main today. Per discussion, this PR tests the auth flow that actually exists instead of one that was rolled back.

## Changes
- `AuthContext.test.tsx`: covers `onAuthStateChanged` sign-in (profile loads, loading clears), sign-out (user/profile clear), profile-snapshot error handling (loading still clears), `login()` invoking `signInWithGoogle`, and the outside-provider error guard.

## Testing
- `npx vitest run` — 142/142 passing
- `npx tsc --noEmit` — clean