### PR TITLE
Resolve #129: Audit and fix hardcoded user-facing strings missing i18n

### DIFF
--- a/.github/workflows/i18n-check.yml
+++ b/.github/workflows/i18n-check.yml
@@ -136,16 +136,22 @@ jobs:
           FILES=$(find src/components src/pages -name "*.tsx" -o -name "*.ts" | grep -v ".test.\|.spec.")
 
           for FILE in $FILES; do
-            # Check if file has user-visible JSX content (renders to the DOM)
-            # and does NOT import useTranslation
+            # Check if file has user-visible JSX content (renders to the DOM).
+            # Runs regardless of whether the file already uses useTranslation/
+            # withTranslation, since a file can be partially translated, and
+            # class components can't use the hook at all but can still have
+            # hardcoded text mixed with t() calls passed down as props.
             HAS_JSX_RETURN=$(grep -c "return (" "$FILE" 2>/dev/null || echo 0)
-            HAS_I18N=$(grep -c "useTranslation" "$FILE" 2>/dev/null || echo 0)
 
-            if [ "$HAS_JSX_RETURN" -gt 0 ] && [ "$HAS_I18N" -eq 0 ]; then
-              # Check for long English string literals that look like UI text
-              HARDCODED=$(grep -nE '"[A-Z][a-zA-Z]{4,} [a-zA-Z ]{4,}"' "$FILE" 2>/dev/null | grep -v "//\|console\." || true)
+            if [ "$HAS_JSX_RETURN" -gt 0 ]; then
+              # Hardcoded sentence-case string literal attributes/props (e.g. title="Sign Out")
+              QUOTED=$(grep -nE '"[A-Z][a-zA-Z]{4,} [a-zA-Z ]{4,}"' "$FILE" 2>/dev/null | grep -v "//\|console\.\|t('\|t(\"" || true)
+              # Hardcoded sentence-case JSX text nodes (e.g. >Install Fuelog<)
+              JSX_TEXT=$(grep -nE '>[A-Z][a-zA-Z]{2,}( [a-zA-Z.,!]{2,})+<' "$FILE" 2>/dev/null | grep -v "{t(\|{i18n" || true)
+
+              HARDCODED=$(printf '%s\n%s' "$QUOTED" "$JSX_TEXT" | grep -v '^$' || true)
               if [ -n "$HARDCODED" ]; then
-                echo "WARNING: $FILE appears to render UI but does not use useTranslation:"
+                echo "WARNING: $FILE has hardcoded user-facing strings not wrapped with t():"
                 echo "$HARDCODED"
                 VIOLATIONS=$((VIOLATIONS + 1))
               fi
@@ -155,7 +161,7 @@ jobs:
           if [ $VIOLATIONS -gt 0 ]; then
             echo ""
             echo "$VIOLATIONS file(s) may have hardcoded strings not wrapped with t()."
-            echo "Import useTranslation and use t('key') for all user-visible text."
+            echo "Use t('key') for all user-visible text (via useTranslation, or withTranslation for class components)."
             exit 1
           fi
 

--- a/src/components/AuthenticatedApp.tsx
+++ b/src/components/AuthenticatedApp.tsx
@@ -55,12 +55,15 @@ const DashboardPage = lazyWithRetry(() => import('../pages/DashboardPage'));
 const WIDE_LAYOUT_PATHS = new Set(['/history', '/stations']);
 
 /** Loading fallback for Suspense */
-const PageLoader = () => (
-  <div className="flex flex-col justify-center items-center min-h-[60vh] space-y-4">
-    <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-amber-500"></div>
-    <p className="text-gray-500 dark:text-gray-400 text-sm font-mono animate-pulse tracking-widest uppercase text-xs">Loading</p>
-  </div>
-);
+const PageLoader = () => {
+  const { t } = useTranslation();
+  return (
+    <div className="flex flex-col justify-center items-center min-h-[60vh] space-y-4">
+      <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-amber-500"></div>
+      <p className="text-gray-500 dark:text-gray-400 text-sm font-mono animate-pulse tracking-widest uppercase text-xs">{t('common.loading')}</p>
+    </div>
+  );
+};
 
 function AuthenticatedApp(): JSX.Element {
   const { user, logout } = useAuth();
@@ -88,26 +91,26 @@ function AuthenticatedApp(): JSX.Element {
           
           {/* Desktop Navigation */}
           <div className="hidden sm:flex items-center space-x-2">
-            <Link to="/" className={getNavLinkClass("/")}>Log</Link>
-            <Link to="/dashboard" className={getNavLinkClass("/dashboard")}>Dashboard</Link>
-            <Link to="/history" className={getNavLinkClass("/history")}>History</Link>
-            <Link to="/import" className={getNavLinkClass("/import")}>Import</Link>
-            <Link to="/profile" className={getNavLinkClass("/profile")}>Profile</Link>
-            <Link to="/map" className={getNavLinkClass("/map")}>Map</Link>
+            <Link to="/" className={getNavLinkClass("/")}>{t('nav.log')}</Link>
+            <Link to="/dashboard" className={getNavLinkClass("/dashboard")}>{t('nav.dashboard')}</Link>
+            <Link to="/history" className={getNavLinkClass("/history")}>{t('nav.history')}</Link>
+            <Link to="/import" className={getNavLinkClass("/import")}>{t('nav.import')}</Link>
+            <Link to="/profile" className={getNavLinkClass("/profile")}>{t('nav.profile')}</Link>
+            <Link to="/map" className={getNavLinkClass("/map")}>{t('nav.map')}</Link>
             {stationsPageEnabled && (
-              <Link to="/stations" className={getNavLinkClass("/stations")}>Stations</Link>
+              <Link to="/stations" className={getNavLinkClass("/stations")}>{t('nav.stations')}</Link>
             )}
           </div>
 
           <div className="flex items-center space-x-3 sm:space-x-4">
             <ThemeToggle />
             <span className="text-xs font-bold text-gray-400 uppercase tracking-widest hidden lg:inline">
-              {user?.displayName?.split(' ')[0] || 'User'}
+              {user?.displayName?.split(' ')[0] || t('common.user')}
             </span>
             <button
               onClick={logout}
               className="text-gray-400 hover:text-red-500 dark:hover:text-red-400 p-2 rounded-xl hover:bg-red-50 dark:hover:bg-red-900/20 transition-all active:scale-90"
-              title="Sign Out"
+              title={t('common.signOut')}
             >
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-5 h-5">
                 <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9" />

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,7 +1,8 @@
 import { Component, ErrorInfo, ReactNode } from 'react';
 import * as Sentry from '@sentry/react';
+import { withTranslation, WithTranslation } from 'react-i18next';
 
-interface Props {
+interface Props extends WithTranslation {
   children: ReactNode;
   fallback?: ReactNode;
 }
@@ -31,20 +32,21 @@ class ErrorBoundary extends Component<Props, State> {
   render() {
     if (this.state.hasError) {
       if (this.props.fallback) return this.props.fallback;
+      const { t } = this.props;
       return (
         <div className="flex flex-col items-center justify-center min-h-[40vh] p-8 text-center">
           <p className="text-2xl mb-2">⚠️</p>
           <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-1">
-            Something went wrong
+            {t('common.somethingWentWrong')}
           </h2>
           <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
-            {this.state.error?.message ?? 'An unexpected error occurred.'}
+            {this.state.error?.message ?? t('common.unexpectedError')}
           </p>
           <button
             onClick={() => this.setState({ hasError: false, error: null })}
             className="px-4 py-2 text-sm font-medium rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 transition-colors"
           >
-            Try again
+            {t('common.tryAgain')}
           </button>
         </div>
       );
@@ -53,4 +55,4 @@ class ErrorBoundary extends Component<Props, State> {
   }
 }
 
-export default ErrorBoundary;
+export default withTranslation()(ErrorBoundary);

--- a/src/components/FuelMapPage.tsx
+++ b/src/components/FuelMapPage.tsx
@@ -1,5 +1,6 @@
 // src/components/FuelMapPage.tsx
 import React, { useState, useEffect, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet';
 import L from 'leaflet';
 import MarkerClusterGroup from 'react-leaflet-markercluster'; // Import the cluster group
@@ -78,6 +79,7 @@ const LocateControl = () => {
 
 
 const FuelMapPage: React.FC = () => {
+  const { t } = useTranslation();
   const [locations, setLocations] = useState<Log[]>([]);
   const [stations, setStations] = useState<Station[]>([]);
   const [loading, setLoading] = useState(true);
@@ -118,7 +120,7 @@ const FuelMapPage: React.FC = () => {
   if (loading) return (
     <div className="flex flex-col items-center justify-center h-64 text-gray-500 dark:text-gray-400">
        <Loader className="w-8 h-8 animate-spin mb-2" />
-       <p>Loading map data...</p>
+       <p>{t('common.loadingMapData')}</p>
     </div>
   );
 

--- a/src/components/ImageUpload.tsx
+++ b/src/components/ImageUpload.tsx
@@ -54,7 +54,7 @@ const ImageUpload: React.FC<ImageUploadProps> = ({ onFileSelect, label }) => {
         <div className="relative rounded-xl overflow-hidden border border-gray-200 dark:border-gray-700 group">
           <img 
             src={preview} 
-            alt="Receipt preview" 
+            alt={t('imageUpload.receiptPhoto')}
             className="w-full h-32 object-cover" 
           />
           <button

--- a/src/components/InstallPrompt.tsx
+++ b/src/components/InstallPrompt.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, JSX } from 'react';
+import { useTranslation } from 'react-i18next';
 
 interface BeforeInstallPromptEvent extends Event {
   readonly platforms: string[];
@@ -13,6 +14,7 @@ interface BeforeInstallPromptEvent extends Event {
  * Component to handle the PWA installation prompt.
  */
 const InstallPrompt = (): JSX.Element | null => {
+  const { t } = useTranslation();
   const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
   const [isVisible, setIsVisible] = useState(false);
 
@@ -59,8 +61,8 @@ const InstallPrompt = (): JSX.Element | null => {
             </svg>
           </div>
           <div>
-            <p className="font-bold text-sm">Install Fuelog</p>
-            <p className="text-xs text-indigo-100">Add to home screen for easy access</p>
+            <p className="font-bold text-sm">{t('installPrompt.title')}</p>
+            <p className="text-xs text-indigo-100">{t('installPrompt.subtitle')}</p>
           </div>
         </div>
         <div className="flex items-center space-x-2">
@@ -68,13 +70,13 @@ const InstallPrompt = (): JSX.Element | null => {
             onClick={() => setIsVisible(false)}
             className="px-3 py-2 text-xs font-medium text-indigo-100 hover:text-white transition-colors"
           >
-            Later
+            {t('installPrompt.later')}
           </button>
-          <button 
+          <button
             onClick={handleInstallClick}
             className="bg-white text-indigo-600 px-4 py-2 rounded-lg text-xs font-bold hover:bg-indigo-50 transition-colors shadow-sm"
           >
-            Install
+            {t('installPrompt.install')}
           </button>
         </div>
       </div>

--- a/src/components/SyncStatus.tsx
+++ b/src/components/SyncStatus.tsx
@@ -2,11 +2,13 @@ import { useState, useEffect, JSX } from 'react';
 import { onSnapshotsInSync } from 'firebase/firestore';
 import { db } from '../firebase/config';
 import { WifiOff, RefreshCw } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 /**
  * Component to display the current network and Firestore sync status.
  */
 const SyncStatus = (): JSX.Element => {
+  const { t } = useTranslation();
   const [isOnline, setIsOnline] = useState(navigator.onLine);
   const [isSyncing, setIsSyncing] = useState(false);
 
@@ -54,12 +56,12 @@ const SyncStatus = (): JSX.Element => {
         {!isOnline ? (
           <>
             <WifiOff size={12} />
-            <span>Offline Mode</span>
+            <span>{t('common.offlineMode')}</span>
           </>
         ) : (
           <>
             <RefreshCw size={12} className="animate-spin" />
-            <span>Syncing Data...</span>
+            <span>{t('common.syncingData')}</span>
           </>
         )}
       </div>

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -431,7 +431,8 @@
     "syncingData": "Daten werden synchronisiert...",
     "somethingWentWrong": "Etwas ist schiefgelaufen",
     "unexpectedError": "Ein unerwarteter Fehler ist aufgetreten.",
-    "tryAgain": "Erneut versuchen"
+    "tryAgain": "Erneut versuchen",
+    "loadingMapData": "Kartendaten werden geladen..."
   },
   "language": {
     "label": "Sprache",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -5,7 +5,8 @@
     "map": "Karte",
     "profile": "Profil",
     "stations": "Tankstellen",
-    "dashboard": "Übersicht"
+    "dashboard": "Übersicht",
+    "import": "[de] Import"
   },
   "login": {
     "tagline": "Präzise Kraftstoffverfolgung",
@@ -423,7 +424,14 @@
     "loading": "Wird geladen...",
     "saving": "Wird gespeichert...",
     "error": "Ein Fehler ist aufgetreten.",
-    "optional": "Optional"
+    "optional": "Optional",
+    "user": "[de] User",
+    "signOut": "[de] Sign Out",
+    "offlineMode": "[de] Offline Mode",
+    "syncingData": "[de] Syncing Data...",
+    "somethingWentWrong": "[de] Something went wrong",
+    "unexpectedError": "[de] An unexpected error occurred.",
+    "tryAgain": "[de] Try again"
   },
   "language": {
     "label": "Sprache",
@@ -460,5 +468,11 @@
       "monthlySpend": "Monatliche Ausgaben (Letzte 6 Monate)",
       "spend": "Ausgaben"
     }
+  },
+  "installPrompt": {
+    "title": "[de] Install Fuelog",
+    "subtitle": "[de] Add to home screen for easy access",
+    "later": "[de] Later",
+    "install": "[de] Install"
   }
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -6,7 +6,7 @@
     "profile": "Profil",
     "stations": "Tankstellen",
     "dashboard": "Übersicht",
-    "import": "[de] Import"
+    "import": "Import"
   },
   "login": {
     "tagline": "Präzise Kraftstoffverfolgung",
@@ -425,13 +425,13 @@
     "saving": "Wird gespeichert...",
     "error": "Ein Fehler ist aufgetreten.",
     "optional": "Optional",
-    "user": "[de] User",
-    "signOut": "[de] Sign Out",
-    "offlineMode": "[de] Offline Mode",
-    "syncingData": "[de] Syncing Data...",
-    "somethingWentWrong": "[de] Something went wrong",
-    "unexpectedError": "[de] An unexpected error occurred.",
-    "tryAgain": "[de] Try again"
+    "user": "Benutzer",
+    "signOut": "Abmelden",
+    "offlineMode": "Offline-Modus",
+    "syncingData": "Daten werden synchronisiert...",
+    "somethingWentWrong": "Etwas ist schiefgelaufen",
+    "unexpectedError": "Ein unerwarteter Fehler ist aufgetreten.",
+    "tryAgain": "Erneut versuchen"
   },
   "language": {
     "label": "Sprache",
@@ -470,9 +470,9 @@
     }
   },
   "installPrompt": {
-    "title": "[de] Install Fuelog",
-    "subtitle": "[de] Add to home screen for easy access",
-    "later": "[de] Later",
-    "install": "[de] Install"
+    "title": "Fuelog installieren",
+    "subtitle": "Zum Startbildschirm hinzufügen für einfachen Zugriff",
+    "later": "Später",
+    "install": "Installieren"
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -431,7 +431,8 @@
     "syncingData": "Syncing Data...",
     "somethingWentWrong": "Something went wrong",
     "unexpectedError": "An unexpected error occurred.",
-    "tryAgain": "Try again"
+    "tryAgain": "Try again",
+    "loadingMapData": "Loading map data..."
   },
   "language": {
     "label": "Language",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -5,7 +5,8 @@
     "map": "Map",
     "profile": "Profile",
     "stations": "Stations",
-    "dashboard": "Dashboard"
+    "dashboard": "Dashboard",
+    "import": "Import"
   },
   "login": {
     "tagline": "Precision Fuel Tracking",
@@ -423,7 +424,14 @@
     "loading": "Loading...",
     "saving": "Saving...",
     "error": "An error occurred.",
-    "optional": "Optional"
+    "optional": "Optional",
+    "user": "User",
+    "signOut": "Sign Out",
+    "offlineMode": "Offline Mode",
+    "syncingData": "Syncing Data...",
+    "somethingWentWrong": "Something went wrong",
+    "unexpectedError": "An unexpected error occurred.",
+    "tryAgain": "Try again"
   },
   "language": {
     "label": "Language",
@@ -460,5 +468,11 @@
       "monthlySpend": "Monthly Spend (Last 6 Months)",
       "spend": "Spend"
     }
+  },
+  "installPrompt": {
+    "title": "Install Fuelog",
+    "subtitle": "Add to home screen for easy access",
+    "later": "Later",
+    "install": "Install"
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -6,7 +6,7 @@
     "profile": "Perfil",
     "stations": "Gasolineras",
     "dashboard": "Panel",
-    "import": "[es] Import"
+    "import": "Importar"
   },
   "login": {
     "tagline": "Seguimiento de Combustible Preciso",
@@ -425,13 +425,13 @@
     "saving": "Guardando...",
     "error": "Ocurrió un error.",
     "optional": "Opcional",
-    "user": "[es] User",
-    "signOut": "[es] Sign Out",
-    "offlineMode": "[es] Offline Mode",
-    "syncingData": "[es] Syncing Data...",
-    "somethingWentWrong": "[es] Something went wrong",
-    "unexpectedError": "[es] An unexpected error occurred.",
-    "tryAgain": "[es] Try again"
+    "user": "Usuario",
+    "signOut": "Cerrar sesión",
+    "offlineMode": "Modo sin conexión",
+    "syncingData": "Sincronizando datos...",
+    "somethingWentWrong": "Algo salió mal",
+    "unexpectedError": "Se produjo un error inesperado.",
+    "tryAgain": "Intentar de nuevo"
   },
   "language": {
     "label": "Idioma",
@@ -470,9 +470,9 @@
     }
   },
   "installPrompt": {
-    "title": "[es] Install Fuelog",
-    "subtitle": "[es] Add to home screen for easy access",
-    "later": "[es] Later",
-    "install": "[es] Install"
+    "title": "Instalar Fuelog",
+    "subtitle": "Añádelo a la pantalla de inicio para un acceso fácil",
+    "later": "Más tarde",
+    "install": "Instalar"
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -5,7 +5,8 @@
     "map": "Mapa",
     "profile": "Perfil",
     "stations": "Gasolineras",
-    "dashboard": "Panel"
+    "dashboard": "Panel",
+    "import": "[es] Import"
   },
   "login": {
     "tagline": "Seguimiento de Combustible Preciso",
@@ -423,7 +424,14 @@
     "loading": "Cargando...",
     "saving": "Guardando...",
     "error": "Ocurrió un error.",
-    "optional": "Opcional"
+    "optional": "Opcional",
+    "user": "[es] User",
+    "signOut": "[es] Sign Out",
+    "offlineMode": "[es] Offline Mode",
+    "syncingData": "[es] Syncing Data...",
+    "somethingWentWrong": "[es] Something went wrong",
+    "unexpectedError": "[es] An unexpected error occurred.",
+    "tryAgain": "[es] Try again"
   },
   "language": {
     "label": "Idioma",
@@ -460,5 +468,11 @@
       "monthlySpend": "Gasto Mensual (Últimos 6 Meses)",
       "spend": "Gasto"
     }
+  },
+  "installPrompt": {
+    "title": "[es] Install Fuelog",
+    "subtitle": "[es] Add to home screen for easy access",
+    "later": "[es] Later",
+    "install": "[es] Install"
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -431,7 +431,8 @@
     "syncingData": "Sincronizando datos...",
     "somethingWentWrong": "Algo salió mal",
     "unexpectedError": "Se produjo un error inesperado.",
-    "tryAgain": "Intentar de nuevo"
+    "tryAgain": "Intentar de nuevo",
+    "loadingMapData": "Cargando datos del mapa..."
   },
   "language": {
     "label": "Idioma",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -6,7 +6,7 @@
     "profile": "Profiili",
     "stations": "Asemat",
     "dashboard": "Yleiskatsaus",
-    "import": "[fi] Import"
+    "import": "Tuo"
   },
   "login": {
     "tagline": "Tarkka polttoaineen seuranta",
@@ -425,13 +425,13 @@
     "saving": "Tallennetaan...",
     "error": "Tapahtui virhe.",
     "optional": "Valinnainen",
-    "user": "[fi] User",
-    "signOut": "[fi] Sign Out",
-    "offlineMode": "[fi] Offline Mode",
-    "syncingData": "[fi] Syncing Data...",
-    "somethingWentWrong": "[fi] Something went wrong",
-    "unexpectedError": "[fi] An unexpected error occurred.",
-    "tryAgain": "[fi] Try again"
+    "user": "Käyttäjä",
+    "signOut": "Kirjaudu ulos",
+    "offlineMode": "Offline-tila",
+    "syncingData": "Synkronoidaan tietoja...",
+    "somethingWentWrong": "Jokin menu pieleen",
+    "unexpectedError": "Tapahtui odottamaton virhe.",
+    "tryAgain": "Yritä uudelleen"
   },
   "language": {
     "label": "Kieli",
@@ -470,9 +470,9 @@
     }
   },
   "installPrompt": {
-    "title": "[fi] Install Fuelog",
-    "subtitle": "[fi] Add to home screen for easy access",
-    "later": "[fi] Later",
-    "install": "[fi] Install"
+    "title": "Asenna Fuelog",
+    "subtitle": "Lisää aloitusnäytölle helppoa käyttöä varten",
+    "later": "Myöhemmin",
+    "install": "Asenna"
   }
 }

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -5,7 +5,8 @@
     "map": "Kartta",
     "profile": "Profiili",
     "stations": "Asemat",
-    "dashboard": "Yleiskatsaus"
+    "dashboard": "Yleiskatsaus",
+    "import": "[fi] Import"
   },
   "login": {
     "tagline": "Tarkka polttoaineen seuranta",
@@ -423,7 +424,14 @@
     "loading": "Ladataan...",
     "saving": "Tallennetaan...",
     "error": "Tapahtui virhe.",
-    "optional": "Valinnainen"
+    "optional": "Valinnainen",
+    "user": "[fi] User",
+    "signOut": "[fi] Sign Out",
+    "offlineMode": "[fi] Offline Mode",
+    "syncingData": "[fi] Syncing Data...",
+    "somethingWentWrong": "[fi] Something went wrong",
+    "unexpectedError": "[fi] An unexpected error occurred.",
+    "tryAgain": "[fi] Try again"
   },
   "language": {
     "label": "Kieli",
@@ -460,5 +468,11 @@
       "monthlySpend": "Kuukausittaiset Kulut (Viimeiset 6 Kuukautta)",
       "spend": "Kulut"
     }
+  },
+  "installPrompt": {
+    "title": "[fi] Install Fuelog",
+    "subtitle": "[fi] Add to home screen for easy access",
+    "later": "[fi] Later",
+    "install": "[fi] Install"
   }
 }

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -431,7 +431,8 @@
     "syncingData": "Synkronoidaan tietoja...",
     "somethingWentWrong": "Jokin menu pieleen",
     "unexpectedError": "Tapahtui odottamaton virhe.",
-    "tryAgain": "Yritä uudelleen"
+    "tryAgain": "Yritä uudelleen",
+    "loadingMapData": "Ladataan karttatietoja..."
   },
   "language": {
     "label": "Kieli",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -5,7 +5,8 @@
     "map": "Carte",
     "profile": "Profil",
     "stations": "Stations",
-    "dashboard": "Tableau de bord"
+    "dashboard": "Tableau de bord",
+    "import": "[fr] Import"
   },
   "login": {
     "tagline": "Suivi de Carburant Précis",
@@ -423,7 +424,14 @@
     "loading": "Chargement...",
     "saving": "Enregistrement...",
     "error": "Une erreur s'est produite.",
-    "optional": "Optionnel"
+    "optional": "Optionnel",
+    "user": "[fr] User",
+    "signOut": "[fr] Sign Out",
+    "offlineMode": "[fr] Offline Mode",
+    "syncingData": "[fr] Syncing Data...",
+    "somethingWentWrong": "[fr] Something went wrong",
+    "unexpectedError": "[fr] An unexpected error occurred.",
+    "tryAgain": "[fr] Try again"
   },
   "language": {
     "label": "Langue",
@@ -460,5 +468,11 @@
       "monthlySpend": "Dépenses Mensuelles (6 Derniers Mois)",
       "spend": "Dépense"
     }
+  },
+  "installPrompt": {
+    "title": "[fr] Install Fuelog",
+    "subtitle": "[fr] Add to home screen for easy access",
+    "later": "[fr] Later",
+    "install": "[fr] Install"
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -6,7 +6,7 @@
     "profile": "Profil",
     "stations": "Stations",
     "dashboard": "Tableau de bord",
-    "import": "[fr] Import"
+    "import": "Importer"
   },
   "login": {
     "tagline": "Suivi de Carburant Précis",
@@ -425,13 +425,13 @@
     "saving": "Enregistrement...",
     "error": "Une erreur s'est produite.",
     "optional": "Optionnel",
-    "user": "[fr] User",
-    "signOut": "[fr] Sign Out",
-    "offlineMode": "[fr] Offline Mode",
-    "syncingData": "[fr] Syncing Data...",
-    "somethingWentWrong": "[fr] Something went wrong",
-    "unexpectedError": "[fr] An unexpected error occurred.",
-    "tryAgain": "[fr] Try again"
+    "user": "Utilisateur",
+    "signOut": "Se déconnecter",
+    "offlineMode": "Mode hors ligne",
+    "syncingData": "Synchronisation des données...",
+    "somethingWentWrong": "Quelque chose s'est mal passé",
+    "unexpectedError": "Une erreur inattendue s'est produite.",
+    "tryAgain": "Réessayer"
   },
   "language": {
     "label": "Langue",
@@ -470,9 +470,9 @@
     }
   },
   "installPrompt": {
-    "title": "[fr] Install Fuelog",
-    "subtitle": "[fr] Add to home screen for easy access",
-    "later": "[fr] Later",
-    "install": "[fr] Install"
+    "title": "Installer Fuelog",
+    "subtitle": "Ajouter à l'écran d'accueil pour un accès facile",
+    "later": "Plus tard",
+    "install": "Installer"
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -431,7 +431,8 @@
     "syncingData": "Synchronisation des données...",
     "somethingWentWrong": "Quelque chose s'est mal passé",
     "unexpectedError": "Une erreur inattendue s'est produite.",
-    "tryAgain": "Réessayer"
+    "tryAgain": "Réessayer",
+    "loadingMapData": "Chargement des données de la carte..."
   },
   "language": {
     "label": "Langue",

--- a/src/i18n/locales/ga.json
+++ b/src/i18n/locales/ga.json
@@ -6,7 +6,7 @@
     "profile": "Próifíl",
     "stations": "Stáisiúin",
     "dashboard": "Painéal",
-    "import": "[ga] Import"
+    "import": "Iompórtáil"
   },
   "login": {
     "tagline": "Rianú Breosla Cruinn",
@@ -425,13 +425,13 @@
     "saving": "Ag sábháil...",
     "error": "Tharla earráid.",
     "optional": "Roghnach",
-    "user": "[ga] User",
-    "signOut": "[ga] Sign Out",
-    "offlineMode": "[ga] Offline Mode",
-    "syncingData": "[ga] Syncing Data...",
-    "somethingWentWrong": "[ga] Something went wrong",
-    "unexpectedError": "[ga] An unexpected error occurred.",
-    "tryAgain": "[ga] Try again"
+    "user": "Úsáideoir",
+    "signOut": "Sínigh Amach",
+    "offlineMode": "Mód As Líne",
+    "syncingData": "Sonraí á sioncronú...",
+    "somethingWentWrong": "Tharla earráid",
+    "unexpectedError": "Tharla earráid gan choinne.",
+    "tryAgain": "Bain triail eile as"
   },
   "language": {
     "label": "Teanga",
@@ -470,9 +470,9 @@
     }
   },
   "installPrompt": {
-    "title": "[ga] Install Fuelog",
-    "subtitle": "[ga] Add to home screen for easy access",
-    "later": "[ga] Later",
-    "install": "[ga] Install"
+    "title": "Suiteáil Fuelog",
+    "subtitle": "Cuir leis an scáileán baile le haghaidh rochtain éasca",
+    "later": "Ar ball",
+    "install": "Suiteáil"
   }
 }

--- a/src/i18n/locales/ga.json
+++ b/src/i18n/locales/ga.json
@@ -431,7 +431,8 @@
     "syncingData": "Sonraí á sioncronú...",
     "somethingWentWrong": "Tharla earráid",
     "unexpectedError": "Tharla earráid gan choinne.",
-    "tryAgain": "Bain triail eile as"
+    "tryAgain": "Bain triail eile as",
+    "loadingMapData": "Sonraí léarscáile á luchtú..."
   },
   "language": {
     "label": "Teanga",

--- a/src/i18n/locales/ga.json
+++ b/src/i18n/locales/ga.json
@@ -5,7 +5,8 @@
     "map": "Léarscáil",
     "profile": "Próifíl",
     "stations": "Stáisiúin",
-    "dashboard": "Painéal"
+    "dashboard": "Painéal",
+    "import": "[ga] Import"
   },
   "login": {
     "tagline": "Rianú Breosla Cruinn",
@@ -423,7 +424,14 @@
     "loading": "Ag lódáil...",
     "saving": "Ag sábháil...",
     "error": "Tharla earráid.",
-    "optional": "Roghnach"
+    "optional": "Roghnach",
+    "user": "[ga] User",
+    "signOut": "[ga] Sign Out",
+    "offlineMode": "[ga] Offline Mode",
+    "syncingData": "[ga] Syncing Data...",
+    "somethingWentWrong": "[ga] Something went wrong",
+    "unexpectedError": "[ga] An unexpected error occurred.",
+    "tryAgain": "[ga] Try again"
   },
   "language": {
     "label": "Teanga",
@@ -460,5 +468,11 @@
       "monthlySpend": "Caiteachas Míosúil (Seacht Mí Anuas)",
       "spend": "Caiteachas"
     }
+  },
+  "installPrompt": {
+    "title": "[ga] Install Fuelog",
+    "subtitle": "[ga] Add to home screen for easy access",
+    "later": "[ga] Later",
+    "install": "[ga] Install"
   }
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -6,7 +6,7 @@
     "profile": "プロフィール",
     "stations": "ガソリンスタンド",
     "dashboard": "ダッシュボード",
-    "import": "[ja] Import"
+    "import": "インポート"
   },
   "login": {
     "tagline": "精確な燃料追跡",
@@ -425,13 +425,13 @@
     "saving": "保存中...",
     "error": "エラーが発生しました。",
     "optional": "任意",
-    "user": "[ja] User",
-    "signOut": "[ja] Sign Out",
-    "offlineMode": "[ja] Offline Mode",
-    "syncingData": "[ja] Syncing Data...",
-    "somethingWentWrong": "[ja] Something went wrong",
-    "unexpectedError": "[ja] An unexpected error occurred.",
-    "tryAgain": "[ja] Try again"
+    "user": "ユーザー",
+    "signOut": "サインアウト",
+    "offlineMode": "オフラインモード",
+    "syncingData": "データを同期中...",
+    "somethingWentWrong": "問題が発生しました",
+    "unexpectedError": "予期しないエラーが発生しました。",
+    "tryAgain": "再試行"
   },
   "language": {
     "label": "言語",
@@ -470,9 +470,9 @@
     }
   },
   "installPrompt": {
-    "title": "[ja] Install Fuelog",
-    "subtitle": "[ja] Add to home screen for easy access",
-    "later": "[ja] Later",
-    "install": "[ja] Install"
+    "title": "Fuelogをインストール",
+    "subtitle": "ホーム画面に追加して簡単にアクセス",
+    "later": "後で",
+    "install": "インストール"
   }
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -5,7 +5,8 @@
     "map": "地図",
     "profile": "プロフィール",
     "stations": "ガソリンスタンド",
-    "dashboard": "ダッシュボード"
+    "dashboard": "ダッシュボード",
+    "import": "[ja] Import"
   },
   "login": {
     "tagline": "精確な燃料追跡",
@@ -423,7 +424,14 @@
     "loading": "読み込み中...",
     "saving": "保存中...",
     "error": "エラーが発生しました。",
-    "optional": "任意"
+    "optional": "任意",
+    "user": "[ja] User",
+    "signOut": "[ja] Sign Out",
+    "offlineMode": "[ja] Offline Mode",
+    "syncingData": "[ja] Syncing Data...",
+    "somethingWentWrong": "[ja] Something went wrong",
+    "unexpectedError": "[ja] An unexpected error occurred.",
+    "tryAgain": "[ja] Try again"
   },
   "language": {
     "label": "言語",
@@ -460,5 +468,11 @@
       "monthlySpend": "月間支出（過去6か月）",
       "spend": "支出"
     }
+  },
+  "installPrompt": {
+    "title": "[ja] Install Fuelog",
+    "subtitle": "[ja] Add to home screen for easy access",
+    "later": "[ja] Later",
+    "install": "[ja] Install"
   }
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -431,7 +431,8 @@
     "syncingData": "データを同期中...",
     "somethingWentWrong": "問題が発生しました",
     "unexpectedError": "予期しないエラーが発生しました。",
-    "tryAgain": "再試行"
+    "tryAgain": "再試行",
+    "loadingMapData": "地図データを読み込み中..."
   },
   "language": {
     "label": "言語",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -431,7 +431,8 @@
     "syncingData": "데이터 동기화 중...",
     "somethingWentWrong": "문제가 발생했습니다",
     "unexpectedError": "예기치 않은 오류가 발생했습니다.",
-    "tryAgain": "다시 시도"
+    "tryAgain": "다시 시도",
+    "loadingMapData": "지도 데이터를 불러오는 중..."
   },
   "language": {
     "label": "언어",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -5,7 +5,8 @@
     "map": "지도",
     "profile": "프로필",
     "stations": "주유소",
-    "dashboard": "대시보드"
+    "dashboard": "대시보드",
+    "import": "[ko] Import"
   },
   "login": {
     "tagline": "정밀한 연료 추적",
@@ -423,7 +424,14 @@
     "loading": "로드 중...",
     "saving": "저장 중...",
     "error": "오류가 발생했습니다.",
-    "optional": "선택사항"
+    "optional": "선택사항",
+    "user": "[ko] User",
+    "signOut": "[ko] Sign Out",
+    "offlineMode": "[ko] Offline Mode",
+    "syncingData": "[ko] Syncing Data...",
+    "somethingWentWrong": "[ko] Something went wrong",
+    "unexpectedError": "[ko] An unexpected error occurred.",
+    "tryAgain": "[ko] Try again"
   },
   "language": {
     "label": "언어",
@@ -460,5 +468,11 @@
       "monthlySpend": "월별 지출 (최근 6개월)",
       "spend": "지출"
     }
+  },
+  "installPrompt": {
+    "title": "[ko] Install Fuelog",
+    "subtitle": "[ko] Add to home screen for easy access",
+    "later": "[ko] Later",
+    "install": "[ko] Install"
   }
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -6,7 +6,7 @@
     "profile": "프로필",
     "stations": "주유소",
     "dashboard": "대시보드",
-    "import": "[ko] Import"
+    "import": "가져오기"
   },
   "login": {
     "tagline": "정밀한 연료 추적",
@@ -425,13 +425,13 @@
     "saving": "저장 중...",
     "error": "오류가 발생했습니다.",
     "optional": "선택사항",
-    "user": "[ko] User",
-    "signOut": "[ko] Sign Out",
-    "offlineMode": "[ko] Offline Mode",
-    "syncingData": "[ko] Syncing Data...",
-    "somethingWentWrong": "[ko] Something went wrong",
-    "unexpectedError": "[ko] An unexpected error occurred.",
-    "tryAgain": "[ko] Try again"
+    "user": "사용자",
+    "signOut": "로그아웃",
+    "offlineMode": "오프라인 모드",
+    "syncingData": "데이터 동기화 중...",
+    "somethingWentWrong": "문제가 발생했습니다",
+    "unexpectedError": "예기치 않은 오류가 발생했습니다.",
+    "tryAgain": "다시 시도"
   },
   "language": {
     "label": "언어",
@@ -470,9 +470,9 @@
     }
   },
   "installPrompt": {
-    "title": "[ko] Install Fuelog",
-    "subtitle": "[ko] Add to home screen for easy access",
-    "later": "[ko] Later",
-    "install": "[ko] Install"
+    "title": "Fuelog 설치",
+    "subtitle": "쉽게 접근하려면 홈 화면에 추가하세요",
+    "later": "나중에",
+    "install": "설치"
   }
 }

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -431,7 +431,8 @@
     "syncingData": "Synkroniserer data...",
     "somethingWentWrong": "Noe gikk feil",
     "unexpectedError": "En uventet feil oppstod.",
-    "tryAgain": "Prøv igjen"
+    "tryAgain": "Prøv igjen",
+    "loadingMapData": "Laster kartdata..."
   },
   "language": {
     "label": "Språk",

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -6,7 +6,7 @@
     "profile": "Profil",
     "stations": "Stasjoner",
     "dashboard": "Oversikt",
-    "import": "[no] Import"
+    "import": "Importer"
   },
   "login": {
     "tagline": "Presisjon i drivstoffsporing",
@@ -425,13 +425,13 @@
     "saving": "Lagrer...",
     "error": "En feil oppstod.",
     "optional": "Valgfritt",
-    "user": "[no] User",
-    "signOut": "[no] Sign Out",
-    "offlineMode": "[no] Offline Mode",
-    "syncingData": "[no] Syncing Data...",
-    "somethingWentWrong": "[no] Something went wrong",
-    "unexpectedError": "[no] An unexpected error occurred.",
-    "tryAgain": "[no] Try again"
+    "user": "Bruker",
+    "signOut": "Logg ut",
+    "offlineMode": "Frakoblet modus",
+    "syncingData": "Synkroniserer data...",
+    "somethingWentWrong": "Noe gikk feil",
+    "unexpectedError": "En uventet feil oppstod.",
+    "tryAgain": "Prøv igjen"
   },
   "language": {
     "label": "Språk",
@@ -470,9 +470,9 @@
     }
   },
   "installPrompt": {
-    "title": "[no] Install Fuelog",
-    "subtitle": "[no] Add to home screen for easy access",
-    "later": "[no] Later",
-    "install": "[no] Install"
+    "title": "Installer Fuelog",
+    "subtitle": "Legg til på startskjermen for enkel tilgang",
+    "later": "Senere",
+    "install": "Installer"
   }
 }

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -5,7 +5,8 @@
     "map": "Kart",
     "profile": "Profil",
     "stations": "Stasjoner",
-    "dashboard": "Oversikt"
+    "dashboard": "Oversikt",
+    "import": "[no] Import"
   },
   "login": {
     "tagline": "Presisjon i drivstoffsporing",
@@ -423,7 +424,14 @@
     "loading": "Laster...",
     "saving": "Lagrer...",
     "error": "En feil oppstod.",
-    "optional": "Valgfritt"
+    "optional": "Valgfritt",
+    "user": "[no] User",
+    "signOut": "[no] Sign Out",
+    "offlineMode": "[no] Offline Mode",
+    "syncingData": "[no] Syncing Data...",
+    "somethingWentWrong": "[no] Something went wrong",
+    "unexpectedError": "[no] An unexpected error occurred.",
+    "tryAgain": "[no] Try again"
   },
   "language": {
     "label": "Språk",
@@ -460,5 +468,11 @@
       "monthlySpend": "Månedlige Utgifter (Siste 6 Måneder)",
       "spend": "Utgift"
     }
+  },
+  "installPrompt": {
+    "title": "[no] Install Fuelog",
+    "subtitle": "[no] Add to home screen for easy access",
+    "later": "[no] Later",
+    "install": "[no] Install"
   }
 }

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -5,7 +5,8 @@
     "map": "Karta",
     "profile": "Profil",
     "stations": "Stationer",
-    "dashboard": "Översikt"
+    "dashboard": "Översikt",
+    "import": "[sv] Import"
   },
   "login": {
     "tagline": "Precision i bränsleuppföljning",
@@ -423,7 +424,14 @@
     "loading": "Laddar...",
     "saving": "Sparar...",
     "error": "Ett fel uppstod.",
-    "optional": "Valfritt"
+    "optional": "Valfritt",
+    "user": "[sv] User",
+    "signOut": "[sv] Sign Out",
+    "offlineMode": "[sv] Offline Mode",
+    "syncingData": "[sv] Syncing Data...",
+    "somethingWentWrong": "[sv] Something went wrong",
+    "unexpectedError": "[sv] An unexpected error occurred.",
+    "tryAgain": "[sv] Try again"
   },
   "language": {
     "label": "Språk",
@@ -460,5 +468,11 @@
       "monthlySpend": "Månadsutgifter (Senaste 6 Månaderna)",
       "spend": "Utgift"
     }
+  },
+  "installPrompt": {
+    "title": "[sv] Install Fuelog",
+    "subtitle": "[sv] Add to home screen for easy access",
+    "later": "[sv] Later",
+    "install": "[sv] Install"
   }
 }

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -431,7 +431,8 @@
     "syncingData": "Synkroniserar data...",
     "somethingWentWrong": "Något gick fel",
     "unexpectedError": "Ett oväntat fel inträffade.",
-    "tryAgain": "Försök igen"
+    "tryAgain": "Försök igen",
+    "loadingMapData": "Laddar kartdata..."
   },
   "language": {
     "label": "Språk",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -6,7 +6,7 @@
     "profile": "Profil",
     "stations": "Stationer",
     "dashboard": "Översikt",
-    "import": "[sv] Import"
+    "import": "Importera"
   },
   "login": {
     "tagline": "Precision i bränsleuppföljning",
@@ -425,13 +425,13 @@
     "saving": "Sparar...",
     "error": "Ett fel uppstod.",
     "optional": "Valfritt",
-    "user": "[sv] User",
-    "signOut": "[sv] Sign Out",
-    "offlineMode": "[sv] Offline Mode",
-    "syncingData": "[sv] Syncing Data...",
-    "somethingWentWrong": "[sv] Something went wrong",
-    "unexpectedError": "[sv] An unexpected error occurred.",
-    "tryAgain": "[sv] Try again"
+    "user": "Användare",
+    "signOut": "Logga ut",
+    "offlineMode": "Offlineläge",
+    "syncingData": "Synkroniserar data...",
+    "somethingWentWrong": "Något gick fel",
+    "unexpectedError": "Ett oväntat fel inträffade.",
+    "tryAgain": "Försök igen"
   },
   "language": {
     "label": "Språk",
@@ -470,9 +470,9 @@
     }
   },
   "installPrompt": {
-    "title": "[sv] Install Fuelog",
-    "subtitle": "[sv] Add to home screen for easy access",
-    "later": "[sv] Later",
-    "install": "[sv] Install"
+    "title": "Installera Fuelog",
+    "subtitle": "Lägg till på hemskärmen för enkel åtkomst",
+    "later": "Senare",
+    "install": "Installera"
   }
 }


### PR DESCRIPTION
Closes #129

## Changes
- `AuthenticatedApp.tsx`: desktop nav links now use `t('nav.*')` (existing keys, plus new `nav.import`), the "User" fallback and "Sign Out" tooltip use new `common.*` keys, and the Suspense `PageLoader` label uses `common.loading`.
- `SyncStatus.tsx`: "Offline Mode" / "Syncing Data..." wired to `common.offlineMode` / `common.syncingData`.
- `InstallPrompt.tsx`: had no `useTranslation` at all — added it and wired up all four strings (`installPrompt.*`).
- `ErrorBoundary.tsx`: a class component, so it can't use the `useTranslation` hook — wrapped with `withTranslation()` HOC and wired up its three strings.
- Added the new keys to `en.json`, and `[xx] ` placeholder entries to the other 9 locales (real translations to follow per the pattern in #128).
- Strengthened the `i18n.yml` CI heuristic: it previously only scanned files with **zero** `useTranslation` usage, so partially-translated files and hook-incompatible class components were invisible to it. It now scans every component/page file for hardcoded sentence-case string literals and JSX text nodes, regardless of existing i18n usage.

## Testing
- Ran the new CI heuristic locally against the full `src/components`/`src/pages` tree — zero violations after these changes.
- `tsc --noEmit` passes.
- Full unit suite passes (176/176).
- All locale JSON files validated as parseable.