### PR TITLE
Resolve #72: Guard against infinite reload loop on chunk fetch failure

### DIFF
--- a/src/components/AuthenticatedApp.tsx
+++ b/src/components/AuthenticatedApp.tsx
@@ -12,14 +12,29 @@ import { useRemoteConfig } from '../context/RemoteConfigContext';
 // Wraps React.lazy with a single reload on chunk fetch failure.
 // This handles the stale-PWA-cache scenario where a new deploy renames
 // chunk files and an old service worker can no longer serve the old hash.
+// Guarded by sessionStorage so a chunk that still 404s after the reload
+// (e.g. CDN propagation lag, offline) falls through to the route's
+// ErrorBoundary instead of reload-looping forever.
+const CHUNK_RELOAD_KEY = 'fuelog-chunk-reload-attempted';
+
 function lazyWithRetry<T extends React.ComponentType<React.ComponentProps<T>>>(
   factory: () => Promise<{ default: T }>
 ) {
   return lazy(() =>
-    factory().catch(() => {
-      window.location.reload();
-      return new Promise<never>(() => {});
-    })
+    factory()
+      .then((module) => {
+        sessionStorage.removeItem(CHUNK_RELOAD_KEY);
+        return module;
+      })
+      .catch((error) => {
+        const alreadyReloaded = sessionStorage.getItem(CHUNK_RELOAD_KEY) === 'true';
+        if (!alreadyReloaded) {
+          sessionStorage.setItem(CHUNK_RELOAD_KEY, 'true');
+          window.location.reload();
+          return new Promise<never>(() => {});
+        }
+        throw error;
+      })
   );
 }
 


### PR DESCRIPTION
Closes #72

## Root cause
`lazyWithRetry` (added pre-existing in `AuthenticatedApp.tsx`) already reloads the page once when a lazy-loaded route chunk 404s after a deploy renames the hashed asset (classic stale-PWA-cache scenario). However it had no guard: if the reload doesn't fix it (CDN propagation lag, the user is offline, or the chunk is genuinely gone), it would reload again and again — surfacing as a repeated `TypeError: Failed to fetch dynamically imported module` in Sentry, since `window.location.reload()` aborts the in-flight import before the route's `ErrorBoundary` ever gets a chance to render a recoverable fallback.

## Changes
- Added a `sessionStorage` flag (`fuelog-chunk-reload-attempted`) so the reload-on-failure only fires once per session.
- On a second failure, the error is rethrown so the existing per-route `ErrorBoundary` catches it, shows the "Something went wrong" fallback, and reports to Sentry with full context instead of looping.
- The flag is cleared as soon as any chunk loads successfully, so a future deploy can still trigger one reload.

## Testing
- `tsc --noEmit` passes.
- Full unit suite passes (176/176) — no existing tests target this lazy-loading wrapper directly; behavior was verified by code inspection given the difficulty of mocking dynamic `import()` failure/reload in jsdom.