### PR TITLE
Resolve #127: Standardize displayed dates to dd/MM/yyyy

### DIFF
--- a/src/components/ApiTokenManager.tsx
+++ b/src/components/ApiTokenManager.tsx
@@ -4,6 +4,7 @@ import { useApiTokens, type TokenScope } from '../context/ApiTokenContext';
 import type { ApiToken } from '../utils/types';
 import { Timestamp } from 'firebase/firestore';
 import { useTranslation, Trans } from 'react-i18next';
+import { formatDate as formatDateDDMMYYYY } from '../utils/formatDate';
 
 const ALL_SCOPES: TokenScope[] = ['read:logs', 'write:logs', 'read:vehicles', 'write:vehicles'];
 
@@ -117,7 +118,7 @@ function TokenRow({ token, onRevoke }: TokenRowProps): JSX.Element {
     if (!ts) return t('apiTokens.row.never');
     const date = ts.toDate?.();
     if (!date) return t('apiTokens.row.never');
-    return date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+    return formatDateDDMMYYYY(date);
   };
 
   return (

--- a/src/components/FuelMapPage.tsx
+++ b/src/components/FuelMapPage.tsx
@@ -12,6 +12,7 @@ import 'leaflet.markercluster/dist/MarkerCluster.Default.css'; // Cluster Defaul
 
 import { fetchFuelLocations, fetchUserStations } from '../firebase/firestoreService'; // Adjust path if needed
 import { Log, Station } from '../utils/types';
+import { formatDate } from '../utils/formatDate';
 
 // --- Icon Fix (points to public assets) ---
 const iconRetinaUrl = '/marker-icon-2x.png';
@@ -176,7 +177,7 @@ const FuelMapPage: React.FC = () => {
                         {group.logs.map(log => (
                             <div key={log.id} className="text-xs border-b border-gray-50 dark:border-gray-800 pb-1 last:border-0">
                                 <p className="flex justify-between font-medium">
-                                    <span>{log.timestamp.toDate().toLocaleDateString()}</span>
+                                    <span>{formatDate(log.timestamp.toDate())}</span>
                                     <span className="text-green-600 dark:text-green-400">€{log.cost.toFixed(2)}</span>
                                 </p>
                                 <p className="text-[10px] text-gray-500">

--- a/src/components/LogCard.tsx
+++ b/src/components/LogCard.tsx
@@ -3,6 +3,7 @@ import { JSX, useState } from 'react';
 import { Log } from '../utils/types';
 import { formatMPG, formatCostPerMile, formatKmL, formatL100km } from '../utils/calculations';
 import { sanitizeUrl } from '../utils/sanitize';
+import { formatDate } from '../utils/formatDate';
 import { MapContainer, TileLayer, Marker, useMap } from 'react-leaflet';
 import L from 'leaflet';
 import { MapPin, Info, Edit3, Trash2, FileText } from 'lucide-react';
@@ -41,7 +42,7 @@ const RecenterMap = ({ center }: { center: L.LatLngExpression }) => {
 function LogCard({ log, onEdit, onDelete, vehicleName, stationName }: LogCardProps): JSX.Element {
   const { profile } = useAuth();
   const { getBoolean } = useRemoteConfig();
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const [isFlipped, setIsFlipped] = useState(false);
   const hasGeo = log.latitude !== undefined && log.longitude !== undefined;
 
@@ -87,7 +88,7 @@ function LogCard({ log, onEdit, onDelete, vehicleName, stationName }: LogCardPro
             <div className="space-y-0.5 min-w-0 flex-grow">
               <div className="flex items-center space-x-1.5">
                 <p className="text-[10px] font-bold text-brand-primary uppercase tracking-widest truncate">
-                    {log.timestamp?.toDate().toLocaleDateString(i18n.language, { day: '2-digit', month: 'short', year: 'numeric' }) ?? 'N/A'}
+                    {log.timestamp?.toDate() ? formatDate(log.timestamp.toDate()) : 'N/A'}
                 </p>
                 {hasGeo && <MapPin size={10} className="text-brand-primary shrink-0 animate-pulse" />}
               </div>

--- a/src/components/StationDetail.tsx
+++ b/src/components/StationDetail.tsx
@@ -8,6 +8,7 @@ import {
 
 import { Log, Station } from '../utils/types';
 import { fetchFuelLogsByStationId, fetchStationById } from '../firebase/firestoreService';
+import { formatDate } from '../utils/formatDate';
 
 const RECENT_LOGS_LIMIT = 12;
 
@@ -97,7 +98,7 @@ const StationDetail: React.FC<StationDetailProps> = ({ stationId }) => {
             .map(log => {
                 const price = log.fuelAmountLiters ? (log.cost / log.fuelAmountLiters) : 0;
                 return {
-                    date: log.timestamp.toDate().toLocaleDateString(),
+                    date: formatDate(log.timestamp.toDate()),
                     pricePerLiter: isFinite(price) ? parseFloat(price.toFixed(3)) : 0, // Ensure it's a finite number
                 };
             })
@@ -218,7 +219,7 @@ const StationDetail: React.FC<StationDetailProps> = ({ stationId }) => {
                     {fuelLogs.map(log => (
                         <div key={log.id} className="flex justify-between items-center bg-gray-50 dark:bg-gray-700 p-3 rounded-md">
                             <p className="text-sm text-gray-900 dark:text-gray-100">
-                                {log.timestamp.toDate().toLocaleDateString()}
+                                {formatDate(log.timestamp.toDate())}
                             </p>
                             <p className="text-sm text-green-600 dark:text-green-400 font-medium">
                                 €{log.cost.toFixed(2)} ({log.fuelAmountLiters.toFixed(2)}L @ {isFinite(log.cost / log.fuelAmountLiters) ? (log.cost / log.fuelAmountLiters).toFixed(3) : t('stationTable.noData')}/L)

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -27,13 +27,14 @@ import { COMMON_CURRENCIES } from '../utils/currencyApi';
 import ImageUpload from '../components/ImageUpload';
 import { uploadReceipt } from '../firebase/storageService';
 import { sanitizeUrl } from '../utils/sanitize';
+import { formatDate } from '../utils/formatDate';
 import { fetchUserStations } from '../firebase/firestoreService';
 import { Station } from '../utils/types';
 
 // --- React Component ---
 function HistoryPage(): JSX.Element {
     const { getBoolean } = useRemoteConfig(); // Use the hook
-    const { t, i18n } = useTranslation();
+    const { t } = useTranslation();
 
     // Get the current authenticated user from context
     const { user, profile } = useAuth();
@@ -225,13 +226,13 @@ function HistoryPage(): JSX.Element {
         // Sort ascending by date for time-series charts
         const sortedLogs = [...filteredLogs].sort((a, b) => a.timestamp.toMillis() - b.timestamp.toMillis());
         return sortedLogs.map(log => ({
-            date: log.timestamp?.toDate().toLocaleDateString(i18n.language, { day: '2-digit', month: '2-digit' }) ?? 'N/A',
+            date: log.timestamp?.toDate() ? formatDate(log.timestamp.toDate()) : 'N/A',
             timestampValue: log.timestamp?.toMillis(),
             mpg: getNumericMPG(log.distanceKm, log.fuelAmountLiters),
             cost: log.cost > 0 ? log.cost : null,
             fuelPrice: getNumericFuelPrice(log.cost, log.fuelAmountLiters)
         }));
-    }, [filteredLogs, i18n.language]); // Recalculate only when filteredLogs or language change
+    }, [filteredLogs]); // Recalculate only when filteredLogs change
 
     // --- Calculate Summary Metrics (Uses filteredLogs) ---
     // Memoized calculation for the total cost, average MPG, and average cost based on the *filtered* logs.
@@ -601,7 +602,7 @@ function HistoryPage(): JSX.Element {
                                     {/* Map over filteredLogs for table rows */}
                                     {filteredLogs.map((log) => (
                                         <tr key={log.id} className="hover:bg-gray-50 dark:hover:bg-gray-700 transition duration-150 ease-in-out">
-                                            <td className="px-3 py-3 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">{log.timestamp?.toDate().toLocaleDateString(i18n.language) ?? 'N/A'}</td>
+                                            <td className="px-3 py-3 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">{log.timestamp?.toDate() ? formatDate(log.timestamp.toDate()) : 'N/A'}</td>
                                             <td className="px-3 py-3 whitespace-nowrap text-sm font-medium text-brand-primary font-mono tracking-tighter">{vehicleMap[log.vehicleId || ''] || '-'}</td>
                                             <td className="px-3 py-3 whitespace-nowrap text-sm text-gray-900 dark:text-gray-200">
                                                 {stations.find(s => s.id === log.stationId)?.name || log.brand}
@@ -694,7 +695,7 @@ function HistoryPage(): JSX.Element {
             {isModalOpen && editingLog && (
                 <div className="fixed inset-0 z-50 overflow-y-auto bg-gray-600 dark:bg-gray-900 bg-opacity-75 dark:bg-opacity-80 transition-opacity flex items-center justify-center" aria-labelledby="modal-title" role="dialog" aria-modal="true">
                     <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-6 w-full max-w-md m-4 space-y-4 transform transition-all">
-                        <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-300" id="modal-title">{t('history.edit.title')} ({editingLog.timestamp.toDate().toLocaleDateString(i18n.language)})</h3>
+                        <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-300" id="modal-title">{t('history.edit.title')} ({formatDate(editingLog.timestamp.toDate())})</h3>
                         {/* Edit Form */}
                         <form onSubmit={handleUpdateLog} className="space-y-4">
                             {/* Vehicle Selection */}

--- a/src/utils/formatDate.test.ts
+++ b/src/utils/formatDate.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { formatDate } from './formatDate';
+
+describe('formatDate', () => {
+  it('zero-pads single-digit day and month', () => {
+    expect(formatDate(new Date(2026, 0, 5))).toBe('05/01/2026');
+  });
+
+  it('formats double-digit day and month without extra padding', () => {
+    expect(formatDate(new Date(2026, 11, 25))).toBe('25/12/2026');
+  });
+
+  it('handles year boundaries correctly', () => {
+    expect(formatDate(new Date(1999, 11, 31))).toBe('31/12/1999');
+    expect(formatDate(new Date(2000, 0, 1))).toBe('01/01/2000');
+  });
+});

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,9 @@
+/**
+ * Formats a Date as dd/MM/yyyy, zero-padded, regardless of browser/i18n locale.
+ */
+export const formatDate = (date: Date): string => {
+  const day = String(date.getDate()).padStart(2, '0');
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const year = date.getFullYear();
+  return `${day}/${month}/${year}`;
+};

--- a/src/utils/pdfExport.ts
+++ b/src/utils/pdfExport.ts
@@ -2,6 +2,7 @@ import jsPDF from 'jspdf';
 import autoTable from 'jspdf-autotable';
 import { Log } from './types';
 import { formatMPG } from './calculations';
+import { formatDate } from './formatDate';
 
 /**
  * Generates and saves a PDF report of the fuel history.
@@ -48,7 +49,7 @@ export const exportLogsToPDF = (logs: Log[], userName: string, dateRange: string
   // --- Table Generation ---
   const tableHeaders = [['Date', 'Brand', `Cost (${homeCurrency})`, 'Original Cost', 'Odo (Km)', 'Dist (Km)', 'Fuel (L)', 'MPG']];
   const tableData = logs.map(log => [
-    log.timestamp?.toDate().toLocaleDateString('en-IE') ?? 'N/A',
+    log.timestamp?.toDate() ? formatDate(log.timestamp.toDate()) : 'N/A',
     log.brand || 'Unknown',
     `${homeCurrencySymbol}${log.cost?.toFixed(2)}`,
     log.currency && log.currency !== homeCurrency ? `${log.originalCost?.toFixed(2)} ${log.currency}` : '-',


### PR DESCRIPTION
Closes #127

## Changes
- Added `src/utils/formatDate.ts` — a locale-independent formatter that always renders `dd/MM/yyyy`, zero-padded.
- Replaced all inconsistent `toLocaleDateString(...)` call sites with the shared utility:
  - `StationDetail.tsx` (chart data + recent logs list)
  - `ApiTokenManager.tsx` (created/last-used dates)
  - `LogCard.tsx`
  - `HistoryPage.tsx` (table column, edit modal title, CSV/chart date field)
  - `FuelMapPage.tsx`
  - `pdfExport.ts` (table date column)
- Left `pdfExport.ts`'s `toLocaleString()` "Generated on" timestamp as-is — that's a full date+time generation stamp, a different concern from the displayed log dates.
- Removed now-unused `i18n.language` references in `HistoryPage.tsx` and `LogCard.tsx`.

## Testing
- Added `src/utils/formatDate.test.ts` covering zero-padding and year boundaries.
- Full unit test suite passes (176/176).
- `tsc --noEmit` passes with no errors.