### PR TITLE
Resolve #100: Add a Dashboard page with monthly fuel spend summary

### DIFF
--- a/src/components/AuthenticatedApp.tsx
+++ b/src/components/AuthenticatedApp.tsx
@@ -32,6 +32,7 @@ const PrivacyPolicyPage = lazyWithRetry(() => import('../pages/PrivacyPolicyPage
 const AboutPage = lazyWithRetry(() => import('../pages/AboutPage'));
 const FuelMapPage = lazyWithRetry(() => import('./FuelMapPage'));
 const StationsPage = lazyWithRetry(() => import('../pages/StationsPage'));
+const DashboardPage = lazyWithRetry(() => import('../pages/DashboardPage'));
 
 /** Loading fallback for Suspense */
 const PageLoader = () => (
@@ -68,6 +69,7 @@ function AuthenticatedApp(): JSX.Element {
           {/* Desktop Navigation */}
           <div className="hidden sm:flex items-center space-x-2">
             <Link to="/" className={getNavLinkClass("/")}>Log</Link>
+            <Link to="/dashboard" className={getNavLinkClass("/dashboard")}>Dashboard</Link>
             <Link to="/history" className={getNavLinkClass("/history")}>History</Link>
             <Link to="/import" className={getNavLinkClass("/import")}>Import</Link>
             <Link to="/profile" className={getNavLinkClass("/profile")}>Profile</Link>
@@ -102,6 +104,7 @@ function AuthenticatedApp(): JSX.Element {
         <Suspense fallback={<PageLoader />}>
           <Routes>
             <Route path="/" element={<QuickLogPage />} />
+            <Route path="/dashboard" element={<DashboardPage />} />
             <Route path="/history" element={<HistoryPage />} />
             <Route path="/import" element={<ImportPage />} />
             <Route path="/profile" element={<ProfilePage />} />

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,6 +1,6 @@
 import { JSX } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { History, Map as MapIcon, User, PlusCircle, Fuel } from 'lucide-react';
+import { History, Map as MapIcon, User, PlusCircle, Fuel, LayoutDashboard } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 /**
@@ -13,13 +13,14 @@ const BottomNav = ({ stationsPageEnabled }: { stationsPageEnabled: boolean }): J
 
   const baseNavItems = [
     { path: '/', label: t('nav.log'), icon: PlusCircle },
+    { path: '/dashboard', label: t('nav.dashboard'), icon: LayoutDashboard },
     { path: '/history', label: t('nav.history'), icon: History },
     { path: '/map', label: t('nav.map'), icon: MapIcon },
     { path: '/profile', label: t('nav.profile'), icon: User },
   ];
 
   const navItems = stationsPageEnabled
-    ? [...baseNavItems.slice(0, 3), { path: '/stations', label: t('nav.stations'), icon: Fuel }, ...baseNavItems.slice(3)]
+    ? [...baseNavItems.slice(0, 4), { path: '/stations', label: t('nav.stations'), icon: Fuel }, ...baseNavItems.slice(4)]
     : baseNavItems;
 
 

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -4,7 +4,8 @@
     "history": "Verlauf",
     "map": "Karte",
     "profile": "Profil",
-    "stations": "[de] Stations"
+    "stations": "[de] Stations",
+    "dashboard": "Übersicht"
   },
   "login": {
     "tagline": "Präzise Kraftstoffverfolgung",
@@ -430,5 +431,28 @@
     "sv": "Svenska",
     "no": "Norsk",
     "fi": "Suomi"
+  },
+  "dashboard": {
+    "title": "Übersicht",
+    "loading": "Übersicht wird geladen...",
+    "offlineError": "Du bist offline. Bitte überprüfe deine Verbindung und versuche es erneut.",
+    "loadError": "Übersichtsdaten konnten nicht geladen werden. Bitte versuche es erneut.",
+    "fields": {
+      "vehicle": "Fahrzeug",
+      "allVehicles": "Alle Fahrzeuge"
+    },
+    "emptyState": {
+      "heading": "Noch keine Tankprotokolle",
+      "subtext": "Erfasse deine erste Tankfüllung, um hier deine Ausgabenübersicht zu sehen."
+    },
+    "cards": {
+      "monthSpend": "Diesen Monat",
+      "monthLitres": "Liter Diesen Monat",
+      "avgPrice": "Ø Preis/Liter"
+    },
+    "charts": {
+      "monthlySpend": "Monatliche Ausgaben (Letzte 6 Monate)",
+      "spend": "Ausgaben"
+    }
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -4,7 +4,8 @@
     "history": "History",
     "map": "Map",
     "profile": "Profile",
-    "stations": "Stations"
+    "stations": "Stations",
+    "dashboard": "Dashboard"
   },
   "login": {
     "tagline": "Precision Fuel Tracking",
@@ -430,5 +431,28 @@
     "sv": "Svenska",
     "no": "Norsk",
     "fi": "Suomi"
+  },
+  "dashboard": {
+    "title": "Dashboard",
+    "loading": "Loading dashboard...",
+    "offlineError": "You are offline. Please check your connection and try again.",
+    "loadError": "Failed to load dashboard data. Please try again.",
+    "fields": {
+      "vehicle": "Vehicle",
+      "allVehicles": "All Vehicles"
+    },
+    "emptyState": {
+      "heading": "No fuel logs yet",
+      "subtext": "Log your first fill-up to see your spending summary here."
+    },
+    "cards": {
+      "monthSpend": "This Month",
+      "monthLitres": "Litres This Month",
+      "avgPrice": "Avg Price/Litre"
+    },
+    "charts": {
+      "monthlySpend": "Monthly Spend (Last 6 Months)",
+      "spend": "Spend"
+    }
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -4,7 +4,8 @@
     "history": "Historial",
     "map": "Mapa",
     "profile": "Perfil",
-    "stations": "[es] Stations"
+    "stations": "[es] Stations",
+    "dashboard": "Panel"
   },
   "login": {
     "tagline": "Seguimiento de Combustible Preciso",
@@ -430,5 +431,28 @@
     "sv": "Svenska",
     "no": "Norsk",
     "fi": "Suomi"
+  },
+  "dashboard": {
+    "title": "Panel",
+    "loading": "Cargando el panel...",
+    "offlineError": "Estás sin conexión. Comprueba tu conexión e inténtalo de nuevo.",
+    "loadError": "No se pudieron cargar los datos del panel. Inténtalo de nuevo.",
+    "fields": {
+      "vehicle": "Vehículo",
+      "allVehicles": "Todos los Vehículos"
+    },
+    "emptyState": {
+      "heading": "Aún no hay registros de combustible",
+      "subtext": "Registra tu primer repostaje para ver aquí el resumen de tus gastos."
+    },
+    "cards": {
+      "monthSpend": "Este Mes",
+      "monthLitres": "Litros Este Mes",
+      "avgPrice": "Precio Medio/Litro"
+    },
+    "charts": {
+      "monthlySpend": "Gasto Mensual (Últimos 6 Meses)",
+      "spend": "Gasto"
+    }
   }
 }

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -4,7 +4,8 @@
     "history": "Historia",
     "map": "Kartta",
     "profile": "Profiili",
-    "stations": "[fi] Stations"
+    "stations": "[fi] Stations",
+    "dashboard": "Yleiskatsaus"
   },
   "login": {
     "tagline": "Tarkka polttoaineen seuranta",
@@ -430,5 +431,28 @@
     "sv": "Svenska",
     "no": "Norsk",
     "fi": "Suomi"
+  },
+  "dashboard": {
+    "title": "Yleiskatsaus",
+    "loading": "Ladataan yleiskatsausta...",
+    "offlineError": "Olet offline-tilassa. Tarkista yhteytesi ja yritä uudelleen.",
+    "loadError": "Tietojen lataaminen epäonnistui. Yritä uudelleen.",
+    "fields": {
+      "vehicle": "Ajoneuvo",
+      "allVehicles": "Kaikki Ajoneuvot"
+    },
+    "emptyState": {
+      "heading": "Ei vielä tankkauksia",
+      "subtext": "Kirjaa ensimmäinen tankkauksesi nähdäksesi kulujen yhteenvedon tässä."
+    },
+    "cards": {
+      "monthSpend": "Tämä Kuukausi",
+      "monthLitres": "Litrat Tässä Kuussa",
+      "avgPrice": "Keskihinta/Litra"
+    },
+    "charts": {
+      "monthlySpend": "Kuukausittaiset Kulut (Viimeiset 6 Kuukautta)",
+      "spend": "Kulut"
+    }
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -4,7 +4,8 @@
     "history": "Historique",
     "map": "Carte",
     "profile": "Profil",
-    "stations": "[fr] Stations"
+    "stations": "[fr] Stations",
+    "dashboard": "Tableau de bord"
   },
   "login": {
     "tagline": "Suivi de Carburant Précis",
@@ -430,5 +431,28 @@
     "sv": "Svenska",
     "no": "Norsk",
     "fi": "Suomi"
+  },
+  "dashboard": {
+    "title": "Tableau de bord",
+    "loading": "Chargement du tableau de bord...",
+    "offlineError": "Vous êtes hors ligne. Vérifiez votre connexion et réessayez.",
+    "loadError": "Échec du chargement des données. Veuillez réessayer.",
+    "fields": {
+      "vehicle": "Véhicule",
+      "allVehicles": "Tous les Véhicules"
+    },
+    "emptyState": {
+      "heading": "Aucun plein enregistré",
+      "subtext": "Enregistrez votre premier plein pour voir ici le résumé de vos dépenses."
+    },
+    "cards": {
+      "monthSpend": "Ce Mois-ci",
+      "monthLitres": "Litres Ce Mois-ci",
+      "avgPrice": "Prix Moyen/Litre"
+    },
+    "charts": {
+      "monthlySpend": "Dépenses Mensuelles (6 Derniers Mois)",
+      "spend": "Dépense"
+    }
   }
 }

--- a/src/i18n/locales/ga.json
+++ b/src/i18n/locales/ga.json
@@ -4,7 +4,8 @@
     "history": "Stair",
     "map": "Léarscáil",
     "profile": "Próifíl",
-    "stations": "[ga] Stations"
+    "stations": "[ga] Stations",
+    "dashboard": "Painéal"
   },
   "login": {
     "tagline": "Rianú Breosla Cruinn",
@@ -430,5 +431,28 @@
     "sv": "Svenska",
     "no": "Norsk",
     "fi": "Suomi"
+  },
+  "dashboard": {
+    "title": "Painéal",
+    "loading": "Painéal á luchtú...",
+    "offlineError": "Tá tú as líne. Seiceáil do nasc agus bain triail eile as.",
+    "loadError": "Theip ar lódáil sonraí an phainéil. Bain triail eile as.",
+    "fields": {
+      "vehicle": "Feithicil",
+      "allVehicles": "Gach Feithicil"
+    },
+    "emptyState": {
+      "heading": "Níl aon logaí breosla fós ann",
+      "subtext": "Logáil do líonadh tobair tosaigh chun achoimre do chaiteachais a fheiceáil anseo."
+    },
+    "cards": {
+      "monthSpend": "An Mhí Seo",
+      "monthLitres": "Lítir an Mhí Seo",
+      "avgPrice": "Meánphraghas/Lítear"
+    },
+    "charts": {
+      "monthlySpend": "Caiteachas Míosúil (Seacht Mí Anuas)",
+      "spend": "Caiteachas"
+    }
   }
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -4,7 +4,8 @@
     "history": "履歴",
     "map": "地図",
     "profile": "プロフィール",
-    "stations": "[ja] Stations"
+    "stations": "[ja] Stations",
+    "dashboard": "ダッシュボード"
   },
   "login": {
     "tagline": "精確な燃料追跡",
@@ -430,5 +431,28 @@
     "sv": "Svenska",
     "no": "Norsk",
     "fi": "Suomi"
+  },
+  "dashboard": {
+    "title": "ダッシュボード",
+    "loading": "ダッシュボードを読み込み中...",
+    "offlineError": "オフラインです。接続を確認して再試行してください。",
+    "loadError": "ダッシュボードデータの読み込みに失敗しました。再試行してください。",
+    "fields": {
+      "vehicle": "車両",
+      "allVehicles": "すべての車両"
+    },
+    "emptyState": {
+      "heading": "燃料記録はまだありません",
+      "subtext": "最初の給油を記録すると、ここに支出の概要が表示されます。"
+    },
+    "cards": {
+      "monthSpend": "今月",
+      "monthLitres": "今月のリットル数",
+      "avgPrice": "平均価格/リットル"
+    },
+    "charts": {
+      "monthlySpend": "月間支出（過去6か月）",
+      "spend": "支出"
+    }
   }
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -4,7 +4,8 @@
     "history": "내역",
     "map": "지도",
     "profile": "프로필",
-    "stations": "[ko] Stations"
+    "stations": "[ko] Stations",
+    "dashboard": "대시보드"
   },
   "login": {
     "tagline": "정밀한 연료 추적",
@@ -430,5 +431,28 @@
     "sv": "Svenska",
     "no": "Norsk",
     "fi": "Suomi"
+  },
+  "dashboard": {
+    "title": "대시보드",
+    "loading": "대시보드를 불러오는 중...",
+    "offlineError": "오프라인 상태입니다. 연결을 확인하고 다시 시도하세요.",
+    "loadError": "대시보드 데이터를 불러오지 못했습니다. 다시 시도하세요.",
+    "fields": {
+      "vehicle": "차량",
+      "allVehicles": "모든 차량"
+    },
+    "emptyState": {
+      "heading": "아직 주유 기록이 없습니다",
+      "subtext": "첫 주유를 기록하면 여기에 지출 요약이 표시됩니다."
+    },
+    "cards": {
+      "monthSpend": "이번 달",
+      "monthLitres": "이번 달 리터",
+      "avgPrice": "평균 가격/리터"
+    },
+    "charts": {
+      "monthlySpend": "월별 지출 (최근 6개월)",
+      "spend": "지출"
+    }
   }
 }

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -4,7 +4,8 @@
     "history": "Historikk",
     "map": "Kart",
     "profile": "Profil",
-    "stations": "[no] Stations"
+    "stations": "[no] Stations",
+    "dashboard": "Oversikt"
   },
   "login": {
     "tagline": "Presisjon i drivstoffsporing",
@@ -430,5 +431,28 @@
     "sv": "Svenska",
     "no": "Norsk",
     "fi": "Suomi"
+  },
+  "dashboard": {
+    "title": "Oversikt",
+    "loading": "Laster oversikt...",
+    "offlineError": "Du er offline. Kontroller tilkoblingen og prøv igjen.",
+    "loadError": "Kunne ikke laste oversiktsdata. Prøv igjen.",
+    "fields": {
+      "vehicle": "Kjøretøy",
+      "allVehicles": "Alle Kjøretøy"
+    },
+    "emptyState": {
+      "heading": "Ingen drivstofflogger ennå",
+      "subtext": "Logg din første fylling for å se en oppsummering av utgiftene dine her."
+    },
+    "cards": {
+      "monthSpend": "Denne Måneden",
+      "monthLitres": "Liter Denne Måneden",
+      "avgPrice": "Snittpris/Liter"
+    },
+    "charts": {
+      "monthlySpend": "Månedlige Utgifter (Siste 6 Måneder)",
+      "spend": "Utgift"
+    }
   }
 }

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -4,7 +4,8 @@
     "history": "Historik",
     "map": "Karta",
     "profile": "Profil",
-    "stations": "[sv] Stations"
+    "stations": "[sv] Stations",
+    "dashboard": "Översikt"
   },
   "login": {
     "tagline": "Precision i bränsleuppföljning",
@@ -430,5 +431,28 @@
     "sv": "Svenska",
     "no": "Norsk",
     "fi": "Suomi"
+  },
+  "dashboard": {
+    "title": "Översikt",
+    "loading": "Laddar översikt...",
+    "offlineError": "Du är offline. Kontrollera din anslutning och försök igen.",
+    "loadError": "Det gick inte att läsa in data. Försök igen.",
+    "fields": {
+      "vehicle": "Fordon",
+      "allVehicles": "Alla Fordon"
+    },
+    "emptyState": {
+      "heading": "Inga tankningar än",
+      "subtext": "Logga din första tankning för att se en sammanfattning av dina utgifter här."
+    },
+    "cards": {
+      "monthSpend": "Denna Månad",
+      "monthLitres": "Liter Denna Månad",
+      "avgPrice": "Snittpris/Liter"
+    },
+    "charts": {
+      "monthlySpend": "Månadsutgifter (Senaste 6 Månaderna)",
+      "spend": "Utgift"
+    }
   }
 }

--- a/src/pages/DashboardPage.test.tsx
+++ b/src/pages/DashboardPage.test.tsx
@@ -116,4 +116,14 @@ describe('DashboardPage', () => {
 
     await waitFor(() => expect(screen.getByText('Failed to load dashboard data. Please try again.')).toBeInTheDocument());
   });
+
+  it('shows an error banner when fetching vehicles fails', async () => {
+    vi.mocked(getDocs)
+      .mockRejectedValueOnce(new Error('Firestore error')) // vehicles
+      .mockResolvedValueOnce(mockSnapshot([]) as never); // logs
+
+    render(<DashboardPage />);
+
+    await waitFor(() => expect(screen.getByText('Failed to load dashboard data. Please try again.')).toBeInTheDocument());
+  });
 });

--- a/src/pages/DashboardPage.test.tsx
+++ b/src/pages/DashboardPage.test.tsx
@@ -1,0 +1,119 @@
+import type { ReactNode } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getDocs } from 'firebase/firestore';
+import { Timestamp } from 'firebase/firestore';
+import DashboardPage from './DashboardPage';
+
+const mockT = (key: string, opts?: Record<string, unknown>) => {
+  if (opts && 'defaultValue' in opts) return opts.defaultValue as string;
+  return key;
+};
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: mockT }),
+}));
+
+const mockUser = { uid: 'user-1' };
+const mockProfile = { homeCurrency: 'EUR' };
+
+vi.mock('../context/AuthContext', () => ({
+  useAuth: () => ({ user: mockUser, profile: mockProfile }),
+}));
+
+vi.mock('../context/ThemeContext', () => ({
+  useTheme: () => ({ theme: 'light' }),
+}));
+
+vi.mock('firebase/firestore', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('firebase/firestore')>();
+  return {
+    ...actual,
+    collection: vi.fn(() => ({})),
+    query: vi.fn(() => ({})),
+    where: vi.fn(() => ({})),
+    getDocs: vi.fn(),
+  };
+});
+
+vi.mock('../firebase/config', () => ({
+  db: {},
+}));
+
+vi.mock('recharts', () => ({
+  BarChart: ({ children }: { children?: ReactNode }) => <div data-testid="bar-chart">{children}</div>,
+  Bar: () => <div />,
+  XAxis: () => <div />,
+  YAxis: () => <div />,
+  CartesianGrid: () => <div />,
+  Tooltip: () => <div />,
+  ResponsiveContainer: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+function mockSnapshot(docs: { id: string; data: Record<string, unknown> }[]) {
+  return {
+    forEach: (cb: (doc: { id: string; data: () => Record<string, unknown> }) => void) => {
+      docs.forEach(d => cb({ id: d.id, data: () => d.data }));
+    },
+  };
+}
+
+describe('DashboardPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the empty state when the user has no logs', async () => {
+    vi.mocked(getDocs).mockResolvedValue(mockSnapshot([]) as never);
+
+    render(<DashboardPage />);
+
+    await waitFor(() => expect(screen.getByText('No fuel logs yet')).toBeInTheDocument());
+    expect(screen.queryByText(/Failed to load/)).not.toBeInTheDocument();
+  });
+
+  it('shows accurate current-month cost, litres, and avg price/litre cards', async () => {
+    const now = new Date();
+    vi.mocked(getDocs)
+      .mockResolvedValueOnce(mockSnapshot([]) as never) // vehicles
+      .mockResolvedValueOnce(mockSnapshot([
+        {
+          id: 'log1',
+          data: {
+            userId: 'user-1',
+            timestamp: Timestamp.fromDate(now),
+            cost: 50,
+            distanceKm: 400,
+            fuelAmountLiters: 25,
+          },
+        },
+        {
+          id: 'log2',
+          data: {
+            userId: 'user-1',
+            timestamp: Timestamp.fromDate(now),
+            cost: 30,
+            distanceKm: 200,
+            fuelAmountLiters: 15,
+          },
+        },
+      ]) as never); // logs
+
+    render(<DashboardPage />);
+
+    await waitFor(() => expect(screen.getByText('€80.00')).toBeInTheDocument());
+    expect(screen.getByText('40.0L')).toBeInTheDocument();
+    // avg price/litre = 80 / 40 = 2.000
+    expect(screen.getByText('€2.000')).toBeInTheDocument();
+  });
+
+  it('shows an error banner when fetching logs fails', async () => {
+    vi.mocked(getDocs)
+      .mockResolvedValueOnce(mockSnapshot([]) as never) // vehicles
+      .mockRejectedValueOnce(new Error('Firestore error')); // logs
+
+    render(<DashboardPage />);
+
+    await waitFor(() => expect(screen.getByText('Failed to load dashboard data. Please try again.')).toBeInTheDocument());
+  });
+});

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,0 +1,198 @@
+// src/pages/DashboardPage.tsx
+import { JSX, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { collection, query, where, getDocs } from 'firebase/firestore';
+import {
+    BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer
+} from 'recharts';
+import { Banknote, Droplets, Gauge } from 'lucide-react';
+import { db } from '../firebase/config';
+import { useAuth } from '../context/AuthContext';
+import { useTheme } from '../context/ThemeContext';
+import { Log, FuelLogData, Vehicle } from '../utils/types';
+import { getMonthlyTotals, getNumericFuelPrice } from '../utils/calculations';
+import { COMMON_CURRENCIES } from '../utils/currencyApi';
+
+const MONTHS_BACK = 6;
+
+function DashboardPage(): JSX.Element {
+    const { user, profile } = useAuth();
+    const { theme } = useTheme();
+    const { t } = useTranslation();
+
+    const homeCurrency = profile?.homeCurrency || 'EUR';
+    const homeCurrencySymbol = COMMON_CURRENCIES.find(c => c.code === homeCurrency)?.symbol || homeCurrency;
+
+    const [logs, setLogs] = useState<Log[]>([]);
+    const [vehicles, setVehicles] = useState<Vehicle[]>([]);
+    const [selectedVehicleId, setSelectedVehicleId] = useState<string>('');
+    const [isLoading, setIsLoading] = useState<boolean>(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!user) { setVehicles([]); return; }
+        const fetchVehicles = async () => {
+            try {
+                const q = query(collection(db, 'vehicles'), where('userId', '==', user.uid));
+                const snap = await getDocs(q);
+                const list: Vehicle[] = [];
+                snap.forEach(doc => list.push({ id: doc.id, ...doc.data() } as Vehicle));
+                setVehicles(list.filter(v => !v.isArchived));
+            } catch (err) {
+                console.error('Error fetching vehicles:', err);
+            }
+        };
+        fetchVehicles();
+    }, [user]);
+
+    useEffect(() => {
+        if (!user) { setIsLoading(false); setLogs([]); return; }
+        setIsLoading(true);
+        setError(null);
+
+        const fetchLogs = async () => {
+            try {
+                const constraints = [where('userId', '==', user.uid)];
+                if (selectedVehicleId) constraints.push(where('vehicleId', '==', selectedVehicleId));
+                const q = query(collection(db, 'fuelLogs'), ...constraints);
+                const snap = await getDocs(q);
+                const list: Log[] = [];
+                snap.forEach(doc => list.push({ id: doc.id, ...(doc.data() as FuelLogData) }));
+                setLogs(list);
+            } catch (err) {
+                console.error('Error fetching logs for dashboard:', err);
+                setError(
+                    !navigator.onLine
+                        ? t('dashboard.offlineError', { defaultValue: 'You are offline. Please check your connection and try again.' })
+                        : t('dashboard.loadError', { defaultValue: 'Failed to load dashboard data. Please try again.' })
+                );
+            } finally {
+                setIsLoading(false);
+            }
+        };
+        fetchLogs();
+    }, [user, selectedVehicleId, t]);
+
+    const monthlyTotals = useMemo(() => getMonthlyTotals(logs, MONTHS_BACK), [logs]);
+
+    const monthFormatter = useMemo(
+        () => new Intl.DateTimeFormat(undefined, { month: 'short' }),
+        []
+    );
+
+    const chartData = useMemo(
+        () => monthlyTotals.map(m => ({
+            month: monthFormatter.format(m.monthStart),
+            cost: Math.round(m.totalCost * 100) / 100,
+        })),
+        [monthlyTotals, monthFormatter]
+    );
+
+    const currentMonth = monthlyTotals[monthlyTotals.length - 1];
+    const currentMonthAvgPrice = currentMonth ? getNumericFuelPrice(currentMonth.totalCost, currentMonth.totalLitres) : null;
+
+    if (isLoading) {
+        return (
+            <div className="text-center py-8">
+                <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-indigo-600 mx-auto"></div>
+                <p className="mt-2 text-sm text-gray-500 animate-pulse">{t('dashboard.loading', { defaultValue: 'Loading dashboard...' })}</p>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="text-center py-10 px-4">
+                <p className="text-red-600 bg-red-100 p-4 rounded-md">{error}</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="container mx-auto max-w-3xl px-4 space-y-6">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                <h2 className="text-2xl font-bold text-gray-800 dark:text-white">{t('dashboard.title', { defaultValue: 'Dashboard' })}</h2>
+
+                {vehicles.length > 1 && (
+                    <div className="w-full sm:w-56">
+                        <label htmlFor="dashboard-vehicle" className="sr-only">{t('dashboard.fields.vehicle', { defaultValue: 'Vehicle' })}</label>
+                        <select
+                            id="dashboard-vehicle"
+                            value={selectedVehicleId}
+                            onChange={(e) => setSelectedVehicleId(e.target.value)}
+                            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:focus:ring-indigo-400 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                        >
+                            <option value="">{t('dashboard.fields.allVehicles', { defaultValue: 'All Vehicles' })}</option>
+                            {vehicles.map(v => (
+                                <option key={v.id} value={v.id}>{v.name} ({v.make})</option>
+                            ))}
+                        </select>
+                    </div>
+                )}
+            </div>
+
+            {logs.length === 0 ? (
+                <div className="bg-gray-50 dark:bg-gray-900/40 border border-gray-100 dark:border-gray-700 rounded-xl p-8 text-center space-y-2">
+                    <p className="text-gray-700 dark:text-gray-300 font-medium">{t('dashboard.emptyState.heading', { defaultValue: 'No fuel logs yet' })}</p>
+                    <p className="text-gray-500 dark:text-gray-400 text-sm">{t('dashboard.emptyState.subtext', { defaultValue: 'Log your first fill-up to see your spending summary here.' })}</p>
+                </div>
+            ) : (
+                <>
+                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-4 flex flex-col items-center gap-2">
+                            <div className="p-2 rounded-lg bg-brand-primary/10 text-brand-primary">
+                                <Banknote size={18} />
+                            </div>
+                            <p className="text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider text-center">{t('dashboard.cards.monthSpend', { defaultValue: 'This Month' })}</p>
+                            <p className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white font-mono tracking-tighter">
+                                {homeCurrencySymbol}{(currentMonth?.totalCost ?? 0).toFixed(2)}
+                            </p>
+                        </div>
+                        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-4 flex flex-col items-center gap-2">
+                            <div className="p-2 rounded-lg bg-brand-primary/10 text-brand-primary">
+                                <Droplets size={18} />
+                            </div>
+                            <p className="text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider text-center">{t('dashboard.cards.monthLitres', { defaultValue: 'Litres This Month' })}</p>
+                            <p className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white font-mono tracking-tighter">
+                                {(currentMonth?.totalLitres ?? 0).toFixed(1)}L
+                            </p>
+                        </div>
+                        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-4 flex flex-col items-center gap-2">
+                            <div className="p-2 rounded-lg bg-brand-primary/10 text-brand-primary">
+                                <Gauge size={18} />
+                            </div>
+                            <p className="text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider text-center">{t('dashboard.cards.avgPrice', { defaultValue: 'Avg Price/Litre' })}</p>
+                            <p className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white font-mono tracking-tighter">
+                                {currentMonthAvgPrice !== null ? `${homeCurrencySymbol}${currentMonthAvgPrice.toFixed(3)}` : 'N/A'}
+                            </p>
+                        </div>
+                    </div>
+
+                    <div className="bg-white dark:bg-gray-800 shadow-lg rounded-xl p-4 sm:p-6 border border-gray-200 dark:border-gray-700">
+                        <h3 className="text-lg font-medium text-gray-700 dark:text-gray-300 mb-4">{t('dashboard.charts.monthlySpend', { defaultValue: 'Monthly Spend (Last 6 Months)' })}</h3>
+                        <ResponsiveContainer width="100%" height={300}>
+                            <BarChart data={chartData} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
+                                <CartesianGrid strokeDasharray="3 3" stroke={theme === 'dark' ? '#4A5568' : '#e0e0e0'} />
+                                <XAxis dataKey="month" tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }} />
+                                <YAxis tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }} />
+                                <Tooltip
+                                    contentStyle={{
+                                        fontSize: '12px',
+                                        padding: '5px',
+                                        backgroundColor: theme === 'dark' ? '#2D3748' : 'white',
+                                        color: theme === 'dark' ? 'white' : 'black',
+                                        border: theme === 'dark' ? '1px solid #4A5568' : '1px solid #e0e0e0'
+                                    }}
+                                    formatter={(value: number) => `${homeCurrencySymbol}${value.toFixed(2)}`}
+                                />
+                                <Bar dataKey="cost" name={t('dashboard.charts.spend', { defaultValue: 'Spend' })} fill="#8884d8" radius={[4, 4, 0, 0]} />
+                            </BarChart>
+                        </ResponsiveContainer>
+                    </div>
+                </>
+            )}
+        </div>
+    );
+}
+
+export default DashboardPage;

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,7 +1,7 @@
 // src/pages/DashboardPage.tsx
 import { JSX, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { collection, query, where, getDocs } from 'firebase/firestore';
+import { collection, query, where, getDocs, Timestamp } from 'firebase/firestore';
 import {
     BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer
 } from 'recharts';
@@ -31,35 +31,53 @@ function DashboardPage(): JSX.Element {
 
     useEffect(() => {
         if (!user) { setVehicles([]); return; }
+        let cancelled = false;
+
         const fetchVehicles = async () => {
             try {
                 const q = query(collection(db, 'vehicles'), where('userId', '==', user.uid));
                 const snap = await getDocs(q);
+                if (cancelled) return;
                 const list: Vehicle[] = [];
                 snap.forEach(doc => list.push({ id: doc.id, ...doc.data() } as Vehicle));
                 setVehicles(list.filter(v => !v.isArchived));
             } catch (err) {
+                if (cancelled) return;
                 console.error('Error fetching vehicles:', err);
+                setError(
+                    !navigator.onLine
+                        ? t('dashboard.offlineError', { defaultValue: 'You are offline. Please check your connection and try again.' })
+                        : t('dashboard.loadError', { defaultValue: 'Failed to load dashboard data. Please try again.' })
+                );
             }
         };
         fetchVehicles();
-    }, [user]);
+
+        return () => { cancelled = true; };
+    }, [user, t]);
 
     useEffect(() => {
         if (!user) { setIsLoading(false); setLogs([]); return; }
         setIsLoading(true);
         setError(null);
+        let cancelled = false;
 
         const fetchLogs = async () => {
             try {
-                const constraints = [where('userId', '==', user.uid)];
+                const windowStart = new Date(new Date().getFullYear(), new Date().getMonth() - (MONTHS_BACK - 1), 1);
+                const constraints = [
+                    where('userId', '==', user.uid),
+                    where('timestamp', '>=', Timestamp.fromDate(windowStart)),
+                ];
                 if (selectedVehicleId) constraints.push(where('vehicleId', '==', selectedVehicleId));
                 const q = query(collection(db, 'fuelLogs'), ...constraints);
                 const snap = await getDocs(q);
+                if (cancelled) return;
                 const list: Log[] = [];
                 snap.forEach(doc => list.push({ id: doc.id, ...(doc.data() as FuelLogData) }));
                 setLogs(list);
             } catch (err) {
+                if (cancelled) return;
                 console.error('Error fetching logs for dashboard:', err);
                 setError(
                     !navigator.onLine
@@ -67,10 +85,12 @@ function DashboardPage(): JSX.Element {
                         : t('dashboard.loadError', { defaultValue: 'Failed to load dashboard data. Please try again.' })
                 );
             } finally {
-                setIsLoading(false);
+                if (!cancelled) setIsLoading(false);
             }
         };
         fetchLogs();
+
+        return () => { cancelled = true; };
     }, [user, selectedVehicleId, t]);
 
     const monthlyTotals = useMemo(() => getMonthlyTotals(logs, MONTHS_BACK), [logs]);

--- a/src/utils/calculations.test.ts
+++ b/src/utils/calculations.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatMPG, formatCostPerMile, formatKmL, formatL100km, getNumericMPG, getNumericFuelPrice, calculateDistance } from './calculations';
+import { formatMPG, formatCostPerMile, formatKmL, formatL100km, getNumericMPG, getNumericFuelPrice, calculateDistance, getMonthlyTotals } from './calculations';
 
 describe('Calculation Utilities', () => {
   describe('formatMPG', () => {
@@ -80,6 +80,62 @@ describe('Calculation Utilities', () => {
     it('returns null for negative values', () => {
       expect(calculateDistance(-1, 100)).toBeNull();
       expect(calculateDistance(100, -1)).toBeNull();
+    });
+  });
+
+  describe('getMonthlyTotals', () => {
+    const log = (year: number, month: number, day: number, cost: number, litres: number) => ({
+      timestamp: { toDate: () => new Date(year, month - 1, day) },
+      cost,
+      fuelAmountLiters: litres,
+    });
+
+    it('zero-fills months with no logs', () => {
+      const referenceDate = new Date(2024, 5, 15); // June 2024
+      const result = getMonthlyTotals([], 6, referenceDate);
+
+      expect(result).toHaveLength(6);
+      expect(result.map(r => r.monthKey)).toEqual([
+        '2024-01', '2024-02', '2024-03', '2024-04', '2024-05', '2024-06',
+      ]);
+      result.forEach(bucket => {
+        expect(bucket.totalCost).toBe(0);
+        expect(bucket.totalLitres).toBe(0);
+        expect(bucket.logCount).toBe(0);
+      });
+    });
+
+    it('aggregates cost, litres, and count per month', () => {
+      const referenceDate = new Date(2024, 5, 15); // June 2024
+      const logs = [
+        log(2024, 6, 1, 50, 30),
+        log(2024, 6, 15, 40, 25),
+        log(2024, 5, 1, 60, 35),
+      ];
+
+      const result = getMonthlyTotals(logs, 6, referenceDate);
+
+      const june = result.find(r => r.monthKey === '2024-06');
+      const may = result.find(r => r.monthKey === '2024-05');
+
+      expect(june).toMatchObject({ totalCost: 90, totalLitres: 55, logCount: 2 });
+      expect(may).toMatchObject({ totalCost: 60, totalLitres: 35, logCount: 1 });
+    });
+
+    it('excludes logs outside the requested window', () => {
+      const referenceDate = new Date(2024, 5, 15); // June 2024
+      const logs = [log(2023, 1, 1, 999, 999)]; // Over a year before the window
+
+      const result = getMonthlyTotals(logs, 6, referenceDate);
+
+      expect(result.every(bucket => bucket.logCount === 0)).toBe(true);
+    });
+
+    it('returns months ordered oldest to newest', () => {
+      const referenceDate = new Date(2024, 0, 15); // January 2024, exercises year rollover
+      const result = getMonthlyTotals([], 3, referenceDate);
+
+      expect(result.map(r => r.monthKey)).toEqual(['2023-11', '2023-12', '2024-01']);
     });
   });
 });

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -14,4 +14,57 @@ const calculateDistance = (currentOdometer: number, previousOdometer: number): n
     return diff > 0 ? diff : null;
 };
 
-export { formatMPG, formatCostPerMile, formatKmL, formatL100km, getNumericMPG, getNumericFuelPrice, calculateDistance };
+interface MonthlyTotal {
+    /** Year-month key in 'YYYY-MM' format, used for stable sorting/lookup. */
+    monthKey: string;
+    /** Start-of-month Date for this bucket, useful for formatting with Intl. */
+    monthStart: Date;
+    totalCost: number;
+    totalLitres: number;
+    logCount: number;
+}
+
+interface MonthlyAggregatable {
+    timestamp: { toDate: () => Date };
+    cost: number;
+    fuelAmountLiters: number;
+}
+
+const monthKeyOf = (date: Date): string => `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+
+/**
+ * Buckets logs into the trailing `monthsBack` calendar months (inclusive of the
+ * current month), zero-filling months with no logs so charts render a continuous
+ * timeline rather than skipping gaps.
+ */
+const getMonthlyTotals = <T extends MonthlyAggregatable>(
+    logs: T[],
+    monthsBack: number = 6,
+    referenceDate: Date = new Date()
+): MonthlyTotal[] => {
+    const buckets = new Map<string, MonthlyTotal>();
+
+    for (let i = monthsBack - 1; i >= 0; i--) {
+        const monthStart = new Date(referenceDate.getFullYear(), referenceDate.getMonth() - i, 1);
+        const key = monthKeyOf(monthStart);
+        buckets.set(key, { monthKey: key, monthStart, totalCost: 0, totalLitres: 0, logCount: 0 });
+    }
+
+    for (const log of logs) {
+        const logDate = log.timestamp.toDate();
+        const key = monthKeyOf(logDate);
+        const bucket = buckets.get(key);
+        if (!bucket) continue; // Outside the requested window
+        bucket.totalCost += log.cost;
+        bucket.totalLitres += log.fuelAmountLiters;
+        bucket.logCount += 1;
+    }
+
+    return Array.from(buckets.values());
+};
+
+export {
+    formatMPG, formatCostPerMile, formatKmL, formatL100km, getNumericMPG, getNumericFuelPrice, calculateDistance,
+    getMonthlyTotals,
+};
+export type { MonthlyTotal };


### PR DESCRIPTION
Closes #100

## Scope note
The issue description says Dashboard should be "the default landing page after login," but the AC checklist only requires it be reachable via BottomNav with a route added — it doesn't require replacing the current default. Per discussion, kept `QuickLogPage` as the `/` landing route (it's the primary daily-use action) and added Dashboard as a new `/dashboard` tab instead, to avoid a bigger UX change than the AC calls for.

## Changes
- New `DashboardPage`: current-month cost/litres/avg-price-per-litre cards, a 6-month bar chart of spend (Recharts, theme-aware), empty state for no logs, error state (including offline-specific message), and a vehicle selector shown only when the user has more than one vehicle.
- `calculations.ts`: new `getMonthlyTotals()` helper — buckets logs into the trailing N calendar months, zero-filling empty months so the chart has no gaps.
- Wired into `AuthenticatedApp` routing and both `BottomNav` (mobile) and the desktop nav.
- Added `nav.dashboard` + `dashboard.*` i18n keys to all 10 locale files (key-parity verified).

## Testing
- `npx vitest run` — 159/159 passing (includes new `getMonthlyTotals` tests and `DashboardPage` tests: empty state, accurate stat cards, error state)
- `npx tsc --noEmit` — clean
- `npm run build` — clean, `DashboardPage` is its own lazy chunk
- Manually drove the dev server with Playwright (mobile 375px + desktop, light/dark) — no console errors, but `/dashboard` redirects to Login since there's no local auth bypass/emulator configured. Full visual verification blocked on that; component logic is covered by the unit tests instead.