### PR TITLE
Resolve #102: Per-station fuel price trend chart in StationDetail

### DIFF
--- a/src/components/StationDetail.tsx
+++ b/src/components/StationDetail.tsx
@@ -7,7 +7,9 @@ import {
 } from 'recharts';
 
 import { Log, Station } from '../utils/types';
-import { fetchFuelLogsByStationId } from '../firebase/firestoreService';
+import { fetchFuelLogsByStationId, fetchStationById } from '../firebase/firestoreService';
+
+const RECENT_LOGS_LIMIT = 12;
 
 interface StationDetailProps {
     stationId: string;
@@ -20,41 +22,30 @@ const StationDetail: React.FC<StationDetailProps> = ({ stationId }) => {
     const [loading, setLoading] = useState<boolean>(true);
     const [error, setError] = useState<string | null>(null);
 
-    // This component currently doesn't directly fetch station details,
-    // it assumes the parent (StationsPage) already has the list of stations.
-    // For a more robust solution, we might want to pass the full station object
-    // or fetch it here if we navigate directly to a station detail page.
-    // For now, it will look for the station in the overall stations list (passed down via context or prop)
-
     useEffect(() => {
         const loadStationData = async () => {
             setLoading(true);
             setError(null);
             try {
-                // In a real app, you might fetch the single station here if navigating directly
-                // For now, assume StationsPage passes the station object or it's in a global state
-                // We don't have access to the full `stations` array here, so we will only fetch logs.
-                // The `StationsPage` parent component is responsible for knowing the `station` object.
-                // A better pattern would be to pass `Station` object itself as a prop.
-                
-                // For now, let's assume we can fetch the station from parent's state or a dedicated API call if needed.
-                // For simplicity, we'll rely on the parent (StationsPage) to provide the full station object
-                // if we want to display more than what's available from the logs.
-                // Given the current structure, let's just fetch the logs and display the ID for now.
-                // The Station object itself could be passed as a prop from StationsPage.
-
-                const logs = await fetchFuelLogsByStationId(stationId);
+                // Fetch only the most recent fills — used for the price-trend chart and
+                // recent-logs list. Lifetime stats (avg/last price, total log count) come
+                // from the station document's server-maintained aggregates (updated on every
+                // fill via updateStationMetrics), not from this limited log window.
+                const [logs, stationDoc] = await Promise.all([
+                    fetchFuelLogsByStationId(stationId, RECENT_LOGS_LIMIT),
+                    fetchStationById(stationId),
+                ]);
                 setFuelLogs(logs);
 
-                // Simulate fetching station details, as it's not directly fetched by ID here
-                // In a real application, you would fetch it from Firestore if it's not passed as a prop.
-                // This mock assumes the station data is available in the parent and can be passed down.
-                // For now, we will construct a partial station object for display from the logs.
-                if (logs.length > 0) {
+                if (stationDoc) {
+                    setStation(stationDoc);
+                } else if (logs.length > 0) {
+                    // Fallback for stations without a stored doc (shouldn't normally happen):
+                    // derive lifetime-ish stats from the fetched log window.
                     const firstLog = logs[0];
                     setStation({
                         id: stationId,
-                        osmId: '', // Not available from log
+                        osmId: '',
                         name: firstLog.brand || 'Unknown Station',
                         brand: firstLog.brand,
                         latitude: firstLog.latitude || 0,
@@ -73,7 +64,7 @@ const StationDetail: React.FC<StationDetailProps> = ({ stationId }) => {
                             : undefined,
                     });
                 } else {
-                    setStation(null); // No logs, no station to display
+                    setStation(null); // No station doc and no logs — nothing to display
                 }
 
             } catch (err) {
@@ -85,7 +76,11 @@ const StationDetail: React.FC<StationDetailProps> = ({ stationId }) => {
         };
 
         loadStationData();
-    }, [stationId, t]);
+        // t is intentionally excluded below: re-running this fetch on every locale change isn't
+        // needed, and including it risks a refetch loop since useTranslation() returns a new t
+        // reference on every render.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [stationId]);
 
     const chartData = useMemo(() => {
         return fuelLogs
@@ -153,14 +148,29 @@ const StationDetail: React.FC<StationDetailProps> = ({ stationId }) => {
                 </div>
             </div>
 
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3">{t('stationDetail.priceHistory')}</h3>
+            <h3 id="price-history-heading" className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3">{t('stationDetail.priceHistory')}</h3>
             {chartData.length > 1 ? (
-                <div className="h-64 w-full mb-6">
+                <div
+                    className="h-64 w-full mb-6"
+                    role="img"
+                    aria-labelledby="price-history-heading"
+                    aria-describedby="price-history-table"
+                >
                     <ResponsiveContainer width="100%" height="100%">
                         <LineChart data={chartData} margin={{ top: 5, right: 20, left: 10, bottom: 5 }}>
                             <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" className="dark:stroke-gray-700" />
-                            <XAxis dataKey="date" stroke="#888888" className="dark:stroke-gray-400" />
-                            <YAxis stroke="#888888" className="dark:stroke-gray-400" domain={['auto', 'auto']} />
+                            <XAxis
+                                dataKey="date"
+                                stroke="#888888"
+                                className="dark:stroke-gray-400"
+                                label={{ value: t('stationDetail.chartAxisDate'), position: 'insideBottom', offset: -5, style: { fontSize: 12, fill: '#888888' } }}
+                            />
+                            <YAxis
+                                stroke="#888888"
+                                className="dark:stroke-gray-400"
+                                domain={['auto', 'auto']}
+                                label={{ value: t('stationDetail.chartAxisPrice'), angle: -90, position: 'insideLeft', style: { fontSize: 12, fill: '#888888', textAnchor: 'middle' } }}
+                            />
                             <Tooltip
                                 contentStyle={{ backgroundColor: 'var(--color-bg-light)', border: 'none', borderRadius: '4px' }}
                                 itemStyle={{ color: 'var(--color-text-light)' }}
@@ -168,6 +178,24 @@ const StationDetail: React.FC<StationDetailProps> = ({ stationId }) => {
                             <Line type="monotone" dataKey="pricePerLiter" stroke="#8b5cf6" strokeWidth={2} dot={false} />
                         </LineChart>
                     </ResponsiveContainer>
+                    {/* Screen-reader-only data table fallback for the chart above */}
+                    <table id="price-history-table" className="sr-only">
+                        <caption>{t('stationDetail.priceHistory')}</caption>
+                        <thead>
+                            <tr>
+                                <th scope="col">{t('stationDetail.chartAxisDate')}</th>
+                                <th scope="col">{t('stationDetail.chartAxisPrice')}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {chartData.map((point, idx) => (
+                                <tr key={idx}>
+                                    <td>{point.date}</td>
+                                    <td>{point.pricePerLiter}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
                 </div>
             ) : (
                 <div className="text-center text-gray-500 dark:text-gray-400 h-64 flex items-center justify-center border border-dashed border-gray-300 dark:border-gray-700 rounded-md mb-6">

--- a/src/components/StationDetail.tsx
+++ b/src/components/StationDetail.tsx
@@ -31,10 +31,19 @@ const StationDetail: React.FC<StationDetailProps> = ({ stationId }) => {
                 // recent-logs list. Lifetime stats (avg/last price, total log count) come
                 // from the station document's server-maintained aggregates (updated on every
                 // fill via updateStationMetrics), not from this limited log window.
-                const [logs, stationDoc] = await Promise.all([
+                // allSettled so a transient failure fetching the station doc doesn't discard
+                // already-fetched logs (and vice versa) — each result is handled independently.
+                const [logsResult, stationResult] = await Promise.allSettled([
                     fetchFuelLogsByStationId(stationId, RECENT_LOGS_LIMIT),
                     fetchStationById(stationId),
                 ]);
+
+                if (logsResult.status === 'rejected') throw logsResult.reason;
+                const logs = logsResult.value;
+                const stationDoc = stationResult.status === 'fulfilled' ? stationResult.value : null;
+                if (stationResult.status === 'rejected') {
+                    console.error('Failed to load station document:', stationResult.reason);
+                }
                 setFuelLogs(logs);
 
                 if (stationDoc) {
@@ -148,13 +157,13 @@ const StationDetail: React.FC<StationDetailProps> = ({ stationId }) => {
                 </div>
             </div>
 
-            <h3 id="price-history-heading" className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3">{t('stationDetail.priceHistory')}</h3>
+            <h3 id={`price-history-heading-${stationId}`} className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3">{t('stationDetail.priceHistory')}</h3>
             {chartData.length > 1 ? (
                 <div
                     className="h-64 w-full mb-6"
                     role="img"
-                    aria-labelledby="price-history-heading"
-                    aria-describedby="price-history-table"
+                    aria-labelledby={`price-history-heading-${stationId}`}
+                    aria-describedby={`price-history-table-${stationId}`}
                 >
                     <ResponsiveContainer width="100%" height="100%">
                         <LineChart data={chartData} margin={{ top: 5, right: 20, left: 10, bottom: 5 }}>
@@ -179,7 +188,7 @@ const StationDetail: React.FC<StationDetailProps> = ({ stationId }) => {
                         </LineChart>
                     </ResponsiveContainer>
                     {/* Screen-reader-only data table fallback for the chart above */}
-                    <table id="price-history-table" className="sr-only">
+                    <table id={`price-history-table-${stationId}`} className="sr-only">
                         <caption>{t('stationDetail.priceHistory')}</caption>
                         <thead>
                             <tr>

--- a/src/components/StationDetail.tsx
+++ b/src/components/StationDetail.tsx
@@ -191,7 +191,7 @@ const StationDetail: React.FC<StationDetailProps> = ({ stationId }) => {
                             {chartData.map((point, idx) => (
                                 <tr key={idx}>
                                     <td>{point.date}</td>
-                                    <td>{point.pricePerLiter}</td>
+                                    <td>{point.pricePerLiter.toFixed(3)}</td>
                                 </tr>
                             ))}
                         </tbody>

--- a/src/components/__tests__/StationDetail.test.tsx
+++ b/src/components/__tests__/StationDetail.test.tsx
@@ -1,14 +1,15 @@
 // src/components/__tests__/StationDetail.test.tsx
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import StationDetail from '../StationDetail';
 import { Log } from '../../utils/types';
 import { Timestamp } from 'firebase/firestore';
-import { fetchFuelLogsByStationId } from '../../firebase/firestoreService'; // Import the actual function for type inference with vi.mocked
+import { fetchFuelLogsByStationId, fetchStationById } from '../../firebase/firestoreService'; // Import the actual function for type inference with vi.mocked
 
 // Mock firebase/firestoreService
 vi.mock('../../firebase/firestoreService', () => ({
   fetchFuelLogsByStationId: vi.fn(), // Initially mock as a simple fn
+  fetchStationById: vi.fn(),
 }));
 
 // Mock react-i18next
@@ -24,6 +25,8 @@ vi.mock('react-i18next', () => ({
         'stationDetail.lastPrice': 'Last Price',
         'stationDetail.logCount': 'Total Logs',
         'stationDetail.priceHistory': 'Price History (per Litre)',
+        'stationDetail.chartAxisDate': 'Fill Date',
+        'stationDetail.chartAxisPrice': 'Price per Litre',
         'stationDetail.notEnoughDataForChart': 'Not enough data to display chart.',
         'stationDetail.recentLogs': 'Recent Logs',
         'stationDetail.noLogsFound': 'No fuel logs found for this station.',
@@ -74,6 +77,8 @@ describe('StationDetail', () => {
     vi.clearAllMocks();
     vi.mocked(fetchFuelLogsByStationId).mockReset(); // Reset the mock before each test
     vi.mocked(fetchFuelLogsByStationId).mockResolvedValue([]); // Default mock implementation
+    vi.mocked(fetchStationById).mockReset();
+    vi.mocked(fetchStationById).mockResolvedValue(null); // No stored station doc by default — falls back to log-derived stats
   });
 
   it('renders loading state initially', async () => {
@@ -114,7 +119,7 @@ describe('StationDetail', () => {
       expect(screen.getByText('€1.250/L')).toBeInTheDocument(); // 50/40 = 1.25
       expect(screen.getByText('Total Logs')).toBeInTheDocument();
       expect(screen.getByText('2')).toBeInTheDocument();
-      expect(screen.getByText('Price History (per Litre)')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: 'Price History (per Litre)' })).toBeInTheDocument();
       expect(screen.getByText('Recent Logs')).toBeInTheDocument();
       expect(screen.getByText('€50.00 (40.00L @ 1.250/L)')).toBeInTheDocument();
       expect(screen.getByText('€60.00 (45.00L @ 1.333/L)')).toBeInTheDocument();
@@ -163,6 +168,52 @@ describe('StationDetail', () => {
       expect(screen.getAllByText('No station data available.')).toHaveLength(2); // Avg price and Last price
       expect(screen.getByText('Not enough data to display chart.')).toBeInTheDocument();
       expect(screen.getByText('€50.00 (0.00L @ N/A/L)')).toBeInTheDocument();
+    });
+  });
+
+  it('renders an accessible screen-reader data table alongside the chart', async () => {
+    vi.mocked(fetchFuelLogsByStationId).mockResolvedValue(mockLogs);
+    render(<StationDetail stationId={mockStationId} />);
+
+    await waitFor(() => {
+      const table = screen.getByRole('table');
+      expect(table).toBeInTheDocument();
+      expect(within(table).getByText('Fill Date')).toBeInTheDocument();
+      expect(within(table).getByText('Price per Litre')).toBeInTheDocument();
+      expect(within(table).getAllByRole('row')).toHaveLength(3); // header + 2 data rows
+    });
+  });
+
+  it('prefers the stored station document over log-derived stats when available', async () => {
+    vi.mocked(fetchFuelLogsByStationId).mockResolvedValue(mockLogs);
+    vi.mocked(fetchStationById).mockResolvedValue({
+      id: mockStationId,
+      osmId: 'node/123',
+      name: 'Shell Lifetime Name',
+      brand: 'Shell',
+      latitude: 1,
+      longitude: 2,
+      logCount: 47, // Lifetime count, larger than the 2 fetched recent logs
+      avgPrice: 1.4,
+      lastPrice: 1.45,
+    });
+
+    render(<StationDetail stationId={mockStationId} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Shell Lifetime Name' })).toBeInTheDocument();
+      expect(screen.getByText('47')).toBeInTheDocument();
+      expect(screen.getByText('€1.400/L')).toBeInTheDocument();
+      expect(screen.getByText('€1.450/L')).toBeInTheDocument();
+    });
+  });
+
+  it('requests only the most recent logs, not the full history', async () => {
+    vi.mocked(fetchFuelLogsByStationId).mockResolvedValue(mockLogs);
+    render(<StationDetail stationId={mockStationId} />);
+
+    await waitFor(() => {
+      expect(fetchFuelLogsByStationId).toHaveBeenCalledWith(mockStationId, 12);
     });
   });
 });

--- a/src/components/__tests__/StationDetail.test.tsx
+++ b/src/components/__tests__/StationDetail.test.tsx
@@ -171,6 +171,20 @@ describe('StationDetail', () => {
     });
   });
 
+  it('still renders log-derived data when fetching the station document fails', async () => {
+    vi.mocked(fetchFuelLogsByStationId).mockResolvedValue(mockLogs);
+    vi.mocked(fetchStationById).mockRejectedValue(new Error('station doc fetch failed'));
+
+    render(<StationDetail stationId={mockStationId} />);
+
+    await waitFor(() => {
+      // Falls back to log-derived stats rather than discarding the successfully-fetched logs
+      expect(screen.getByRole('heading', { name: 'Shell' })).toBeInTheDocument();
+      expect(screen.getByText('€50.00 (40.00L @ 1.250/L)')).toBeInTheDocument();
+      expect(screen.queryByText('Failed to load station details.')).not.toBeInTheDocument();
+    });
+  });
+
   it('renders an accessible screen-reader data table alongside the chart', async () => {
     vi.mocked(fetchFuelLogsByStationId).mockResolvedValue(mockLogs);
     render(<StationDetail stationId={mockStationId} />);

--- a/src/firebase/__tests__/firestoreService.test.ts
+++ b/src/firebase/__tests__/firestoreService.test.ts
@@ -1,9 +1,9 @@
 // src/firebase/__tests__/firestoreService.test.ts
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { CollectionReference, Query, QueryConstraint, QuerySnapshot, QueryFieldFilterConstraint, QueryOrderByConstraint } from 'firebase/firestore';
-import { collection, query, where, getDocs, orderBy, Timestamp } from 'firebase/firestore';
+import type { CollectionReference, Query, QueryConstraint, QuerySnapshot, QueryFieldFilterConstraint, QueryOrderByConstraint, QueryLimitConstraint } from 'firebase/firestore';
+import { collection, query, where, getDocs, orderBy, limit, doc, getDoc, Timestamp } from 'firebase/firestore';
 import { auth, db } from '../config'; // Mocked config for auth and db
-import { fetchFuelLogsByStationId } from '../firestoreService';
+import { fetchFuelLogsByStationId, fetchStationById } from '../firestoreService';
 import { Log } from '../../utils/types';
 
 // Mock Firebase
@@ -16,6 +16,9 @@ vi.mock('firebase/firestore', async (importOriginal) => {
         where: vi.fn(),
         getDocs: vi.fn(),
         orderBy: vi.fn(),
+        limit: vi.fn(),
+        doc: vi.fn(),
+        getDoc: vi.fn(),
         Timestamp: {
             fromDate: vi.fn((date: Date) => ({
                 toDate: () => date,
@@ -53,6 +56,7 @@ describe('firestoreService', () => {
         vi.mocked(query).mockReturnValue({} as Query);
         vi.mocked(where).mockReturnValue({} as unknown as QueryFieldFilterConstraint);
         vi.mocked(orderBy).mockReturnValue({} as unknown as QueryOrderByConstraint);
+        vi.mocked(limit).mockReturnValue({} as unknown as QueryLimitConstraint);
     });
 
     describe('fetchFuelLogsByStationId', () => {
@@ -92,11 +96,13 @@ describe('firestoreService', () => {
                 {} as CollectionReference,
                 {} as QueryConstraint, // where userId
                 {} as QueryConstraint, // where stationId
-                {} as QueryConstraint  // orderBy timestamp
+                {} as QueryConstraint, // orderBy timestamp
+                {} as QueryConstraint  // limit
             );
             expect(where).toHaveBeenCalledWith('userId', '==', mockUserId);
             expect(where).toHaveBeenCalledWith('stationId', '==', mockStationId);
             expect(orderBy).toHaveBeenCalledWith('timestamp', 'desc');
+            expect(limit).toHaveBeenCalledWith(12);
             expect(getDocs).toHaveBeenCalled();
             expect(result).toEqual(mockLogs);
         });
@@ -135,6 +141,31 @@ describe('firestoreService', () => {
             vi.spyOn(navigator, 'onLine', 'get').mockReturnValueOnce(false);
 
             await expect(fetchFuelLogsByStationId(mockStationId)).rejects.toThrow('You are offline');
+        });
+    });
+
+    describe('fetchStationById', () => {
+        it('returns the station when the document exists', async () => {
+            vi.mocked(doc).mockReturnValue({} as never);
+            vi.mocked(getDoc).mockResolvedValue({
+                exists: () => true,
+                id: mockStationId,
+                data: () => ({ osmId: 'node/1', name: 'Shell', brand: 'Shell', latitude: 1, longitude: 2, logCount: 5, avgPrice: 1.5 }),
+            } as never);
+
+            const result = await fetchStationById(mockStationId);
+
+            expect(doc).toHaveBeenCalledWith(db, 'stations', mockStationId);
+            expect(result).toEqual({ id: mockStationId, osmId: 'node/1', name: 'Shell', brand: 'Shell', latitude: 1, longitude: 2, logCount: 5, avgPrice: 1.5 });
+        });
+
+        it('returns null when the document does not exist', async () => {
+            vi.mocked(doc).mockReturnValue({} as never);
+            vi.mocked(getDoc).mockResolvedValue({ exists: () => false } as never);
+
+            const result = await fetchStationById(mockStationId);
+
+            expect(result).toBeNull();
         });
     });
 });

--- a/src/firebase/firestoreService.ts
+++ b/src/firebase/firestoreService.ts
@@ -73,6 +73,17 @@ export const getLastOdometerReading = async (vehicleId: string): Promise<number 
 };
 
 /**
+ * Fetches a single station document by its Firestore doc ID.
+ * Returns null if no such station exists.
+ */
+export const fetchStationById = async (stationId: string): Promise<Station | null> => {
+    const stationRef = doc(db, 'stations', stationId);
+    const stationSnap = await getDoc(stationRef);
+    if (!stationSnap.exists()) return null;
+    return { id: stationSnap.id, ...(stationSnap.data() as Omit<Station, 'id'>) };
+};
+
+/**
  * Gets a station by OSM ID or creates it if it doesn't exist.
  * Sanitizes the ID for Firestore doc path.
  */
@@ -157,7 +168,7 @@ export const fetchUserStations = async (logs: Log[]): Promise<Station[]> => {
  * @param stationId The ID of the station to fetch logs for.
  * @returns A promise that resolves to an array of Log objects.
  */
-export const fetchFuelLogsByStationId = async (stationId: string): Promise<Log[]> => {
+export const fetchFuelLogsByStationId = async (stationId: string, maxResults: number = 12): Promise<Log[]> => {
     if (!auth.currentUser) {
         throw new Error('No user logged in');
     }
@@ -167,7 +178,8 @@ export const fetchFuelLogsByStationId = async (stationId: string): Promise<Log[]
         logsCollection,
         where('userId', '==', auth.currentUser.uid),
         where('stationId', '==', stationId),
-        orderBy('timestamp', 'desc')
+        orderBy('timestamp', 'desc'),
+        limit(maxResults)
     );
 
     try {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -36,6 +36,8 @@
     "lastPrice": "[de] Last Price",
     "logCount": "[de] Total Logs",
     "priceHistory": "[de] Price History (per Litre)",
+    "chartAxisDate": "Tankdatum",
+    "chartAxisPrice": "Preis pro Liter",
     "notEnoughDataForChart": "[de] Not enough data to display chart (at least 2 logs needed).",
     "recentLogs": "[de] Recent Logs",
     "noLogsFound": "[de] No fuel logs found for this station.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -36,6 +36,8 @@
     "lastPrice": "Last Price",
     "logCount": "Total Logs",
     "priceHistory": "Price History (per Litre)",
+    "chartAxisDate": "Fill Date",
+    "chartAxisPrice": "Price per Litre",
     "notEnoughDataForChart": "Not enough data to display chart (at least 2 logs needed).",
     "recentLogs": "Recent Logs",
     "noLogsFound": "No fuel logs found for this station.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -36,6 +36,8 @@
     "lastPrice": "[es] Last Price",
     "logCount": "[es] Total Logs",
     "priceHistory": "[es] Price History (per Litre)",
+    "chartAxisDate": "Fecha de Repostaje",
+    "chartAxisPrice": "Precio por Litro",
     "notEnoughDataForChart": "[es] Not enough data to display chart (at least 2 logs needed).",
     "recentLogs": "[es] Recent Logs",
     "noLogsFound": "[es] No fuel logs found for this station.",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -36,6 +36,8 @@
     "lastPrice": "[fi] Last Price",
     "logCount": "[fi] Total Logs",
     "priceHistory": "[fi] Price History (per Litre)",
+    "chartAxisDate": "Tankkauspäivä",
+    "chartAxisPrice": "Hinta per Litra",
     "notEnoughDataForChart": "[fi] Not enough data to display chart (at least 2 logs needed).",
     "recentLogs": "[fi] Recent Logs",
     "noLogsFound": "[fi] No fuel logs found for this station.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -36,6 +36,8 @@
     "lastPrice": "[fr] Last Price",
     "logCount": "[fr] Total Logs",
     "priceHistory": "[fr] Price History (per Litre)",
+    "chartAxisDate": "Date de Plein",
+    "chartAxisPrice": "Prix par Litre",
     "notEnoughDataForChart": "[fr] Not enough data to display chart (at least 2 logs needed).",
     "recentLogs": "[fr] Recent Logs",
     "noLogsFound": "[fr] No fuel logs found for this station.",

--- a/src/i18n/locales/ga.json
+++ b/src/i18n/locales/ga.json
@@ -36,6 +36,8 @@
     "lastPrice": "[ga] Last Price",
     "logCount": "[ga] Total Logs",
     "priceHistory": "[ga] Price History (per Litre)",
+    "chartAxisDate": "Dáta Líonta",
+    "chartAxisPrice": "Praghas in aghaidh an Lítir",
     "notEnoughDataForChart": "[ga] Not enough data to display chart (at least 2 logs needed).",
     "recentLogs": "[ga] Recent Logs",
     "noLogsFound": "[ga] No fuel logs found for this station.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -36,6 +36,8 @@
     "lastPrice": "[ja] Last Price",
     "logCount": "[ja] Total Logs",
     "priceHistory": "[ja] Price History (per Litre)",
+    "chartAxisDate": "給油日",
+    "chartAxisPrice": "リットルあたりの価格",
     "notEnoughDataForChart": "[ja] Not enough data to display chart (at least 2 logs needed).",
     "recentLogs": "[ja] Recent Logs",
     "noLogsFound": "[ja] No fuel logs found for this station.",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -36,6 +36,8 @@
     "lastPrice": "[ko] Last Price",
     "logCount": "[ko] Total Logs",
     "priceHistory": "[ko] Price History (per Litre)",
+    "chartAxisDate": "주유 날짜",
+    "chartAxisPrice": "리터당 가격",
     "notEnoughDataForChart": "[ko] Not enough data to display chart (at least 2 logs needed).",
     "recentLogs": "[ko] Recent Logs",
     "noLogsFound": "[ko] No fuel logs found for this station.",

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -36,6 +36,8 @@
     "lastPrice": "[no] Siste pris",
     "logCount": "[no] Totalt antall logger",
     "priceHistory": "[no] Prishistorikk (per liter)",
+    "chartAxisDate": "Fylledato",
+    "chartAxisPrice": "Pris per Liter",
     "notEnoughDataForChart": "[no] Ikke nok data for å vise diagram (minst 2 logger nødvendig).",
     "recentLogs": "[no] Siste logger",
     "noLogsFound": "[no] Ingen drivstofflogger funnet for denne stasjonen.",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -36,6 +36,8 @@
     "lastPrice": "[sv] Senaste pris",
     "logCount": "[sv] Totalt antal loggar",
     "priceHistory": "[sv] Prishistorik (per liter)",
+    "chartAxisDate": "Tankningsdatum",
+    "chartAxisPrice": "Pris per Liter",
     "notEnoughDataForChart": "[sv] Inte tillräckligt med data för att visa diagram (minst 2 loggar behövs).",
     "recentLogs": "[sv] Senaste loggar",
     "noLogsFound": "[sv] Inga bränsleloggar hittades för denna station.",


### PR DESCRIPTION
Closes #102

## Scope note
The price-over-time line chart already existed in `StationDetail` (including the "not enough data" fallback for 0/1 points) — it predates this issue. What was missing per the AC: pagination to the latest 12 fills, the no-extra-index requirement, and accessibility. This PR closes those gaps.

## Changes
- `fetchFuelLogsByStationId(stationId, maxResults = 12)`: added a limit, satisfying "paginated, latest 12" without a new Firestore index (`limit()` doesn't need one — confirmed against the existing `(userId, stationId, timestamp desc)` index).
- New `fetchStationById()`: `StationDetail`'s lifetime stats (avg/last price, total log count) now come from the station doc's server-maintained aggregates (`updateStationMetrics`) instead of being recomputed from just the 12 fetched logs — avoids under-counting/skewing those numbers for stations with more than 12 fills. Falls back to the old log-derived calculation if no station doc exists (covers existing edge-case tests).
- Accessibility: chart now has a `role="img"` with `aria-labelledby`/`aria-describedby`, labeled axes, and a visually-hidden (`sr-only`) `<table>` data fallback for screen readers.
- Fixed a latent refetch-loop risk: the data-fetch effect depended on `t` (a new reference every render from `useTranslation()`), which the added `fetchStationById` call tipped into an actual "Maximum update depth exceeded" loop surfaced by the new tests. Removed `t` from the dependency array (documented with an inline comment).
- i18n: `stationDetail.chartAxisDate`/`chartAxisPrice` added to all 10 locales.

## Testing
- `npx vitest run` — 171/171 passing, including new tests for the screen-reader table, station-doc-preferred-over-log-derived stats, and the recent-logs query being limited to 12
- `npx tsc --noEmit`, `npm run lint`, `npm run build` — all clean