### PR TITLE
Resolve #130: Redesign Recent Logs list on StationDetail

### DIFF
--- a/src/components/StationDetail.tsx
+++ b/src/components/StationDetail.tsx
@@ -11,6 +11,7 @@ import { fetchFuelLogsByStationId, fetchStationById } from '../firebase/firestor
 import { formatDate } from '../utils/formatDate';
 
 const RECENT_LOGS_LIMIT = 12;
+const RECENT_LOGS_COLLAPSED_LIMIT = 5;
 
 interface StationDetailProps {
     stationId: string;
@@ -22,6 +23,7 @@ const StationDetail: React.FC<StationDetailProps> = ({ stationId }) => {
     const [fuelLogs, setFuelLogs] = useState<Log[]>([]);
     const [loading, setLoading] = useState<boolean>(true);
     const [error, setError] = useState<string | null>(null);
+    const [showAllLogs, setShowAllLogs] = useState(false);
 
     useEffect(() => {
         const loadStationData = async () => {
@@ -215,18 +217,31 @@ const StationDetail: React.FC<StationDetailProps> = ({ stationId }) => {
 
             <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3">{t('stationDetail.recentLogs')}</h3>
             {fuelLogs.length > 0 ? (
-                <div className="space-y-2 max-h-48 overflow-y-auto pr-2">
-                    {fuelLogs.map(log => (
-                        <div key={log.id} className="flex justify-between items-center bg-gray-50 dark:bg-gray-700 p-3 rounded-md">
-                            <p className="text-sm text-gray-900 dark:text-gray-100">
-                                {formatDate(log.timestamp.toDate())}
-                            </p>
-                            <p className="text-sm text-green-600 dark:text-green-400 font-medium">
-                                €{log.cost.toFixed(2)} ({log.fuelAmountLiters.toFixed(2)}L @ {isFinite(log.cost / log.fuelAmountLiters) ? (log.cost / log.fuelAmountLiters).toFixed(3) : t('stationTable.noData')}/L)
-                            </p>
-                        </div>
-                    ))}
-                </div>
+                <>
+                    <div className="space-y-2">
+                        {(showAllLogs ? fuelLogs : fuelLogs.slice(0, RECENT_LOGS_COLLAPSED_LIMIT)).map(log => (
+                            <div key={log.id} className="flex justify-between items-center bg-gray-50 dark:bg-gray-700 p-3 rounded-md">
+                                <p className="text-sm text-gray-900 dark:text-gray-100">
+                                    {formatDate(log.timestamp.toDate())}
+                                </p>
+                                <p className="text-sm text-green-600 dark:text-green-400 font-medium">
+                                    €{log.cost.toFixed(2)} ({log.fuelAmountLiters.toFixed(2)}L @ {isFinite(log.cost / log.fuelAmountLiters) ? (log.cost / log.fuelAmountLiters).toFixed(3) : t('stationTable.noData')}/L)
+                                </p>
+                            </div>
+                        ))}
+                    </div>
+                    {fuelLogs.length > RECENT_LOGS_COLLAPSED_LIMIT && (
+                        <button
+                            type="button"
+                            onClick={() => setShowAllLogs(prev => !prev)}
+                            className="mt-3 text-sm font-medium text-brand-primary hover:underline"
+                        >
+                            {showAllLogs
+                                ? t('stationDetail.showFewer')
+                                : t('stationDetail.showMore', { count: fuelLogs.length - RECENT_LOGS_COLLAPSED_LIMIT })}
+                        </button>
+                    )}
+                </>
             ) : (
                 <div className="text-center text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-700 p-4 rounded-md">
                     <p>{t('stationDetail.noLogsFound')}</p>

--- a/src/components/__tests__/StationDetail.test.tsx
+++ b/src/components/__tests__/StationDetail.test.tsx
@@ -1,5 +1,5 @@
 // src/components/__tests__/StationDetail.test.tsx
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen, waitFor, within, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import StationDetail from '../StationDetail';
 import { Log } from '../../utils/types';
@@ -30,6 +30,8 @@ vi.mock('react-i18next', () => ({
         'stationDetail.notEnoughDataForChart': 'Not enough data to display chart.',
         'stationDetail.recentLogs': 'Recent Logs',
         'stationDetail.noLogsFound': 'No fuel logs found for this station.',
+        'stationDetail.showMore': 'Show more',
+        'stationDetail.showFewer': 'Show fewer',
         'stationTable.noData': 'N/A', // from stationTable, used by stationDetail
       };
       return translations[key] || key;
@@ -228,6 +230,44 @@ describe('StationDetail', () => {
 
     await waitFor(() => {
       expect(fetchFuelLogsByStationId).toHaveBeenCalledWith(mockStationId, 12);
+    });
+  });
+
+  it('does not render a nested scroll container for the recent logs list', async () => {
+    vi.mocked(fetchFuelLogsByStationId).mockResolvedValue(mockLogs);
+    const { container } = render(<StationDetail stationId={mockStationId} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Recent Logs')).toBeInTheDocument();
+    });
+
+    expect(container.querySelector('.overflow-y-auto')).not.toBeInTheDocument();
+    expect(container.querySelector('.max-h-48')).not.toBeInTheDocument();
+  });
+
+  it('collapses logs beyond the default limit behind a "Show more" toggle', async () => {
+    const manyLogs: Log[] = Array.from({ length: 7 }, (_, i) => ({
+      ...mockLogs[0],
+      id: `log${i}`,
+      cost: 10 + i,
+    }));
+    vi.mocked(fetchFuelLogsByStationId).mockResolvedValue(manyLogs);
+    render(<StationDetail stationId={mockStationId} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('€10.00 (40.00L @ 0.250/L)')).toBeInTheDocument();
+    });
+
+    // Only the first 5 are shown by default
+    expect(screen.getByText('€14.00 (40.00L @ 0.350/L)')).toBeInTheDocument();
+    expect(screen.queryByText('€16.00 (40.00L @ 0.400/L)')).not.toBeInTheDocument();
+
+    const toggle = screen.getByText('Show more');
+    fireEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(screen.getByText('€16.00 (40.00L @ 0.400/L)')).toBeInTheDocument();
+      expect(screen.getByText('Show fewer')).toBeInTheDocument();
     });
   });
 });

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -44,7 +44,9 @@
     "recentLogs": "Letzte Einträge",
     "noLogsFound": "Keine Tankeinträge für diese Tankstelle gefunden.",
     "loading": "Tankstellendetails werden geladen...",
-    "errorLoading": "Tankstellendetails konnten nicht geladen werden. Bitte versuchen Sie es erneut."
+    "errorLoading": "Tankstellendetails konnten nicht geladen werden. Bitte versuchen Sie es erneut.",
+    "showMore": "{{count}} weitere anzeigen",
+    "showFewer": "Weniger anzeigen"
   },
   "quickLog": {
     "title": "Neuer Kraftstoffeintrag",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -44,7 +44,9 @@
     "recentLogs": "Recent Logs",
     "noLogsFound": "No fuel logs found for this station.",
     "loading": "Loading station details...",
-    "errorLoading": "Failed to load station details. Please try again."
+    "errorLoading": "Failed to load station details. Please try again.",
+    "showMore": "Show {{count}} more",
+    "showFewer": "Show fewer"
   },
   "quickLog": {
     "title": "Log New Fuel Entry",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -44,7 +44,9 @@
     "recentLogs": "Registros recientes",
     "noLogsFound": "No se encontraron registros de combustible para esta gasolinera.",
     "loading": "Cargando los detalles de la gasolinera...",
-    "errorLoading": "No se pudieron cargar los detalles de la gasolinera. Inténtalo de nuevo."
+    "errorLoading": "No se pudieron cargar los detalles de la gasolinera. Inténtalo de nuevo.",
+    "showMore": "Mostrar {{count}} más",
+    "showFewer": "Mostrar menos"
   },
   "quickLog": {
     "title": "Nuevo Registro de Combustible",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -44,7 +44,9 @@
     "recentLogs": "Viimeisimmät merkinnät",
     "noLogsFound": "Tälle asemalle ei löytynyt polttoainemerkintöjä.",
     "loading": "Ladataan aseman tietoja...",
-    "errorLoading": "Aseman tietojen lataaminen epäonnistui. Yritä uudelleen."
+    "errorLoading": "Aseman tietojen lataaminen epäonnistui. Yritä uudelleen.",
+    "showMore": "Näytä {{count}} lisää",
+    "showFewer": "Näytä vähemmän"
   },
   "quickLog": {
     "title": "Kirjaa uusi tankkaus",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -44,7 +44,9 @@
     "recentLogs": "Entrées récentes",
     "noLogsFound": "Aucune entrée de carburant trouvée pour cette station.",
     "loading": "Chargement des détails de la station...",
-    "errorLoading": "Impossible de charger les détails de la station. Veuillez réessayer."
+    "errorLoading": "Impossible de charger les détails de la station. Veuillez réessayer.",
+    "showMore": "Afficher {{count}} de plus",
+    "showFewer": "Afficher moins"
   },
   "quickLog": {
     "title": "Nouvelle Saisie de Carburant",

--- a/src/i18n/locales/ga.json
+++ b/src/i18n/locales/ga.json
@@ -44,7 +44,9 @@
     "recentLogs": "Logaí Le Déanaí",
     "noLogsFound": "Níor aimsíodh aon logaí breosla don stáisiún seo.",
     "loading": "Sonraí an stáisiúin á luchtú...",
-    "errorLoading": "Theip ar luchtú sonraí an stáisiúin. Bain triail eile as."
+    "errorLoading": "Theip ar luchtú sonraí an stáisiúin. Bain triail eile as.",
+    "showMore": "Taispeáin {{count}} eile",
+    "showFewer": "Taispeáin níos lú"
   },
   "quickLog": {
     "title": "Iontráil Breosla Nua",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -44,7 +44,9 @@
     "recentLogs": "最近の記録",
     "noLogsFound": "このスタンドの給油記録が見つかりません。",
     "loading": "スタンドの詳細を読み込み中...",
-    "errorLoading": "スタンドの詳細の読み込みに失敗しました。再試行してください。"
+    "errorLoading": "スタンドの詳細の読み込みに失敗しました。再試行してください。",
+    "showMore": "さらに{{count}}件表示",
+    "showFewer": "表示を減らす"
   },
   "quickLog": {
     "title": "新しい燃料記録",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -44,7 +44,9 @@
     "recentLogs": "최근 기록",
     "noLogsFound": "이 주유소에 대한 주유 기록을 찾을 수 없습니다.",
     "loading": "주유소 세부 정보를 불러오는 중...",
-    "errorLoading": "주유소 세부 정보를 불러오지 못했습니다. 다시 시도해 주세요."
+    "errorLoading": "주유소 세부 정보를 불러오지 못했습니다. 다시 시도해 주세요.",
+    "showMore": "{{count}}개 더 보기",
+    "showFewer": "간략히 보기"
   },
   "quickLog": {
     "title": "새 연료 기록",

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -44,7 +44,9 @@
     "recentLogs": "Siste logger",
     "noLogsFound": "Ingen drivstofflogger funnet for denne stasjonen.",
     "loading": "Laster stasjonsdetaljer...",
-    "errorLoading": "Kunne ikke laste stasjonsdetaljer. Prøv igjen."
+    "errorLoading": "Kunne ikke laste stasjonsdetaljer. Prøv igjen.",
+    "showMore": "Vis {{count}} til",
+    "showFewer": "Vis færre"
   },
   "quickLog": {
     "title": "Logg ny drivstoffoppføring",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -44,7 +44,9 @@
     "recentLogs": "Senaste loggar",
     "noLogsFound": "Inga bränsleloggar hittades för denna station.",
     "loading": "Laddar stationsdetaljer...",
-    "errorLoading": "Misslyckades med att ladda stationsdetaljer. Försök igen."
+    "errorLoading": "Misslyckades med att ladda stationsdetaljer. Försök igen.",
+    "showMore": "Visa {{count}} till",
+    "showFewer": "Visa färre"
   },
   "quickLog": {
     "title": "Logga ny bränslepost",


### PR DESCRIPTION
Closes #130

## Changes
- Removed the `max-h-48 overflow-y-auto` nested scrollbar on the Recent Logs list in `StationDetail.tsx` (same anti-pattern family as #124).
- The first 5 logs now render directly in the page flow; if there are more (up to the existing 12-log fetch limit), a "Show N more" / "Show fewer" toggle button reveals/collapses the rest — no inner scroll required at any width.
- All existing data per log (date, cost, fuel amount, price/L) remains visible, unchanged in content/format.
- Added `stationDetail.showMore` / `stationDetail.showFewer` i18n keys with real translations across all 10 locales.

## Testing
- Added test coverage: no nested scroll container is rendered, and the show-more/show-fewer toggle correctly expands/collapses logs beyond the 5-row default.
- Full unit suite passes (178/178, up from 176 with the 2 new tests).
- `tsc --noEmit` passes.
- Verified no hardcoded strings via the i18n CI heuristic, locale JSON validity.