### PR TITLE
Land issues #106, #107, #97, #96, #104 into main

### DIFF
--- a/src/context/AuthContext.test.tsx
+++ b/src/context/AuthContext.test.tsx
@@ -1,0 +1,163 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { onAuthStateChanged, User } from 'firebase/auth';
+import { onSnapshot } from 'firebase/firestore';
+import { AuthProvider, useAuth } from './AuthContext';
+
+vi.mock('firebase/auth', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('firebase/auth')>();
+    return {
+        ...actual,
+        onAuthStateChanged: vi.fn(),
+    };
+});
+
+vi.mock('firebase/firestore', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('firebase/firestore')>();
+    return {
+        ...actual,
+        doc: vi.fn(),
+        setDoc: vi.fn(),
+        onSnapshot: vi.fn(),
+    };
+});
+
+vi.mock('firebase/analytics', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('firebase/analytics')>();
+    return {
+        ...actual,
+        setUserProperties: vi.fn(),
+    };
+});
+
+vi.mock('../firebase/config', () => ({
+    auth: {},
+    db: {},
+    analytics: Promise.resolve(null),
+    signInWithGoogle: vi.fn(),
+    logout: vi.fn(),
+}));
+
+import { signInWithGoogle as mockSignInWithGoogle } from '../firebase/config';
+
+const TestComponent = () => {
+    const { loading, user, profile, login } = useAuth();
+    if (loading) return <div data-testid="loading">Loading...</div>;
+    return (
+        <div data-testid="content">
+            <span data-testid="user">{user ? user.uid : 'none'}</span>
+            <span data-testid="profile">{profile ? profile.homeCurrency : 'none'}</span>
+            <button onClick={() => login()}>Sign in</button>
+        </div>
+    );
+};
+
+describe('AuthContext', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('sets loading false and exposes the user once signed in with a profile', async () => {
+        const mockUser = { uid: 'user-1' } as User;
+
+        vi.mocked(onAuthStateChanged).mockImplementation((_auth, callback) => {
+            (callback as (user: User | null) => void)(mockUser);
+            return vi.fn();
+        });
+
+        vi.mocked(onSnapshot).mockImplementation((_ref, onNext) => {
+            (onNext as (snap: { exists: () => boolean; data: () => unknown }) => void)({
+                exists: () => true,
+                data: () => ({ homeCurrency: 'USD', tester_group: false }),
+            });
+            return vi.fn();
+        });
+
+        render(
+            <AuthProvider>
+                <TestComponent />
+            </AuthProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId('content')).toBeInTheDocument();
+        });
+
+        expect(screen.getByTestId('user').textContent).toBe('user-1');
+        expect(screen.getByTestId('profile').textContent).toBe('USD');
+    });
+
+    it('clears the user and profile, and stops loading, when signed out', async () => {
+        vi.mocked(onAuthStateChanged).mockImplementation((_auth, callback) => {
+            (callback as (user: User | null) => void)(null);
+            return vi.fn();
+        });
+
+        render(
+            <AuthProvider>
+                <TestComponent />
+            </AuthProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId('content')).toBeInTheDocument();
+        });
+
+        expect(screen.getByTestId('user').textContent).toBe('none');
+        expect(screen.getByTestId('profile').textContent).toBe('none');
+    });
+
+    it('clears loading even if the profile snapshot errors out', async () => {
+        vi.mocked(onAuthStateChanged).mockImplementation((_auth, callback) => {
+            (callback as (user: User | null) => void)({ uid: 'user-1' } as User);
+            return vi.fn();
+        });
+
+        vi.mocked(onSnapshot).mockImplementation((_ref, _onNext, onError) => {
+            (onError as (error: { code: string; message: string }) => void)({
+                code: 'permission-denied',
+                message: 'Missing permissions',
+            });
+            return vi.fn();
+        });
+
+        render(
+            <AuthProvider>
+                <TestComponent />
+            </AuthProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId('content')).toBeInTheDocument();
+        });
+
+        expect(screen.getByTestId('profile').textContent).toBe('none');
+    });
+
+    it('login() calls signInWithGoogle', async () => {
+        vi.mocked(onAuthStateChanged).mockImplementation((_auth, callback) => {
+            (callback as (user: User | null) => void)(null);
+            return vi.fn();
+        });
+
+        render(
+            <AuthProvider>
+                <TestComponent />
+            </AuthProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId('content')).toBeInTheDocument();
+        });
+
+        screen.getByText('Sign in').click();
+
+        expect(mockSignInWithGoogle).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws when useAuth is used outside of an AuthProvider', () => {
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        expect(() => render(<TestComponent />)).toThrow('useAuth must be used within an AuthProvider');
+        consoleSpy.mockRestore();
+    });
+});

--- a/src/context/AuthContext.test.tsx
+++ b/src/context/AuthContext.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { onAuthStateChanged, User } from 'firebase/auth';
 import { onSnapshot } from 'firebase/firestore';
 import { AuthProvider, useAuth } from './AuthContext';
+import { signInWithGoogle as mockSignInWithGoogle, logout as mockLogout } from '../firebase/config';
 
 vi.mock('firebase/auth', async (importOriginal) => {
     const actual = await importOriginal<typeof import('firebase/auth')>();
@@ -38,16 +39,15 @@ vi.mock('../firebase/config', () => ({
     logout: vi.fn(),
 }));
 
-import { signInWithGoogle as mockSignInWithGoogle } from '../firebase/config';
-
 const TestComponent = () => {
-    const { loading, user, profile, login } = useAuth();
+    const { loading, user, profile, login, logout } = useAuth();
     if (loading) return <div data-testid="loading">Loading...</div>;
     return (
         <div data-testid="content">
             <span data-testid="user">{user ? user.uid : 'none'}</span>
             <span data-testid="profile">{profile ? profile.homeCurrency : 'none'}</span>
             <button onClick={() => login()}>Sign in</button>
+            <button onClick={() => logout()}>Sign out</button>
         </div>
     );
 };
@@ -108,13 +108,16 @@ describe('AuthContext', () => {
     });
 
     it('clears loading even if the profile snapshot errors out', async () => {
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
         vi.mocked(onAuthStateChanged).mockImplementation((_auth, callback) => {
             (callback as (user: User | null) => void)({ uid: 'user-1' } as User);
             return vi.fn();
         });
 
         vi.mocked(onSnapshot).mockImplementation((_ref, _onNext, onError) => {
-            (onError as (error: { code: string; message: string }) => void)({
+            (onError as unknown as (error: { code: string; message: string }) => void)({
                 code: 'permission-denied',
                 message: 'Missing permissions',
             });
@@ -132,6 +135,11 @@ describe('AuthContext', () => {
         });
 
         expect(screen.getByTestId('profile').textContent).toBe('none');
+        expect(consoleErrorSpy).toHaveBeenCalled();
+        expect(consoleWarnSpy).toHaveBeenCalled();
+
+        consoleErrorSpy.mockRestore();
+        consoleWarnSpy.mockRestore();
     });
 
     it('login() calls signInWithGoogle', async () => {
@@ -150,9 +158,30 @@ describe('AuthContext', () => {
             expect(screen.getByTestId('content')).toBeInTheDocument();
         });
 
-        screen.getByText('Sign in').click();
+        fireEvent.click(screen.getByText('Sign in'));
 
         expect(mockSignInWithGoogle).toHaveBeenCalledTimes(1);
+    });
+
+    it('logout() calls logout from config', async () => {
+        vi.mocked(onAuthStateChanged).mockImplementation((_auth, callback) => {
+            (callback as (user: User | null) => void)({ uid: 'user-1' } as User);
+            return vi.fn();
+        });
+
+        render(
+            <AuthProvider>
+                <TestComponent />
+            </AuthProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId('content')).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByText('Sign out'));
+
+        expect(mockLogout).toHaveBeenCalledTimes(1);
     });
 
     it('throws when useAuth is used outside of an AuthProvider', () => {

--- a/src/firebase/__tests__/firestoreService.test.ts
+++ b/src/firebase/__tests__/firestoreService.test.ts
@@ -101,15 +101,12 @@ describe('firestoreService', () => {
             expect(result).toEqual(mockLogs);
         });
 
-        it('should return an empty array if no user is logged in', async () => {
+        it('should throw if no user is logged in', async () => {
             mockCurrentUser = null; // Set to null for this test
 
-            const result = await fetchFuelLogsByStationId(mockStationId);
-
-            expect(result).toEqual([]);
+            await expect(fetchFuelLogsByStationId(mockStationId)).rejects.toThrow('No user logged in');
             expect(collection).not.toHaveBeenCalled();
             expect(getDocs).not.toHaveBeenCalled();
-            expect(console.error).toHaveBeenCalledWith("No user logged in");
         });
 
         it('should return an empty array if no logs are found for the stationId', async () => {
@@ -124,14 +121,20 @@ describe('firestoreService', () => {
             expect(getDocs).toHaveBeenCalled();
         });
 
-        it('should return an empty array and log an error if fetching fails', async () => {
+        it('should propagate the error if fetching fails', async () => {
             const mockError = new Error('Firestore error');
             vi.mocked(getDocs).mockRejectedValueOnce(mockError);
 
-            const result = await fetchFuelLogsByStationId(mockStationId);
-
-            expect(result).toEqual([]);
+            await expect(fetchFuelLogsByStationId(mockStationId)).rejects.toThrow('Firestore error');
             expect(console.error).toHaveBeenCalledWith(`Error fetching fuel logs for station ${mockStationId}:`, mockError);
+        });
+
+        it('should throw a FirestoreOfflineError when the browser is offline', async () => {
+            const mockError = new Error('Firestore error');
+            vi.mocked(getDocs).mockRejectedValueOnce(mockError);
+            vi.spyOn(navigator, 'onLine', 'get').mockReturnValueOnce(false);
+
+            await expect(fetchFuelLogsByStationId(mockStationId)).rejects.toThrow('You are offline');
         });
     });
 });

--- a/src/firebase/aggregationService.test.ts
+++ b/src/firebase/aggregationService.test.ts
@@ -69,7 +69,7 @@ describe('aggregationService', () => {
         expect(where).toHaveBeenCalledTimes(1);
     });
 
-    it('defaults missing aggregate fields to zero rather than negative or undefined', async () => {
+    it('defaults missing aggregate fields to zero when undefined', async () => {
         vi.mocked(getAggregateFromServer).mockResolvedValue({
             data: () => ({}),
         } as never);
@@ -84,7 +84,7 @@ describe('aggregationService', () => {
         });
     });
 
-    it('reflects a reduced count and totals after a log is deleted, never going negative', async () => {
+    it('reflects a reduced count and totals after a log is deleted', async () => {
         // Before deletion: 3 logs
         vi.mocked(getAggregateFromServer).mockResolvedValueOnce({
             data: () => ({ totalCost: 150, totalLitres: 75, totalDistanceKm: 900, logCount: 3 }),
@@ -100,7 +100,5 @@ describe('aggregationService', () => {
 
         expect(after.logCount).toBe(2);
         expect(after.totalCost).toBeLessThan(before.totalCost);
-        expect(after.logCount).toBeGreaterThanOrEqual(0);
-        expect(after.totalCost).toBeGreaterThanOrEqual(0);
     });
 });

--- a/src/firebase/aggregationService.test.ts
+++ b/src/firebase/aggregationService.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { collection, query, where, getAggregateFromServer } from 'firebase/firestore';
+import { getLifetimeStats } from './aggregationService';
+
+vi.mock('firebase/firestore', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('firebase/firestore')>();
+    return {
+        ...actual,
+        collection: vi.fn(),
+        query: vi.fn(),
+        where: vi.fn(),
+        getAggregateFromServer: vi.fn(),
+    };
+});
+
+vi.mock('./config', () => ({
+    db: {},
+}));
+
+describe('aggregationService', () => {
+    const mockUserId = 'testUserId';
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(collection).mockReturnValue({} as never);
+        vi.mocked(query).mockReturnValue({} as never);
+        vi.mocked(where).mockReturnValue({} as never);
+    });
+
+    it('computes lifetime stats from aggregate fixture data', async () => {
+        vi.mocked(getAggregateFromServer).mockResolvedValue({
+            data: () => ({
+                totalCost: 245.5,
+                totalLitres: 120.25,
+                totalDistanceKm: 1800,
+                logCount: 12,
+            }),
+        } as never);
+
+        const result = await getLifetimeStats(mockUserId);
+
+        expect(result).toEqual({
+            totalCost: 245.5,
+            totalLitres: 120.25,
+            totalDistanceKm: 1800,
+            logCount: 12,
+        });
+    });
+
+    it('filters by vehicleId when provided', async () => {
+        vi.mocked(getAggregateFromServer).mockResolvedValue({
+            data: () => ({ totalCost: 50, totalLitres: 25, totalDistanceKm: 400, logCount: 2 }),
+        } as never);
+
+        await getLifetimeStats(mockUserId, 'vehicle-1');
+
+        expect(where).toHaveBeenCalledWith('userId', '==', mockUserId);
+        expect(where).toHaveBeenCalledWith('vehicleId', '==', 'vehicle-1');
+    });
+
+    it('does not filter by vehicleId when omitted', async () => {
+        vi.mocked(getAggregateFromServer).mockResolvedValue({
+            data: () => ({ totalCost: 0, totalLitres: 0, totalDistanceKm: 0, logCount: 0 }),
+        } as never);
+
+        await getLifetimeStats(mockUserId);
+
+        expect(where).toHaveBeenCalledWith('userId', '==', mockUserId);
+        expect(where).toHaveBeenCalledTimes(1);
+    });
+
+    it('defaults missing aggregate fields to zero rather than negative or undefined', async () => {
+        vi.mocked(getAggregateFromServer).mockResolvedValue({
+            data: () => ({}),
+        } as never);
+
+        const result = await getLifetimeStats(mockUserId);
+
+        expect(result).toEqual({
+            totalCost: 0,
+            totalLitres: 0,
+            totalDistanceKm: 0,
+            logCount: 0,
+        });
+    });
+
+    it('reflects a reduced count and totals after a log is deleted, never going negative', async () => {
+        // Before deletion: 3 logs
+        vi.mocked(getAggregateFromServer).mockResolvedValueOnce({
+            data: () => ({ totalCost: 150, totalLitres: 75, totalDistanceKm: 900, logCount: 3 }),
+        } as never);
+        const before = await getLifetimeStats(mockUserId);
+        expect(before.logCount).toBe(3);
+
+        // After deleting one log: server-side aggregate recomputes from remaining logs
+        vi.mocked(getAggregateFromServer).mockResolvedValueOnce({
+            data: () => ({ totalCost: 100, totalLitres: 50, totalDistanceKm: 600, logCount: 2 }),
+        } as never);
+        const after = await getLifetimeStats(mockUserId);
+
+        expect(after.logCount).toBe(2);
+        expect(after.totalCost).toBeLessThan(before.totalCost);
+        expect(after.logCount).toBeGreaterThanOrEqual(0);
+        expect(after.totalCost).toBeGreaterThanOrEqual(0);
+    });
+});

--- a/src/firebase/firestoreService.ts
+++ b/src/firebase/firestoreService.ts
@@ -4,10 +4,24 @@ import { db, auth } from './config'; // db and auth from your config file
 import { Log, FuelLogData, Station } from '../utils/types'; // Adjust path as needed
 import { OSMStation } from '../utils/locationService';
 
+export class FirestoreOfflineError extends Error {
+  constructor(message = 'You are offline. Please check your connection and try again.') {
+    super(message);
+    this.name = 'FirestoreOfflineError';
+  }
+}
+
+const rethrowFirestoreError = (error: unknown, context: string): never => {
+  console.error(context, error);
+  if (!navigator.onLine) {
+    throw new FirestoreOfflineError();
+  }
+  throw error instanceof Error ? error : new Error(String(error));
+};
+
 export const fetchFuelLocations = async (): Promise<Log[]> => {
   if (!auth.currentUser) {
-    console.error("No user logged in");
-    return [];
+    throw new Error('No user logged in');
   }
 
   const logsCollection = collection(db, 'fuelLogs');
@@ -29,16 +43,17 @@ export const fetchFuelLocations = async (): Promise<Log[]> => {
     // Additional filtering just in case Firestore rules change or for robustness
     return locations.filter(p => p.latitude !== undefined && p.longitude !== undefined);
   } catch (error) {
-    console.error("Error fetching fuel locations:", error);
-    return [];
+    return rethrowFirestoreError(error, 'Error fetching fuel locations:');
   }
 };
 
 // You could add other Firestore-related functions here later (e.g., addFuelLog, updateFuelLog)
 
 export const getLastOdometerReading = async (vehicleId: string): Promise<number | null> => {
-    if (!auth.currentUser) return null;
-    
+    if (!auth.currentUser) {
+        throw new Error('No user logged in');
+    }
+
     const q = query(
         collection(db, 'fuelLogs'),
         where('userId', '==', auth.currentUser.uid),
@@ -46,15 +61,14 @@ export const getLastOdometerReading = async (vehicleId: string): Promise<number 
         orderBy('timestamp', 'desc'),
         limit(1)
     );
-    
+
     try {
         const querySnapshot = await getDocs(q);
         if (querySnapshot.empty) return null;
         const lastLog = querySnapshot.docs[0].data() as FuelLogData;
         return lastLog.odometerKm ?? null;
     } catch (error) {
-        console.error("Error fetching last odometer reading:", error);
-        return null;
+        return rethrowFirestoreError(error, 'Error fetching last odometer reading:');
     }
 };
 
@@ -145,8 +159,7 @@ export const fetchUserStations = async (logs: Log[]): Promise<Station[]> => {
  */
 export const fetchFuelLogsByStationId = async (stationId: string): Promise<Log[]> => {
     if (!auth.currentUser) {
-        console.error("No user logged in");
-        return [];
+        throw new Error('No user logged in');
     }
 
     const logsCollection = collection(db, 'fuelLogs');
@@ -165,7 +178,6 @@ export const fetchFuelLogsByStationId = async (stationId: string): Promise<Log[]
         }));
         return logs;
     } catch (error) {
-        console.error(`Error fetching fuel logs for station ${stationId}:`, error);
-        return [];
+        return rethrowFirestoreError(error, `Error fetching fuel logs for station ${stationId}:`);
     }
 };

--- a/src/firebase/messagingService.test.ts
+++ b/src/firebase/messagingService.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { getMessaging, getToken, onMessage } from 'firebase/messaging';
 import { isSupported } from 'firebase/analytics';
 
@@ -41,7 +41,11 @@ describe('messagingService', () => {
             configurable: true,
         });
 
-        import.meta.env.VITE_FIREBASE_VAPID_KEY = 'test-vapid-key';
+        vi.stubEnv('VITE_FIREBASE_VAPID_KEY', 'test-vapid-key');
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
     });
 
     it('requests a token from getToken when permission is granted', async () => {

--- a/src/firebase/messagingService.test.ts
+++ b/src/firebase/messagingService.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getMessaging, getToken, onMessage } from 'firebase/messaging';
+import { isSupported } from 'firebase/analytics';
+
+vi.mock('firebase/messaging', () => ({
+    getMessaging: vi.fn(),
+    getToken: vi.fn(),
+    onMessage: vi.fn(),
+}));
+
+vi.mock('firebase/analytics', () => ({
+    isSupported: vi.fn(),
+}));
+
+vi.mock('./config', () => ({
+    app: {},
+}));
+
+const setNotificationPermission = (requestPermission: () => Promise<NotificationPermission>) => {
+    Object.defineProperty(global, 'Notification', {
+        value: { requestPermission },
+        writable: true,
+        configurable: true,
+    });
+};
+
+describe('messagingService', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        vi.clearAllMocks();
+        vi.mocked(isSupported).mockResolvedValue(true);
+        vi.mocked(getMessaging).mockReturnValue({} as never);
+
+        Object.defineProperty(window, 'PushManager', { value: {}, writable: true, configurable: true });
+        Object.defineProperty(navigator, 'serviceWorker', {
+            value: {
+                getRegistration: vi.fn().mockResolvedValue(undefined),
+                ready: Promise.resolve({ active: { postMessage: vi.fn() } }),
+            },
+            writable: true,
+            configurable: true,
+        });
+
+        import.meta.env.VITE_FIREBASE_VAPID_KEY = 'test-vapid-key';
+    });
+
+    it('requests a token from getToken when permission is granted', async () => {
+        setNotificationPermission(() => Promise.resolve('granted'));
+        vi.mocked(getToken).mockResolvedValue('mock-fcm-token');
+
+        const { requestNotificationPermission } = await import('./messagingService');
+        const token = await requestNotificationPermission();
+
+        expect(getToken).toHaveBeenCalled();
+        expect(token).toBe('mock-fcm-token');
+    });
+
+    it('returns null without throwing when permission is denied', async () => {
+        setNotificationPermission(() => Promise.resolve('denied'));
+
+        const { requestNotificationPermission } = await import('./messagingService');
+        const token = await requestNotificationPermission();
+
+        expect(token).toBeNull();
+        expect(getToken).not.toHaveBeenCalled();
+    });
+
+    it('returns null when messaging is unsupported in this environment', async () => {
+        vi.mocked(isSupported).mockResolvedValue(false);
+        setNotificationPermission(() => Promise.resolve('granted'));
+
+        const { requestNotificationPermission } = await import('./messagingService');
+        const token = await requestNotificationPermission();
+
+        expect(token).toBeNull();
+        expect(getToken).not.toHaveBeenCalled();
+    });
+
+    it('returns null and does not throw when getToken rejects', async () => {
+        setNotificationPermission(() => Promise.resolve('granted'));
+        vi.mocked(getToken).mockRejectedValue(new Error('token fetch failed'));
+
+        const { requestNotificationPermission } = await import('./messagingService');
+        await expect(requestNotificationPermission()).resolves.toBeNull();
+    });
+
+    it('registers a foreground message handler via onMessage', async () => {
+        const unsubscribe = vi.fn();
+        vi.mocked(onMessage).mockReturnValue(unsubscribe);
+
+        const { onForegroundMessage } = await import('./messagingService');
+        const handler = vi.fn();
+        const unsub = await onForegroundMessage(handler);
+
+        expect(onMessage).toHaveBeenCalledWith({}, handler);
+        expect(unsub).toBe(unsubscribe);
+    });
+
+    it('returns a no-op unsubscribe when messaging is unsupported', async () => {
+        vi.mocked(isSupported).mockResolvedValue(false);
+
+        const { onForegroundMessage } = await import('./messagingService');
+        const unsub = await onForegroundMessage(vi.fn());
+
+        expect(() => unsub()).not.toThrow();
+        expect(onMessage).not.toHaveBeenCalled();
+    });
+});

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -147,7 +147,11 @@ function HistoryPage(): JSX.Element {
         }, (err) => {
             // Handle Firestore errors
             console.error("Error fetching fuel logs:", err);
-            setError(t('history.loadError', { defaultValue: 'Failed to load fuel history. Please check your connection and try again.' }));
+            setError(
+                !navigator.onLine
+                    ? t('history.offlineError', { defaultValue: 'You are offline. Please check your connection and try again.' })
+                    : t('history.loadError', { defaultValue: 'Failed to load fuel history. Please check your connection and try again.' })
+            );
             setIsLoading(false);
         });
 
@@ -158,7 +162,14 @@ function HistoryPage(): JSX.Element {
     // --- Fetch Stations Effect ---
     useEffect(() => {
         if (logs.length > 0) {
-            fetchUserStations(logs).then(setStations).catch(console.error);
+            fetchUserStations(logs).then(setStations).catch(err => {
+                console.error('Error fetching stations:', err);
+                setError(
+                    !navigator.onLine
+                        ? t('history.offlineError', { defaultValue: 'You are offline. Please check your connection and try again.' })
+                        : t('history.loadError', { defaultValue: 'Failed to load fuel history. Please check your connection and try again.' })
+                );
+            });
         } else {
             setStations([]);
         }

--- a/src/pages/QuickLogPage.test.tsx
+++ b/src/pages/QuickLogPage.test.tsx
@@ -1,0 +1,207 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { addDoc, getDocs } from 'firebase/firestore';
+import { fetchExchangeRate } from '../utils/currencyApi';
+import { getLastOdometerReading } from '../firebase/firestoreService';
+import { extractDataFromReceipt } from '../utils/gemini';
+import QuickLogPage from './QuickLogPage';
+
+const mockT = (key: string, opts?: Record<string, unknown>) => {
+  if (opts && 'defaultValue' in opts) return opts.defaultValue as string;
+  return key;
+};
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: mockT }),
+}));
+
+const mockUser = { uid: 'user-1' };
+const mockProfile = { homeCurrency: 'EUR' };
+
+vi.mock('../context/AuthContext', () => ({
+  useAuth: () => ({ user: mockUser, profile: mockProfile }),
+}));
+
+const mockGetBoolean = (key: string) =>
+  key === 'odometerInputEnabled' || key === 'receiptDigitizationEnabled' || key === 'receiptAutoFillEnabled';
+
+vi.mock('../context/RemoteConfigContext', () => ({
+  useRemoteConfig: () => ({ getBoolean: mockGetBoolean }),
+}));
+
+vi.mock('firebase/firestore', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('firebase/firestore')>();
+  return {
+    ...actual,
+    collection: vi.fn(() => ({})),
+    query: vi.fn(() => ({})),
+    where: vi.fn(() => ({})),
+    getDocs: vi.fn(),
+    addDoc: vi.fn(),
+  };
+});
+
+vi.mock('../firebase/config', () => ({
+  db: {},
+  analytics: Promise.resolve(null),
+}));
+
+vi.mock('../utils/currencyApi', () => ({
+  fetchExchangeRate: vi.fn(),
+  COMMON_CURRENCIES: [
+    { code: 'EUR', symbol: '€' },
+    { code: 'USD', symbol: '$' },
+    { code: 'GBP', symbol: '£' },
+  ],
+}));
+
+vi.mock('../firebase/storageService', () => ({
+  uploadReceipt: vi.fn().mockResolvedValue(''),
+}));
+
+vi.mock('../firebase/firestoreService', () => ({
+  getLastOdometerReading: vi.fn().mockResolvedValue(null),
+  getOrCreateStation: vi.fn(),
+  updateStationMetrics: vi.fn(),
+}));
+
+vi.mock('../utils/gemini', () => ({
+  extractDataFromReceipt: vi.fn(),
+}));
+
+vi.mock('../utils/locationService', () => ({
+  findNearestStation: vi.fn().mockResolvedValue(null),
+  isAccurateEnoughForStationMatch: () => true,
+  GPS_ACCURACY_THRESHOLD_METERS: 100,
+}));
+
+const mockVehicle = { id: 'vehicle-1', name: 'Car', make: 'Toyota', isDefault: true, isArchived: false };
+
+function mockSnapshot(docs: { id: string; data: Record<string, unknown> }[]) {
+  return {
+    forEach: (cb: (doc: { id: string; data: () => Record<string, unknown> }) => void) => {
+      docs.forEach(d => cb({ id: d.id, data: () => d.data }));
+    },
+  };
+}
+
+describe('QuickLogPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getDocs).mockImplementation(async () => {
+      return mockSnapshot([{ id: mockVehicle.id, data: mockVehicle }]) as never;
+    });
+    vi.mocked(getLastOdometerReading).mockResolvedValue(null);
+
+    Object.defineProperty(global.navigator, 'geolocation', {
+      value: { getCurrentPosition: vi.fn((_success, error) => error?.({ code: 1, message: 'denied' })) },
+      configurable: true,
+    });
+  });
+
+  it('saves a fuel log with the correct payload on the happy path', async () => {
+    render(<QuickLogPage />);
+
+    await waitFor(() => expect(screen.getByLabelText('quickLog.fields.totalCost')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText(/quickLog\.fields\.fillingStation/), { target: { value: 'Shell' } });
+    fireEvent.change(screen.getByLabelText('quickLog.fields.totalCost'), { target: { value: '50' } });
+    fireEvent.change(screen.getByLabelText('quickLog.fields.distance'), { target: { value: '400' } });
+    fireEvent.change(screen.getByLabelText('quickLog.fields.fuel'), { target: { value: '30' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /quickLog.submit.save/ }));
+
+    await waitFor(() => expect(addDoc).toHaveBeenCalledTimes(1));
+
+    const [, payload] = vi.mocked(addDoc).mock.calls[0];
+    expect(payload).toMatchObject({
+      userId: 'user-1',
+      vehicleId: 'vehicle-1',
+      brand: 'Shell',
+      cost: 50,
+      distanceKm: 400,
+      fuelAmountLiters: 30,
+      currency: 'EUR',
+      originalCost: 50,
+      exchangeRate: 1,
+    });
+  });
+
+  it('shows a validation error when required fields are missing', async () => {
+    render(<QuickLogPage />);
+
+    await waitFor(() => expect(screen.getByLabelText('quickLog.fields.totalCost')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /quickLog.submit.save/ }));
+
+    await waitFor(() => expect(screen.getByText('quickLog.messages.fillRequired')).toBeInTheDocument());
+    expect(addDoc).not.toHaveBeenCalled();
+  });
+
+  it('auto-populates distance from the odometer reading when a prior reading exists', async () => {
+    vi.mocked(getLastOdometerReading).mockResolvedValue(10000);
+
+    render(<QuickLogPage />);
+
+    await waitFor(() => expect(screen.getByLabelText('quickLog.fields.odometer')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText('quickLog.fields.odometer'), { target: { value: '10400' } });
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('quickLog.fields.distance') as HTMLInputElement).value).toBe('400.0');
+    });
+  });
+
+  it('fetches the exchange rate and stores originalCost + exchangeRate when a non-home currency is selected', async () => {
+    vi.mocked(fetchExchangeRate).mockResolvedValue(1.1);
+
+    render(<QuickLogPage />);
+
+    await waitFor(() => expect(screen.getByLabelText('quickLog.fields.currency')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText('quickLog.fields.currency'), { target: { value: 'USD' } });
+
+    await waitFor(() => expect(fetchExchangeRate).toHaveBeenCalledWith(expect.any(Date), 'USD', 'EUR'));
+    await waitFor(() => expect((screen.getByLabelText(/quickLog.fields.exchangeRate/) as HTMLInputElement).value).toBe('1.1'));
+
+    fireEvent.change(screen.getByLabelText(/quickLog\.fields\.fillingStation/), { target: { value: 'Shell' } });
+    fireEvent.change(screen.getByLabelText('quickLog.fields.totalCost'), { target: { value: '50' } });
+    fireEvent.change(screen.getByLabelText('quickLog.fields.distance'), { target: { value: '400' } });
+    fireEvent.change(screen.getByLabelText('quickLog.fields.fuel'), { target: { value: '30' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /quickLog.submit.save/ }));
+
+    await waitFor(() => expect(addDoc).toHaveBeenCalledTimes(1));
+    const [, payload] = vi.mocked(addDoc).mock.calls[0];
+    expect(payload).toMatchObject({
+      currency: 'USD',
+      originalCost: 50,
+      exchangeRate: 1.1,
+    });
+    expect((payload as { cost: number }).cost).toBeCloseTo(55);
+  });
+
+  it('extracts and pre-fills form fields from a receipt image', async () => {
+    vi.mocked(extractDataFromReceipt).mockResolvedValue({ cost: 42.5, fuelAmountLiters: 28, brand: 'Esso' });
+
+    render(<QuickLogPage />);
+
+    await waitFor(() => expect(screen.getByLabelText('quickLog.fields.totalCost')).toBeInTheDocument());
+
+    const file = new File(['mock'], 'receipt.jpg', { type: 'image/jpeg' });
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await fireEvent.change(fileInput, { target: { files: [file] } });
+
+    const extractButton = await screen.findByRole('button', { name: 'receipt.autoFillWithAI' });
+    fireEvent.click(extractButton);
+
+    await waitFor(() => expect(extractDataFromReceipt).toHaveBeenCalledWith(file));
+
+    const useValuesButton = await screen.findByRole('button', { name: 'receipt.useValues' });
+    fireEvent.click(useValuesButton);
+
+    expect((screen.getByLabelText('quickLog.fields.totalCost') as HTMLInputElement).value).toBe('42.5');
+    expect((screen.getByLabelText('quickLog.fields.fuel') as HTMLInputElement).value).toBe('28');
+    expect((screen.getByLabelText(/quickLog\.fields\.fillingStation/) as HTMLInputElement).value).toBe('Esso');
+  });
+});

--- a/src/pages/QuickLogPage.test.tsx
+++ b/src/pages/QuickLogPage.test.tsx
@@ -4,11 +4,13 @@ import { addDoc, getDocs } from 'firebase/firestore';
 import { fetchExchangeRate } from '../utils/currencyApi';
 import { getLastOdometerReading } from '../firebase/firestoreService';
 import { extractDataFromReceipt } from '../utils/gemini';
+import { isAccurateEnoughForStationMatch } from '../utils/locationService';
 import QuickLogPage from './QuickLogPage';
 
 const mockT = (key: string, opts?: Record<string, unknown>) => {
-  if (opts && 'defaultValue' in opts) return opts.defaultValue as string;
-  return key;
+  const template = opts && 'defaultValue' in opts ? (opts.defaultValue as string) : key;
+  if (!opts) return template;
+  return template.replace(/\{\{(\w+)\}\}/g, (_match, name) => String(opts[name] ?? ''));
 };
 
 vi.mock('react-i18next', () => ({
@@ -71,7 +73,7 @@ vi.mock('../utils/gemini', () => ({
 
 vi.mock('../utils/locationService', () => ({
   findNearestStation: vi.fn().mockResolvedValue(null),
-  isAccurateEnoughForStationMatch: () => true,
+  isAccurateEnoughForStationMatch: vi.fn(() => true),
   GPS_ACCURACY_THRESHOLD_METERS: 100,
 }));
 
@@ -203,5 +205,91 @@ describe('QuickLogPage', () => {
     expect((screen.getByLabelText('quickLog.fields.totalCost') as HTMLInputElement).value).toBe('42.5');
     expect((screen.getByLabelText('quickLog.fields.fuel') as HTMLInputElement).value).toBe('28');
     expect((screen.getByLabelText(/quickLog\.fields\.fillingStation/) as HTMLInputElement).value).toBe('Esso');
+  });
+
+  describe('low GPS accuracy warning', () => {
+    const setGeolocationAccuracy = (accuracy: number) => {
+      Object.defineProperty(global.navigator, 'geolocation', {
+        value: {
+          getCurrentPosition: vi.fn((success) => {
+            success({ coords: { latitude: 53.3, longitude: -6.2, accuracy } });
+          }),
+        },
+        configurable: true,
+      });
+    };
+
+    it('shows a persistent warning banner that survives the save flow when accuracy is poor', async () => {
+      vi.mocked(isAccurateEnoughForStationMatch).mockReturnValue(false);
+      setGeolocationAccuracy(500);
+
+      render(<QuickLogPage />);
+
+      await waitFor(() => expect(screen.getByLabelText('quickLog.fields.totalCost')).toBeInTheDocument());
+
+      fireEvent.change(screen.getByLabelText('quickLog.fields.totalCost'), { target: { value: '50' } });
+      fireEvent.change(screen.getByLabelText('quickLog.fields.distance'), { target: { value: '400' } });
+      fireEvent.change(screen.getByLabelText('quickLog.fields.fuel'), { target: { value: '30' } });
+
+      fireEvent.click(screen.getByRole('button', { name: /quickLog.submit.save/ }));
+
+      // The warning appears during station-detection...
+      await waitFor(() =>
+        expect(screen.getByText('GPS accuracy is low (500m); skipping station detection.')).toBeInTheDocument()
+      );
+
+      // ...and is still visible once the save completes successfully (not overwritten
+      // by the subsequent "saving"/"success" status messages, which share a different slot).
+      await waitFor(() => expect(addDoc).toHaveBeenCalledTimes(1));
+      expect(screen.getByText('GPS accuracy is low (500m); skipping station detection.')).toBeInTheDocument();
+    });
+
+    it('does not show the warning banner when accuracy is within the threshold', async () => {
+      vi.mocked(isAccurateEnoughForStationMatch).mockReturnValue(true);
+      setGeolocationAccuracy(20);
+
+      render(<QuickLogPage />);
+
+      await waitFor(() => expect(screen.getByLabelText('quickLog.fields.totalCost')).toBeInTheDocument());
+
+      fireEvent.change(screen.getByLabelText('quickLog.fields.totalCost'), { target: { value: '50' } });
+      fireEvent.change(screen.getByLabelText('quickLog.fields.distance'), { target: { value: '400' } });
+      fireEvent.change(screen.getByLabelText('quickLog.fields.fuel'), { target: { value: '30' } });
+
+      fireEvent.click(screen.getByRole('button', { name: /quickLog.submit.save/ }));
+
+      await waitFor(() => expect(addDoc).toHaveBeenCalledTimes(1));
+      expect(screen.queryByText(/skipping station detection/)).not.toBeInTheDocument();
+    });
+
+    it('clears a previous warning when a new submission has good accuracy', async () => {
+      vi.mocked(isAccurateEnoughForStationMatch).mockReturnValue(false);
+      setGeolocationAccuracy(500);
+
+      render(<QuickLogPage />);
+      await waitFor(() => expect(screen.getByLabelText('quickLog.fields.totalCost')).toBeInTheDocument());
+
+      fireEvent.change(screen.getByLabelText('quickLog.fields.totalCost'), { target: { value: '50' } });
+      fireEvent.change(screen.getByLabelText('quickLog.fields.distance'), { target: { value: '400' } });
+      fireEvent.change(screen.getByLabelText('quickLog.fields.fuel'), { target: { value: '30' } });
+      fireEvent.click(screen.getByRole('button', { name: /quickLog.submit.save/ }));
+
+      await waitFor(() =>
+        expect(screen.getByText('GPS accuracy is low (500m); skipping station detection.')).toBeInTheDocument()
+      );
+      await waitFor(() => expect(addDoc).toHaveBeenCalledTimes(1));
+
+      // Second submission with good accuracy should clear the stale warning.
+      vi.mocked(isAccurateEnoughForStationMatch).mockReturnValue(true);
+      setGeolocationAccuracy(20);
+
+      fireEvent.change(screen.getByLabelText('quickLog.fields.totalCost'), { target: { value: '60' } });
+      fireEvent.change(screen.getByLabelText('quickLog.fields.distance'), { target: { value: '300' } });
+      fireEvent.change(screen.getByLabelText('quickLog.fields.fuel'), { target: { value: '20' } });
+      fireEvent.click(screen.getByRole('button', { name: /quickLog.submit.save/ }));
+
+      await waitFor(() => expect(addDoc).toHaveBeenCalledTimes(2));
+      expect(screen.queryByText(/skipping station detection/)).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/pages/QuickLogPage.test.tsx
+++ b/src/pages/QuickLogPage.test.tsx
@@ -2,9 +2,9 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { addDoc, getDocs } from 'firebase/firestore';
 import { fetchExchangeRate } from '../utils/currencyApi';
-import { getLastOdometerReading } from '../firebase/firestoreService';
+import { getLastOdometerReading, getOrCreateStation, updateStationMetrics } from '../firebase/firestoreService';
 import { extractDataFromReceipt } from '../utils/gemini';
-import { isAccurateEnoughForStationMatch } from '../utils/locationService';
+import { findNearestStation, isAccurateEnoughForStationMatch } from '../utils/locationService';
 import QuickLogPage from './QuickLogPage';
 
 const mockT = (key: string, opts?: Record<string, unknown>) => {
@@ -88,6 +88,8 @@ function mockSnapshot(docs: { id: string; data: Record<string, unknown> }[]) {
 }
 
 describe('QuickLogPage', () => {
+  let mockGetCurrentPosition: ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(getDocs).mockImplementation(async () => {
@@ -95,8 +97,9 @@ describe('QuickLogPage', () => {
     });
     vi.mocked(getLastOdometerReading).mockResolvedValue(null);
 
+    mockGetCurrentPosition = vi.fn((_success, error) => error?.({ code: 1, message: 'denied' }));
     Object.defineProperty(global.navigator, 'geolocation', {
-      value: { getCurrentPosition: vi.fn((_success, error) => error?.({ code: 1, message: 'denied' })) },
+      value: { getCurrentPosition: mockGetCurrentPosition },
       configurable: true,
     });
   });
@@ -209,13 +212,8 @@ describe('QuickLogPage', () => {
 
   describe('low GPS accuracy warning', () => {
     const setGeolocationAccuracy = (accuracy: number) => {
-      Object.defineProperty(global.navigator, 'geolocation', {
-        value: {
-          getCurrentPosition: vi.fn((success) => {
-            success({ coords: { latitude: 53.3, longitude: -6.2, accuracy } });
-          }),
-        },
-        configurable: true,
+      mockGetCurrentPosition.mockImplementation((success) => {
+        success({ coords: { latitude: 53.3, longitude: -6.2, accuracy } });
       });
     };
 
@@ -291,5 +289,52 @@ describe('QuickLogPage', () => {
       await waitFor(() => expect(addDoc).toHaveBeenCalledTimes(2));
       expect(screen.queryByText(/skipping station detection/)).not.toBeInTheDocument();
     });
+  });
+
+  it('successfully captures location, matches nearest station, and updates station metrics', async () => {
+    const mockStation = {
+      id: 'station-123',
+      osmId: 'node/123',
+      name: 'Shell Berlin',
+      brand: 'Shell',
+      latitude: 52.52,
+      longitude: 13.405,
+    };
+
+    vi.mocked(findNearestStation).mockResolvedValue(mockStation);
+    vi.mocked(getOrCreateStation).mockResolvedValue('station-123');
+
+    mockGetCurrentPosition.mockImplementation((success) =>
+      success({
+        coords: {
+          latitude: 52.52,
+          longitude: 13.405,
+          accuracy: 15,
+        },
+      })
+    );
+
+    render(<QuickLogPage />);
+
+    await waitFor(() => expect(screen.getByLabelText('quickLog.fields.totalCost')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText('quickLog.fields.totalCost'), { target: { value: '50' } });
+    fireEvent.change(screen.getByLabelText('quickLog.fields.distance'), { target: { value: '400' } });
+    fireEvent.change(screen.getByLabelText('quickLog.fields.fuel'), { target: { value: '30' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /quickLog.submit.save/ }));
+
+    await waitFor(() => expect(addDoc).toHaveBeenCalledTimes(1));
+
+    const [, payload] = vi.mocked(addDoc).mock.calls[0];
+    expect(payload).toMatchObject({
+      brand: 'Shell Berlin',
+      latitude: 52.52,
+      longitude: 13.405,
+      locationAccuracy: 15,
+      stationId: 'station-123',
+    });
+
+    expect(updateStationMetrics).toHaveBeenCalledWith('station-123', 50 / 30);
   });
 });

--- a/src/pages/QuickLogPage.tsx
+++ b/src/pages/QuickLogPage.tsx
@@ -12,12 +12,12 @@ import { uploadReceipt } from '../firebase/storageService';
 import { getLastOdometerReading, getOrCreateStation, updateStationMetrics } from '../firebase/firestoreService';
 import { extractDataFromReceipt, ReceiptData } from '../utils/gemini';
 import { calculateDistance } from '../utils/calculations';
-import { findNearestStation } from '../utils/locationService';
+import { findNearestStation, isAccurateEnoughForStationMatch, GPS_ACCURACY_THRESHOLD_METERS } from '../utils/locationService';
 import ReceiptAISection from '../components/ReceiptAISection';
 import { useTranslation } from 'react-i18next';
 
 // Types
-type MessageType = 'success' | 'error' | 'info' | '';
+type MessageType = 'success' | 'error' | 'info' | 'warning' | '';
 interface MessageState {
   type: MessageType;
   text: string;
@@ -275,24 +275,35 @@ function QuickLogPage(): JSX.Element {
 
     // --- Get Location ---
     const locationData = await getCurrentLocation();
-    
+
     // --- Find Station ---
     let linkedStationId: string | undefined;
     let stationName: string | undefined;
 
     if (locationData) {
-        try {
-            const nearest = await findNearestStation(locationData.latitude, locationData.longitude);
-            if (nearest) {
-                linkedStationId = await getOrCreateStation(nearest);
-                stationName = nearest.name;
-                // If brand is empty, auto-fill it with station name
-                if (!brand.trim()) {
-                    setBrand(nearest.name);
+        if (!isAccurateEnoughForStationMatch(locationData.locationAccuracy)) {
+            console.warn(
+                `GPS accuracy (${locationData.locationAccuracy.toFixed(0)}m) exceeds threshold ` +
+                `(${GPS_ACCURACY_THRESHOLD_METERS}m); skipping automatic station association.`
+            );
+            setMessage({ type: 'warning', text: t('quickLog.messages.lowAccuracySkippedStation', {
+                accuracy: locationData.locationAccuracy.toFixed(0),
+                defaultValue: 'GPS accuracy is low ({{accuracy}}m); skipping station detection.',
+            }) });
+        } else {
+            try {
+                const nearest = await findNearestStation(locationData.latitude, locationData.longitude);
+                if (nearest) {
+                    linkedStationId = await getOrCreateStation(nearest);
+                    stationName = nearest.name;
+                    // If brand is empty, auto-fill it with station name
+                    if (!brand.trim()) {
+                        setBrand(nearest.name);
+                    }
                 }
+            } catch (err) {
+                console.error("Station lookup failed:", err);
             }
-        } catch (err) {
-            console.error("Station lookup failed:", err);
         }
     }
 
@@ -383,7 +394,9 @@ function QuickLogPage(): JSX.Element {
     ? 'text-red-700 bg-red-100 border-red-200 dark:bg-red-900/30 dark:text-red-300 dark:border-red-800'
     : message.type === 'success'
       ? 'text-green-700 bg-green-100 border-green-200 dark:bg-green-900/30 dark:text-green-300 dark:border-green-800'
-      : 'text-blue-700 bg-blue-100 border-blue-200 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-800';
+      : message.type === 'warning'
+        ? 'text-yellow-700 bg-yellow-100 border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-300 dark:border-yellow-800'
+        : 'text-blue-700 bg-blue-100 border-blue-200 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-800';
 
   const homeCurrencySymbol = COMMON_CURRENCIES.find(c => c.code === homeCurrency)?.symbol || homeCurrency;
 

--- a/src/pages/QuickLogPage.tsx
+++ b/src/pages/QuickLogPage.tsx
@@ -46,6 +46,7 @@ function QuickLogPage(): JSX.Element {
   const [isSaving, setIsSaving] = useState<boolean>(false);
   const [savingStep, setSavingStep] = useState<'locating' | 'saving'>('saving');
   const [message, setMessage] = useState<MessageState>({ type: '', text: '' });
+  const [stationWarning, setStationWarning] = useState<string>('');
   const [knownBrands, setKnownBrands] = useState<string[]>([]);
   const [isLoadingBrands, setIsLoadingBrands] = useState<boolean>(false);
 
@@ -271,6 +272,7 @@ function QuickLogPage(): JSX.Element {
 
     setIsSaving(true);
     setSavingStep('locating');
+    setStationWarning('');
     setMessage({ type: 'info', text: t('quickLog.messages.gettingLocation') });
 
     // --- Get Location ---
@@ -286,10 +288,10 @@ function QuickLogPage(): JSX.Element {
                 `GPS accuracy (${locationData.locationAccuracy.toFixed(0)}m) exceeds threshold ` +
                 `(${GPS_ACCURACY_THRESHOLD_METERS}m); skipping automatic station association.`
             );
-            setMessage({ type: 'warning', text: t('quickLog.messages.lowAccuracySkippedStation', {
+            setStationWarning(t('quickLog.messages.lowAccuracySkippedStation', {
                 accuracy: locationData.locationAccuracy.toFixed(0),
                 defaultValue: 'GPS accuracy is low ({{accuracy}}m); skipping station detection.',
-            }) });
+            }));
         } else {
             try {
                 const nearest = await findNearestStation(locationData.latitude, locationData.longitude);
@@ -533,6 +535,13 @@ function QuickLogPage(): JSX.Element {
                     {isSaving && <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle><path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>}
                     {isSaving ? t(`quickLog.submit.${savingStep}`) : t('quickLog.submit.save')}
                 </button>
+
+                {/* Station Detection Warning (persists independently of the transient save status message) */}
+                {stationWarning && (
+                  <div className="mt-4 p-4 rounded-xl border text-sm font-medium text-center shadow-sm text-yellow-700 bg-yellow-100 border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-300 dark:border-yellow-800">
+                    {stationWarning}
+                  </div>
+                )}
 
                 {/* Feedback Message */}
                 {message.text && (

--- a/src/pages/QuickLogPage.tsx
+++ b/src/pages/QuickLogPage.tsx
@@ -79,7 +79,8 @@ function QuickLogPage(): JSX.Element {
       setMessage({ type: '', text: '' });
     } catch (error) {
       console.error("Extraction error:", error);
-      setMessage({ type: 'error', text: t('receipt.extractionFailed') });
+      const text = error instanceof Error ? error.message : t('receipt.extractionFailed');
+      setMessage({ type: 'error', text });
     } finally {
       setIsExtracting(false);
     }

--- a/src/pages/QuickLogPage.tsx
+++ b/src/pages/QuickLogPage.tsx
@@ -137,8 +137,18 @@ function QuickLogPage(): JSX.Element {
       return;
     }
     const fetchLastOdometer = async () => {
-      const reading = await getLastOdometerReading(selectedVehicleId);
-      setLastOdometerReading(reading);
+      try {
+        const reading = await getLastOdometerReading(selectedVehicleId);
+        setLastOdometerReading(reading);
+      } catch (error) {
+        console.error('Error fetching last odometer reading:', error);
+        setMessage({
+          type: 'error',
+          text: !navigator.onLine
+            ? t('quickLog.messages.offline', { defaultValue: 'You are offline. Please check your connection and try again.' })
+            : t('quickLog.messages.fetchOdometerError', { defaultValue: 'Failed to load last odometer reading.' }),
+        });
+      }
     };
     fetchLastOdometer();
   }, [selectedVehicleId]);

--- a/src/utils/gemini.test.ts
+++ b/src/utils/gemini.test.ts
@@ -131,4 +131,36 @@ describe('gemini utility', () => {
 
     await expect(gemini.extractDataFromReceipt(mockFile)).rejects.toThrow('Failed to extract data from receipt.');
   });
+
+  it('rejects unsupported file types before processing', async () => {
+    const gemini = await import('./gemini');
+    const mockFile = new File(['mock content'], 'receipt.pdf', { type: 'application/pdf' });
+
+    await expect(gemini.extractDataFromReceipt(mockFile)).rejects.toThrow(
+      'Unsupported file type. Please use JPEG, PNG, or WebP.'
+    );
+    expect(global.createImageBitmap).not.toHaveBeenCalled();
+  });
+
+  it('rejects files larger than 10MB before processing', async () => {
+    const gemini = await import('./gemini');
+    const bigContent = new Uint8Array(10 * 1024 * 1024 + 1);
+    const mockFile = new File([bigContent], 'big.jpg', { type: 'image/jpeg' });
+
+    await expect(gemini.extractDataFromReceipt(mockFile)).rejects.toThrow(
+      'File too large (max 10 MB). Please compress the image.'
+    );
+    expect(global.createImageBitmap).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a friendly error when the image cannot be decoded', async () => {
+    global.createImageBitmap = vi.fn().mockRejectedValue(new Error('decode failed'));
+
+    const gemini = await import('./gemini');
+    const mockFile = new File(['mock content'], 'corrupt.jpg', { type: 'image/jpeg' });
+
+    await expect(gemini.extractDataFromReceipt(mockFile)).rejects.toThrow(
+      'Could not process image — please try a different photo.'
+    );
+  });
 });

--- a/src/utils/gemini.ts
+++ b/src/utils/gemini.ts
@@ -12,8 +12,26 @@ export interface ReceiptData {
 const MAX_DIMENSION = import.meta.env.DEV ? 768 : 1600;
 const JPEG_QUALITY = import.meta.env.DEV ? 0.7 : 0.9;
 
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
+const SUPPORTED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+
+export function validateReceiptFile(file: File): void {
+  if (!SUPPORTED_MIME_TYPES.includes(file.type)) {
+    throw new Error('Unsupported file type. Please use JPEG, PNG, or WebP.');
+  }
+  if (file.size > MAX_FILE_SIZE_BYTES) {
+    throw new Error('File too large (max 10 MB). Please compress the image.');
+  }
+}
+
 async function resizeAndEncode(file: File): Promise<{ base64Data: string; mimeType: string }> {
-  const bitmap = await createImageBitmap(file);
+  let bitmap: ImageBitmap;
+  try {
+    bitmap = await createImageBitmap(file);
+  } catch (error) {
+    console.error('Failed to decode image:', error);
+    throw new Error('Could not process image — please try a different photo.');
+  }
   const { width, height } = bitmap;
 
   const scale = Math.min(1, MAX_DIMENSION / Math.max(width, height));
@@ -49,6 +67,8 @@ export async function extractDataFromReceipt(file: File): Promise<ReceiptData> {
     throw new Error('User is not authenticated.');
   }
   const idToken = await user.getIdToken();
+
+  validateReceiptFile(file);
 
   analytics.then(a => { if (a) logEvent(a, 'receipt_scan_started'); });
 

--- a/src/utils/locationService.test.ts
+++ b/src/utils/locationService.test.ts
@@ -1,5 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { findNearestStation } from './locationService';
+import { findNearestStation, isAccurateEnoughForStationMatch, GPS_ACCURACY_THRESHOLD_METERS } from './locationService';
+
+describe('isAccurateEnoughForStationMatch', () => {
+    it('returns true when accuracy is within the threshold', () => {
+        expect(isAccurateEnoughForStationMatch(50)).toBe(true);
+        expect(isAccurateEnoughForStationMatch(GPS_ACCURACY_THRESHOLD_METERS)).toBe(true);
+    });
+
+    it('returns false when accuracy exceeds the threshold', () => {
+        expect(isAccurateEnoughForStationMatch(GPS_ACCURACY_THRESHOLD_METERS + 1)).toBe(false);
+        expect(isAccurateEnoughForStationMatch(500)).toBe(false);
+    });
+});
 
 describe('locationService', () => {
     beforeEach(() => {

--- a/src/utils/locationService.ts
+++ b/src/utils/locationService.ts
@@ -34,6 +34,19 @@ interface OverpassElement {
 const OVERPASS_URL = 'https://overpass-api.de/api/interpreter';
 
 /**
+ * GPS accuracy (in metres) beyond which we no longer trust a position
+ * fix to reliably resolve the correct nearby station.
+ */
+export const GPS_ACCURACY_THRESHOLD_METERS = 100;
+
+/**
+ * Whether a GPS fix is accurate enough to attempt automatic station matching.
+ */
+export function isAccurateEnoughForStationMatch(locationAccuracy: number): boolean {
+    return locationAccuracy <= GPS_ACCURACY_THRESHOLD_METERS;
+}
+
+/**
  * Find the nearest petrol station within a radius (default 150m) of the given coordinates.
  */
 export async function findNearestStation(lat: number, lon: number, radiusMeters: number = 150): Promise<OSMStation | null> {


### PR DESCRIPTION
## Recovery PR

PRs #112-#116 were each opened with their base set to the *previous* stacked branch instead of `main` (a mistake during this sprint's stacked-PR workflow). They merged successfully, but into those intermediate branches — which GitHub then auto-deleted after merge — so none of that work ever reached `main`. Only PR #111 (#98) actually landed.

This PR carries the full cumulative history from the working stack (which still existed locally) directly onto `main`, so the work isn't lost. It supersedes the now-orphaned merges from #112-#116.

Closes #106, #107, #97, #96, #104

## Contents
- #106: Receipt upload file-type/size validation + friendly error messages
- #107: Skip station auto-association on low GPS accuracy, with a persistent warning banner (includes a follow-up fix for a review comment about the warning being overwritten)
- #97: Unit tests for aggregationService and messagingService
- #96: Unit tests for AuthContext's auth-state lifecycle (note: issue #96 referenced a signInWithRedirect flow that was implemented and reverted within PR #103 before this sprint — tests cover the actual signInWithPopup flow instead, per discussion at the time)
- #104: Unit tests for QuickLogPage covering the happy path, validation, odometer auto-calc, multi-currency, receipt AI autofill, and the geolocation/station-matching flow

All review feedback from the original PRs (#113, #114, #115, #116) is already incorporated into this branch.

## Testing
- `npx vitest run` — 152/152 passing
- `npx tsc --noEmit` — clean