### PR TITLE
Fix: StationsPage always shows empty state (#122)

### DIFF
--- a/src/pages/StationsPage.tsx
+++ b/src/pages/StationsPage.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Loader, AlertCircle } from 'lucide-react';
 
-import { fetchUserStations } from '../firebase/firestoreService';
+import { fetchFuelLocations, fetchUserStations } from '../firebase/firestoreService';
 import { Station } from '../utils/types';
 import StationTable from '../components/StationTable'; // Will create this component
 import StationDetail from '../components/StationDetail'; // Will create this component
@@ -20,23 +20,8 @@ const StationsPage: React.FC = () => {
             setLoading(true);
             setError(null);
             try {
-                // Fetch all fuel logs to then get all unique stations
-                // Note: fetchUserStations currently expects logs as input.
-                // We might need to adjust firestoreService to fetch all stations directly,
-                // or ensure a mechanism to get all relevant logs.
-                // For now, I'll assume an empty array will result in no stations or we modify fetchUserStations
-                // to fetch all unique stations from fuelLogs without requiring prior logs.
-                // A better approach would be to have a dedicated 'fetchAllStations' if not tied to logs.
-                // For initial implementation, we'll fetch all unique stations based on existing logs.
-                
-                // Temporarily fetch all logs to get associated stations. This is not ideal for a large dataset,
-                // a dedicated 'fetchAllStations' function would be better.
-                // Assuming `fetchUserStations` can handle an empty log array or we need to pass a dummy.
-                // Let's assume fetchUserStations is modified to accept an optional logs array and
-                // if not provided, it fetches all stations the user has ever logged against.
-                // For now, I'll use `[]` and rely on a future refactor or assumption of internal logic.
-
-                const userStations = await fetchUserStations([]); // Assuming modification or smarter internal logic
+                const logs = await fetchFuelLocations();
+                const userStations = await fetchUserStations(logs);
                 setStations(userStations);
             } catch (err) {
                 console.error("Failed to load stations:", err);

--- a/src/pages/__tests__/StationsPage.test.tsx
+++ b/src/pages/__tests__/StationsPage.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import StationsPage from '../StationsPage';
 import { Station } from '../../utils/types';
-import { fetchUserStations } from '../../firebase/firestoreService';
+import { fetchFuelLocations, fetchUserStations } from '../../firebase/firestoreService';
 
 // Mock react-i18next
 vi.mock('react-i18next', () => ({
@@ -23,6 +23,7 @@ vi.mock('react-i18next', () => ({
 
 // Mock firebase/firestoreService
 vi.mock('../../firebase/firestoreService', () => ({
+  fetchFuelLocations: vi.fn(),
   fetchUserStations: vi.fn(),
 }));
 
@@ -72,6 +73,7 @@ const mockStations: Station[] = [
 describe('StationsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(fetchFuelLocations).mockResolvedValue([]);
     vi.mocked(fetchUserStations).mockResolvedValue([]); // Default to no stations
   });
 
@@ -96,6 +98,17 @@ describe('StationsPage', () => {
     render(<StationsPage />);
     await waitFor(() => {
       expect(screen.getByText('No fuel stations found.')).toBeInTheDocument();
+    });
+  });
+
+  it('fetches fuel logs and passes them to fetchUserStations', async () => {
+    const mockLogs = [{ id: 'log1', latitude: 10, longitude: 20 }] as never;
+    vi.mocked(fetchFuelLocations).mockResolvedValue(mockLogs);
+    vi.mocked(fetchUserStations).mockResolvedValue(mockStations);
+    render(<StationsPage />);
+    await waitFor(() => {
+      expect(fetchFuelLocations).toHaveBeenCalled();
+      expect(fetchUserStations).toHaveBeenCalledWith(mockLogs);
     });
   });
 


### PR DESCRIPTION
Closes #122

## Problem
`StationsPage.tsx` called `fetchUserStations([])` with a hardcoded empty array (a leftover placeholder from the original implementation), so the page always rendered the "No fuel stations found" empty state, even for users with logged fuel entries that have location data.

## Fix
Fetch the user's actual fuel logs via `fetchFuelLocations()` first, then pass them to `fetchUserStations`.

## Testing
- Updated `StationsPage.test.tsx` to mock `fetchFuelLocations` and added a test asserting its result is passed through to `fetchUserStations`.
- `npx vitest run src/pages/__tests__/StationsPage.test.tsx` — 6/6 passing
- `npx tsc -b` — clean
- `npx eslint` on changed files — clean