### PR TITLE
Resolve #128: Translate Stations placeholder strings in all locales

### DIFF
--- a/.github/workflows/i18n-check.yml
+++ b/.github/workflows/i18n-check.yml
@@ -85,6 +85,49 @@ jobs:
           console.log(`Key parity check passed for ${files.length} locales. ${baseKeys.size} keys verified per file.`);
           EOF
 
+      - name: Check for untranslated placeholder strings
+        run: |
+          node - <<'EOF'
+          import fs from 'fs';
+          import path from 'path';
+
+          const localesDir = 'src/i18n/locales';
+          const files = fs.readdirSync(localesDir).filter(f => f.endsWith('.json') && f !== 'en.json');
+          const placeholderPattern = /^\[[a-z]{2}\]\s/;
+
+          let failed = false;
+
+          function findPlaceholders(obj, prefix = '') {
+            const hits = [];
+            for (const [k, v] of Object.entries(obj)) {
+              const fullKey = prefix ? `${prefix}.${k}` : k;
+              if (typeof v === 'object' && v !== null && !Array.isArray(v)) {
+                hits.push(...findPlaceholders(v, fullKey));
+              } else if (typeof v === 'string' && placeholderPattern.test(v)) {
+                hits.push(`${fullKey}: "${v}"`);
+              }
+            }
+            return hits;
+          }
+
+          files.forEach(file => {
+            const data = JSON.parse(fs.readFileSync(path.join(localesDir, file), 'utf8'));
+            const hits = findPlaceholders(data);
+            if (hits.length > 0) {
+              console.error(`Placeholder strings found in ${file}:`);
+              hits.forEach(h => console.error(`    - ${h}`));
+              failed = true;
+            }
+          });
+
+          if (failed) {
+            console.error('\nLocale files must not contain "[xx] " placeholder strings.');
+            process.exit(1);
+          }
+
+          console.log(`No placeholder strings found in ${files.length} locale files.`);
+          EOF
+
       - name: Check components/pages use useTranslation (not raw strings)
         run: |
           VIOLATIONS=0

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -4,7 +4,7 @@
     "history": "Verlauf",
     "map": "Karte",
     "profile": "Profil",
-    "stations": "[de] Stations",
+    "stations": "Tankstellen",
     "dashboard": "Übersicht"
   },
   "login": {
@@ -15,35 +15,35 @@
     "error": "Anmeldung fehlgeschlagen. Bitte versuchen Sie es erneut."
   },
   "stations": {
-    "title": "[de] Fuel Stations",
-    "loading": "[de] Loading fuel stations...",
-    "errorLoading": "[de] Failed to load fuel stations. Please try again.",
-    "noStationsFound": "[de] No fuel stations found with logged entries. Log some fuel with location data!",
-    "selectStationPrompt": "[de] Select a station from the left to view details."
+    "title": "Tankstellen",
+    "loading": "Tankstellen werden geladen...",
+    "errorLoading": "Tankstellen konnten nicht geladen werden. Bitte versuchen Sie es erneut.",
+    "noStationsFound": "Keine Tankstellen mit erfassten Einträgen gefunden. Erfassen Sie Tankvorgänge mit Standortdaten!",
+    "selectStationPrompt": "Wählen Sie links eine Tankstelle aus, um Details anzuzeigen."
   },
   "stationTable": {
-    "sortBy": "[de] Sort by",
-    "name": "[de] Name",
-    "brand": "[de] Brand",
-    "avgPrice": "[de] Avg. Price",
-    "logCount": "[de] Logs",
-    "unknownBrand": "[de] Unknown Brand",
-    "noData": "[de] N/A"
+    "sortBy": "Sortieren nach",
+    "name": "Name",
+    "brand": "Marke",
+    "avgPrice": "Ø-Preis",
+    "logCount": "Einträge",
+    "unknownBrand": "Unbekannte Marke",
+    "noData": "k. A."
   },
   "stationDetail": {
-    "unknownBrand": "[de] Unknown Brand",
-    "noData": "[de] N/A",
-    "avgPrice": "[de] Average Price",
-    "lastPrice": "[de] Last Price",
-    "logCount": "[de] Total Logs",
-    "priceHistory": "[de] Price History (per Litre)",
+    "unknownBrand": "Unbekannte Marke",
+    "noData": "k. A.",
+    "avgPrice": "Durchschnittspreis",
+    "lastPrice": "Letzter Preis",
+    "logCount": "Einträge gesamt",
+    "priceHistory": "Preisverlauf (pro Liter)",
     "chartAxisDate": "Tankdatum",
     "chartAxisPrice": "Preis pro Liter",
-    "notEnoughDataForChart": "[de] Not enough data to display chart (at least 2 logs needed).",
-    "recentLogs": "[de] Recent Logs",
-    "noLogsFound": "[de] No fuel logs found for this station.",
-    "loading": "[de] Loading station details...",
-    "errorLoading": "[de] Failed to load station details. Please try again."
+    "notEnoughDataForChart": "Nicht genug Daten, um ein Diagramm anzuzeigen (mindestens 2 Einträge erforderlich).",
+    "recentLogs": "Letzte Einträge",
+    "noLogsFound": "Keine Tankeinträge für diese Tankstelle gefunden.",
+    "loading": "Tankstellendetails werden geladen...",
+    "errorLoading": "Tankstellendetails konnten nicht geladen werden. Bitte versuchen Sie es erneut."
   },
   "quickLog": {
     "title": "Neuer Kraftstoffeintrag",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -4,7 +4,7 @@
     "history": "Historial",
     "map": "Mapa",
     "profile": "Perfil",
-    "stations": "[es] Stations",
+    "stations": "Gasolineras",
     "dashboard": "Panel"
   },
   "login": {
@@ -15,35 +15,35 @@
     "error": "Error al iniciar sesión. Por favor, inténtalo de nuevo."
   },
   "stations": {
-    "title": "[es] Fuel Stations",
-    "loading": "[es] Loading fuel stations...",
-    "errorLoading": "[es] Failed to load fuel stations. Please try again.",
-    "noStationsFound": "[es] No fuel stations found with logged entries. Log some fuel with location data!",
-    "selectStationPrompt": "[es] Select a station from the left to view details."
+    "title": "Gasolineras",
+    "loading": "Cargando gasolineras...",
+    "errorLoading": "No se pudieron cargar las gasolineras. Inténtalo de nuevo.",
+    "noStationsFound": "No se encontraron gasolineras con registros guardados. ¡Registra combustible con datos de ubicación!",
+    "selectStationPrompt": "Selecciona una gasolinera a la izquierda para ver los detalles."
   },
   "stationTable": {
-    "sortBy": "[es] Sort by",
-    "name": "[es] Name",
-    "brand": "[es] Brand",
-    "avgPrice": "[es] Avg. Price",
-    "logCount": "[es] Logs",
-    "unknownBrand": "[es] Unknown Brand",
-    "noData": "[es] N/A"
+    "sortBy": "Ordenar por",
+    "name": "Nombre",
+    "brand": "Marca",
+    "avgPrice": "Precio medio",
+    "logCount": "Registros",
+    "unknownBrand": "Marca desconocida",
+    "noData": "N/D"
   },
   "stationDetail": {
-    "unknownBrand": "[es] Unknown Brand",
-    "noData": "[es] N/A",
-    "avgPrice": "[es] Average Price",
-    "lastPrice": "[es] Last Price",
-    "logCount": "[es] Total Logs",
-    "priceHistory": "[es] Price History (per Litre)",
+    "unknownBrand": "Marca desconocida",
+    "noData": "N/D",
+    "avgPrice": "Precio medio",
+    "lastPrice": "Último precio",
+    "logCount": "Total de registros",
+    "priceHistory": "Historial de precios (por litro)",
     "chartAxisDate": "Fecha de Repostaje",
     "chartAxisPrice": "Precio por Litro",
-    "notEnoughDataForChart": "[es] Not enough data to display chart (at least 2 logs needed).",
-    "recentLogs": "[es] Recent Logs",
-    "noLogsFound": "[es] No fuel logs found for this station.",
-    "loading": "[es] Loading station details...",
-    "errorLoading": "[es] Failed to load station details. Please try again."
+    "notEnoughDataForChart": "No hay suficientes datos para mostrar el gráfico (se necesitan al menos 2 registros).",
+    "recentLogs": "Registros recientes",
+    "noLogsFound": "No se encontraron registros de combustible para esta gasolinera.",
+    "loading": "Cargando los detalles de la gasolinera...",
+    "errorLoading": "No se pudieron cargar los detalles de la gasolinera. Inténtalo de nuevo."
   },
   "quickLog": {
     "title": "Nuevo Registro de Combustible",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -4,7 +4,7 @@
     "history": "Historia",
     "map": "Kartta",
     "profile": "Profiili",
-    "stations": "[fi] Stations",
+    "stations": "Asemat",
     "dashboard": "Yleiskatsaus"
   },
   "login": {
@@ -15,35 +15,35 @@
     "error": "Kirjautuminen epäonnistui. Yritä uudelleen."
   },
   "stations": {
-    "title": "[fi] Fuel Stations",
-    "loading": "[fi] Loading fuel stations...",
-    "errorLoading": "[fi] Failed to load fuel stations. Please try again.",
-    "noStationsFound": "[fi] No fuel stations found with logged entries. Log some fuel with location data!",
-    "selectStationPrompt": "[fi] Select a station from the left to view details."
+    "title": "Huoltoasemat",
+    "loading": "Ladataan huoltoasemia...",
+    "errorLoading": "Huoltoasemien lataaminen epäonnistui. Yritä uudelleen.",
+    "noStationsFound": "Huoltoasemia, joilla on kirjattuja merkintöjä, ei löytynyt. Kirjaa polttoainetta sijaintitiedoilla!",
+    "selectStationPrompt": "Valitse asema vasemmalta nähdäksesi tiedot."
   },
   "stationTable": {
-    "sortBy": "[fi] Sort by",
-    "name": "[fi] Name",
-    "brand": "[fi] Brand",
-    "avgPrice": "[fi] Avg. Price",
-    "logCount": "[fi] Logs",
-    "unknownBrand": "[fi] Unknown Brand",
-    "noData": "[fi] N/A"
+    "sortBy": "Lajittele",
+    "name": "Nimi",
+    "brand": "Merkki",
+    "avgPrice": "Keskihinta",
+    "logCount": "Merkinnät",
+    "unknownBrand": "Tuntematon merkki",
+    "noData": "Ei tietoa"
   },
   "stationDetail": {
-    "unknownBrand": "[fi] Unknown Brand",
-    "noData": "[fi] N/A",
-    "avgPrice": "[fi] Average Price",
-    "lastPrice": "[fi] Last Price",
-    "logCount": "[fi] Total Logs",
-    "priceHistory": "[fi] Price History (per Litre)",
+    "unknownBrand": "Tuntematon merkki",
+    "noData": "Ei tietoa",
+    "avgPrice": "Keskihinta",
+    "lastPrice": "Viimeisin hinta",
+    "logCount": "Merkintöjä yhteensä",
+    "priceHistory": "Hintahistoria (per litra)",
     "chartAxisDate": "Tankkauspäivä",
     "chartAxisPrice": "Hinta per Litra",
-    "notEnoughDataForChart": "[fi] Not enough data to display chart (at least 2 logs needed).",
-    "recentLogs": "[fi] Recent Logs",
-    "noLogsFound": "[fi] No fuel logs found for this station.",
-    "loading": "[fi] Loading station details...",
-    "errorLoading": "[fi] Failed to load station details. Please try again."
+    "notEnoughDataForChart": "Kaavion näyttämiseen ei ole tarpeeksi tietoa (vähintään 2 merkintää tarvitaan).",
+    "recentLogs": "Viimeisimmät merkinnät",
+    "noLogsFound": "Tälle asemalle ei löytynyt polttoainemerkintöjä.",
+    "loading": "Ladataan aseman tietoja...",
+    "errorLoading": "Aseman tietojen lataaminen epäonnistui. Yritä uudelleen."
   },
   "quickLog": {
     "title": "Kirjaa uusi tankkaus",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -4,7 +4,7 @@
     "history": "Historique",
     "map": "Carte",
     "profile": "Profil",
-    "stations": "[fr] Stations",
+    "stations": "Stations",
     "dashboard": "Tableau de bord"
   },
   "login": {
@@ -15,35 +15,35 @@
     "error": "Échec de la connexion. Veuillez réessayer."
   },
   "stations": {
-    "title": "[fr] Fuel Stations",
-    "loading": "[fr] Loading fuel stations...",
-    "errorLoading": "[fr] Failed to load fuel stations. Please try again.",
-    "noStationsFound": "[fr] No fuel stations found with logged entries. Log some fuel with location data!",
-    "selectStationPrompt": "[fr] Select a station from the left to view details."
+    "title": "Stations-service",
+    "loading": "Chargement des stations-service...",
+    "errorLoading": "Impossible de charger les stations-service. Veuillez réessayer.",
+    "noStationsFound": "Aucune station-service trouvée avec des entrées enregistrées. Enregistrez du carburant avec des données de localisation !",
+    "selectStationPrompt": "Sélectionnez une station à gauche pour voir les détails."
   },
   "stationTable": {
-    "sortBy": "[fr] Sort by",
-    "name": "[fr] Name",
-    "brand": "[fr] Brand",
-    "avgPrice": "[fr] Avg. Price",
-    "logCount": "[fr] Logs",
-    "unknownBrand": "[fr] Unknown Brand",
-    "noData": "[fr] N/A"
+    "sortBy": "Trier par",
+    "name": "Nom",
+    "brand": "Marque",
+    "avgPrice": "Prix moyen",
+    "logCount": "Entrées",
+    "unknownBrand": "Marque inconnue",
+    "noData": "N/D"
   },
   "stationDetail": {
-    "unknownBrand": "[fr] Unknown Brand",
-    "noData": "[fr] N/A",
-    "avgPrice": "[fr] Average Price",
-    "lastPrice": "[fr] Last Price",
-    "logCount": "[fr] Total Logs",
-    "priceHistory": "[fr] Price History (per Litre)",
+    "unknownBrand": "Marque inconnue",
+    "noData": "N/D",
+    "avgPrice": "Prix moyen",
+    "lastPrice": "Dernier prix",
+    "logCount": "Total des entrées",
+    "priceHistory": "Historique des prix (par litre)",
     "chartAxisDate": "Date de Plein",
     "chartAxisPrice": "Prix par Litre",
-    "notEnoughDataForChart": "[fr] Not enough data to display chart (at least 2 logs needed).",
-    "recentLogs": "[fr] Recent Logs",
-    "noLogsFound": "[fr] No fuel logs found for this station.",
-    "loading": "[fr] Loading station details...",
-    "errorLoading": "[fr] Failed to load station details. Please try again."
+    "notEnoughDataForChart": "Pas assez de données pour afficher le graphique (au moins 2 entrées nécessaires).",
+    "recentLogs": "Entrées récentes",
+    "noLogsFound": "Aucune entrée de carburant trouvée pour cette station.",
+    "loading": "Chargement des détails de la station...",
+    "errorLoading": "Impossible de charger les détails de la station. Veuillez réessayer."
   },
   "quickLog": {
     "title": "Nouvelle Saisie de Carburant",

--- a/src/i18n/locales/ga.json
+++ b/src/i18n/locales/ga.json
@@ -4,7 +4,7 @@
     "history": "Stair",
     "map": "Léarscáil",
     "profile": "Próifíl",
-    "stations": "[ga] Stations",
+    "stations": "Stáisiúin",
     "dashboard": "Painéal"
   },
   "login": {
@@ -15,35 +15,35 @@
     "error": "Theip ar an gcomhshuíomh. Déan iarracht arís le do thoil."
   },
   "stations": {
-    "title": "[ga] Fuel Stations",
-    "loading": "[ga] Loading fuel stations...",
-    "errorLoading": "[ga] Failed to load fuel stations. Please try again.",
-    "noStationsFound": "[ga] No fuel stations found with logged entries. Log some fuel with location data!",
-    "selectStationPrompt": "[ga] Select a station from the left to view details."
+    "title": "Stáisiúin Breosla",
+    "loading": "Stáisiúin bhreosla á luchtú...",
+    "errorLoading": "Theip ar luchtú na stáisiúin bhreosla. Bain triail eile as.",
+    "noStationsFound": "Níor aimsíodh aon stáisiún breosla le hiontrálacha logáilte. Logáil breosla le sonraí suímh!",
+    "selectStationPrompt": "Roghnaigh stáisiún ar chlé chun sonraí a fheiceáil."
   },
   "stationTable": {
-    "sortBy": "[ga] Sort by",
-    "name": "[ga] Name",
-    "brand": "[ga] Brand",
-    "avgPrice": "[ga] Avg. Price",
-    "logCount": "[ga] Logs",
-    "unknownBrand": "[ga] Unknown Brand",
-    "noData": "[ga] N/A"
+    "sortBy": "Sórtáil de réir",
+    "name": "Ainm",
+    "brand": "Branda",
+    "avgPrice": "Meánphraghas",
+    "logCount": "Logaí",
+    "unknownBrand": "Branda Anaithnid",
+    "noData": "N/B"
   },
   "stationDetail": {
-    "unknownBrand": "[ga] Unknown Brand",
-    "noData": "[ga] N/A",
-    "avgPrice": "[ga] Average Price",
-    "lastPrice": "[ga] Last Price",
-    "logCount": "[ga] Total Logs",
-    "priceHistory": "[ga] Price History (per Litre)",
+    "unknownBrand": "Branda Anaithnid",
+    "noData": "N/B",
+    "avgPrice": "Meánphraghas",
+    "lastPrice": "An Praghas Deireanach",
+    "logCount": "Iomlán Logaí",
+    "priceHistory": "Stair Praghsanna (in aghaidh an Lítir)",
     "chartAxisDate": "Dáta Líonta",
     "chartAxisPrice": "Praghas in aghaidh an Lítir",
-    "notEnoughDataForChart": "[ga] Not enough data to display chart (at least 2 logs needed).",
-    "recentLogs": "[ga] Recent Logs",
-    "noLogsFound": "[ga] No fuel logs found for this station.",
-    "loading": "[ga] Loading station details...",
-    "errorLoading": "[ga] Failed to load station details. Please try again."
+    "notEnoughDataForChart": "Níl dóthain sonraí ann chun an chairt a thaispeáint (tá gá le 2 logaí ar a laghad).",
+    "recentLogs": "Logaí Le Déanaí",
+    "noLogsFound": "Níor aimsíodh aon logaí breosla don stáisiún seo.",
+    "loading": "Sonraí an stáisiúin á luchtú...",
+    "errorLoading": "Theip ar luchtú sonraí an stáisiúin. Bain triail eile as."
   },
   "quickLog": {
     "title": "Iontráil Breosla Nua",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -4,7 +4,7 @@
     "history": "履歴",
     "map": "地図",
     "profile": "プロフィール",
-    "stations": "[ja] Stations",
+    "stations": "ガソリンスタンド",
     "dashboard": "ダッシュボード"
   },
   "login": {
@@ -15,35 +15,35 @@
     "error": "ログインに失敗しました。もう一度お試しください。"
   },
   "stations": {
-    "title": "[ja] Fuel Stations",
-    "loading": "[ja] Loading fuel stations...",
-    "errorLoading": "[ja] Failed to load fuel stations. Please try again.",
-    "noStationsFound": "[ja] No fuel stations found with logged entries. Log some fuel with location data!",
-    "selectStationPrompt": "[ja] Select a station from the left to view details."
+    "title": "ガソリンスタンド",
+    "loading": "ガソリンスタンドを読み込み中...",
+    "errorLoading": "ガソリンスタンドの読み込みに失敗しました。再試行してください。",
+    "noStationsFound": "記録された給油データがあるガソリンスタンドが見つかりません。位置情報付きで給油を記録してください！",
+    "selectStationPrompt": "左側からスタンドを選択して詳細を表示してください。"
   },
   "stationTable": {
-    "sortBy": "[ja] Sort by",
-    "name": "[ja] Name",
-    "brand": "[ja] Brand",
-    "avgPrice": "[ja] Avg. Price",
-    "logCount": "[ja] Logs",
-    "unknownBrand": "[ja] Unknown Brand",
-    "noData": "[ja] N/A"
+    "sortBy": "並び替え",
+    "name": "名前",
+    "brand": "ブランド",
+    "avgPrice": "平均価格",
+    "logCount": "記録数",
+    "unknownBrand": "不明なブランド",
+    "noData": "なし"
   },
   "stationDetail": {
-    "unknownBrand": "[ja] Unknown Brand",
-    "noData": "[ja] N/A",
-    "avgPrice": "[ja] Average Price",
-    "lastPrice": "[ja] Last Price",
-    "logCount": "[ja] Total Logs",
-    "priceHistory": "[ja] Price History (per Litre)",
+    "unknownBrand": "不明なブランド",
+    "noData": "なし",
+    "avgPrice": "平均価格",
+    "lastPrice": "最新価格",
+    "logCount": "合計記録数",
+    "priceHistory": "価格履歴（リットルあたり）",
     "chartAxisDate": "給油日",
     "chartAxisPrice": "リットルあたりの価格",
-    "notEnoughDataForChart": "[ja] Not enough data to display chart (at least 2 logs needed).",
-    "recentLogs": "[ja] Recent Logs",
-    "noLogsFound": "[ja] No fuel logs found for this station.",
-    "loading": "[ja] Loading station details...",
-    "errorLoading": "[ja] Failed to load station details. Please try again."
+    "notEnoughDataForChart": "グラフを表示するためのデータが不足しています（少なくとも2件の記録が必要です）。",
+    "recentLogs": "最近の記録",
+    "noLogsFound": "このスタンドの給油記録が見つかりません。",
+    "loading": "スタンドの詳細を読み込み中...",
+    "errorLoading": "スタンドの詳細の読み込みに失敗しました。再試行してください。"
   },
   "quickLog": {
     "title": "新しい燃料記録",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -4,7 +4,7 @@
     "history": "내역",
     "map": "지도",
     "profile": "프로필",
-    "stations": "[ko] Stations",
+    "stations": "주유소",
     "dashboard": "대시보드"
   },
   "login": {
@@ -15,35 +15,35 @@
     "error": "로그인에 실패했습니다. 다시 시도해 주세요."
   },
   "stations": {
-    "title": "[ko] Fuel Stations",
-    "loading": "[ko] Loading fuel stations...",
-    "errorLoading": "[ko] Failed to load fuel stations. Please try again.",
-    "noStationsFound": "[ko] No fuel stations found with logged entries. Log some fuel with location data!",
-    "selectStationPrompt": "[ko] Select a station from the left to view details."
+    "title": "주유소",
+    "loading": "주유소를 불러오는 중...",
+    "errorLoading": "주유소를 불러오지 못했습니다. 다시 시도해 주세요.",
+    "noStationsFound": "기록된 항목이 있는 주유소를 찾을 수 없습니다. 위치 데이터와 함께 주유 기록을 남겨보세요!",
+    "selectStationPrompt": "왼쪽에서 주유소를 선택하여 세부 정보를 확인하세요."
   },
   "stationTable": {
-    "sortBy": "[ko] Sort by",
-    "name": "[ko] Name",
-    "brand": "[ko] Brand",
-    "avgPrice": "[ko] Avg. Price",
-    "logCount": "[ko] Logs",
-    "unknownBrand": "[ko] Unknown Brand",
-    "noData": "[ko] N/A"
+    "sortBy": "정렬 기준",
+    "name": "이름",
+    "brand": "브랜드",
+    "avgPrice": "평균 가격",
+    "logCount": "기록 수",
+    "unknownBrand": "알 수 없는 브랜드",
+    "noData": "해당 없음"
   },
   "stationDetail": {
-    "unknownBrand": "[ko] Unknown Brand",
-    "noData": "[ko] N/A",
-    "avgPrice": "[ko] Average Price",
-    "lastPrice": "[ko] Last Price",
-    "logCount": "[ko] Total Logs",
-    "priceHistory": "[ko] Price History (per Litre)",
+    "unknownBrand": "알 수 없는 브랜드",
+    "noData": "해당 없음",
+    "avgPrice": "평균 가격",
+    "lastPrice": "최근 가격",
+    "logCount": "총 기록 수",
+    "priceHistory": "가격 기록 (리터당)",
     "chartAxisDate": "주유 날짜",
     "chartAxisPrice": "리터당 가격",
-    "notEnoughDataForChart": "[ko] Not enough data to display chart (at least 2 logs needed).",
-    "recentLogs": "[ko] Recent Logs",
-    "noLogsFound": "[ko] No fuel logs found for this station.",
-    "loading": "[ko] Loading station details...",
-    "errorLoading": "[ko] Failed to load station details. Please try again."
+    "notEnoughDataForChart": "차트를 표시할 데이터가 충분하지 않습니다 (최소 2개의 기록이 필요합니다).",
+    "recentLogs": "최근 기록",
+    "noLogsFound": "이 주유소에 대한 주유 기록을 찾을 수 없습니다.",
+    "loading": "주유소 세부 정보를 불러오는 중...",
+    "errorLoading": "주유소 세부 정보를 불러오지 못했습니다. 다시 시도해 주세요."
   },
   "quickLog": {
     "title": "새 연료 기록",

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -4,7 +4,7 @@
     "history": "Historikk",
     "map": "Kart",
     "profile": "Profil",
-    "stations": "[no] Stations",
+    "stations": "Stasjoner",
     "dashboard": "Oversikt"
   },
   "login": {
@@ -15,35 +15,35 @@
     "error": "Kunne ikke logge inn. Prøv igjen."
   },
   "stations": {
-    "title": "[no] Fuel Stations",
-    "loading": "[no] Laster drivstoffstasjoner...",
-    "errorLoading": "[no] Kunne ikke laste drivstoffstasjoner. Prøv igjen.",
-    "noStationsFound": "[no] Ingen drivstoffstasjoner funnet med loggede oppføringer. Logg drivstoff med posisjonsdata!",
-    "selectStationPrompt": "[no] Velg en stasjon fra venstre for å se detaljer."
+    "title": "Drivstoffstasjoner",
+    "loading": "Laster drivstoffstasjoner...",
+    "errorLoading": "Kunne ikke laste drivstoffstasjoner. Prøv igjen.",
+    "noStationsFound": "Ingen drivstoffstasjoner funnet med loggede oppføringer. Logg drivstoff med posisjonsdata!",
+    "selectStationPrompt": "Velg en stasjon fra venstre for å se detaljer."
   },
   "stationTable": {
-    "sortBy": "[no] Sort by",
-    "name": "[no] Navn",
-    "brand": "[no] Merke",
-    "avgPrice": "[no] Gj.snitt. Pris",
-    "logCount": "[no] Logger",
-    "unknownBrand": "[no] Ukjent merke",
-    "noData": "[no] I/T"
+    "sortBy": "Sorter etter",
+    "name": "Navn",
+    "brand": "Merke",
+    "avgPrice": "Gj.snitt. Pris",
+    "logCount": "Logger",
+    "unknownBrand": "Ukjent merke",
+    "noData": "I/T"
   },
   "stationDetail": {
-    "unknownBrand": "[no] Ukjent merke",
-    "noData": "[no] I/T",
-    "avgPrice": "[no] Gjennomsnittlig pris",
-    "lastPrice": "[no] Siste pris",
-    "logCount": "[no] Totalt antall logger",
-    "priceHistory": "[no] Prishistorikk (per liter)",
+    "unknownBrand": "Ukjent merke",
+    "noData": "I/T",
+    "avgPrice": "Gjennomsnittlig pris",
+    "lastPrice": "Siste pris",
+    "logCount": "Totalt antall logger",
+    "priceHistory": "Prishistorikk (per liter)",
     "chartAxisDate": "Fylledato",
     "chartAxisPrice": "Pris per Liter",
-    "notEnoughDataForChart": "[no] Ikke nok data for å vise diagram (minst 2 logger nødvendig).",
-    "recentLogs": "[no] Siste logger",
-    "noLogsFound": "[no] Ingen drivstofflogger funnet for denne stasjonen.",
-    "loading": "[no] Laster stasjonsdetaljer...",
-    "errorLoading": "[no] Kunne ikke laste stasjonsdetaljer. Prøv igjen."
+    "notEnoughDataForChart": "Ikke nok data for å vise diagram (minst 2 logger nødvendig).",
+    "recentLogs": "Siste logger",
+    "noLogsFound": "Ingen drivstofflogger funnet for denne stasjonen.",
+    "loading": "Laster stasjonsdetaljer...",
+    "errorLoading": "Kunne ikke laste stasjonsdetaljer. Prøv igjen."
   },
   "quickLog": {
     "title": "Logg ny drivstoffoppføring",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -4,7 +4,7 @@
     "history": "Historik",
     "map": "Karta",
     "profile": "Profil",
-    "stations": "[sv] Stations",
+    "stations": "Stationer",
     "dashboard": "Översikt"
   },
   "login": {
@@ -15,35 +15,35 @@
     "error": "Misslyckades med att logga in. Försök igen."
   },
   "stations": {
-    "title": "[sv] Fuel Stations",
-    "loading": "[sv] Laddar bränslestationer...",
-    "errorLoading": "[sv] Misslyckades med att ladda bränslestationer. Försök igen.",
-    "noStationsFound": "[sv] Inga bränslestationer hittades med loggade poster. Logga bränsle med platsdata!",
-    "selectStationPrompt": "[sv] Välj en station från vänster för att se detaljer."
+    "title": "Bränslestationer",
+    "loading": "Laddar bränslestationer...",
+    "errorLoading": "Misslyckades med att ladda bränslestationer. Försök igen.",
+    "noStationsFound": "Inga bränslestationer hittades med loggade poster. Logga bränsle med platsdata!",
+    "selectStationPrompt": "Välj en station från vänster för att se detaljer."
   },
   "stationTable": {
-    "sortBy": "[sv] Sort by",
-    "name": "[sv] Namn",
-    "brand": "[sv] Märke",
-    "avgPrice": "[sv] Genomsnittligt pris",
-    "logCount": "[sv] Loggar",
-    "unknownBrand": "[sv] Okänt märke",
-    "noData": "[sv] Ej tillgänglig"
+    "sortBy": "Sortera efter",
+    "name": "Namn",
+    "brand": "Märke",
+    "avgPrice": "Genomsnittligt pris",
+    "logCount": "Loggar",
+    "unknownBrand": "Okänt märke",
+    "noData": "Ej tillgänglig"
   },
   "stationDetail": {
-    "unknownBrand": "[sv] Okänt märke",
-    "noData": "[sv] Ej tillgänglig",
-    "avgPrice": "[sv] Genomsnittligt pris",
-    "lastPrice": "[sv] Senaste pris",
-    "logCount": "[sv] Totalt antal loggar",
-    "priceHistory": "[sv] Prishistorik (per liter)",
+    "unknownBrand": "Okänt märke",
+    "noData": "Ej tillgänglig",
+    "avgPrice": "Genomsnittligt pris",
+    "lastPrice": "Senaste pris",
+    "logCount": "Totalt antal loggar",
+    "priceHistory": "Prishistorik (per liter)",
     "chartAxisDate": "Tankningsdatum",
     "chartAxisPrice": "Pris per Liter",
-    "notEnoughDataForChart": "[sv] Inte tillräckligt med data för att visa diagram (minst 2 loggar behövs).",
-    "recentLogs": "[sv] Senaste loggar",
-    "noLogsFound": "[sv] Inga bränsleloggar hittades för denna station.",
-    "loading": "[sv] Laddar stationsdetaljer...",
-    "errorLoading": "[sv] Misslyckades med att ladda stationsdetaljer. Försök igen."
+    "notEnoughDataForChart": "Inte tillräckligt med data för att visa diagram (minst 2 loggar behövs).",
+    "recentLogs": "Senaste loggar",
+    "noLogsFound": "Inga bränsleloggar hittades för denna station.",
+    "loading": "Laddar stationsdetaljer...",
+    "errorLoading": "Misslyckades med att ladda stationsdetaljer. Försök igen."
   },
   "quickLog": {
     "title": "Logga ny bränslepost",


### PR DESCRIPTION
Closes #128

## Changes
- Replaced all 24 `[xx] ...` placeholder strings across `de`, `es`, `fi`, `fr`, `ga`, `ja`, `ko`, `no`, `sv` locale files with real translations for the `nav.stations`, `stations.*`, `stationTable.*`, and `stationDetail.*` keys.
- `no` and `sv` had partial translations with the placeholder tag still prefixed — stripped the `[xx] ` prefix from those.
- Added a CI guard to `.github/workflows/i18n-check.yml` that scans all non-English locale files for the `^\[xx\] ` placeholder pattern and fails the build if any remain, so this can't silently regress.

## Testing
- Validated all 10 locale JSON files parse correctly.
- Confirmed key parity unaffected (only values changed, no keys added/removed).
- Manually grepped for the placeholder pattern post-change — none remain.