### PR TITLE
Resolve #126: Show station location map on StationDetail

### DIFF
--- a/src/components/StationDetail.tsx
+++ b/src/components/StationDetail.tsx
@@ -5,10 +5,31 @@ import { Loader, AlertCircle, MapPin } from 'lucide-react';
 import {
     LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer
 } from 'recharts';
+import { MapContainer, TileLayer, Marker } from 'react-leaflet';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
 
 import { Log, Station } from '../utils/types';
 import { fetchFuelLogsByStationId, fetchStationById } from '../firebase/firestoreService';
 import { formatDate } from '../utils/formatDate';
+
+// Leaflet's default marker icon URLs are broken under bundlers like Vite;
+// point them at the public assets instead. Safe to call more than once
+// (e.g. if FuelMapPage.tsx also runs this) since mergeOptions is idempotent.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+delete (L.Icon.Default.prototype as any)._getIconUrl;
+L.Icon.Default.mergeOptions({
+    iconRetinaUrl: '/marker-icon-2x.png',
+    iconUrl: '/marker-icon.png',
+    shadowUrl: '/marker-shadow.png',
+});
+
+// A station with no recorded coordinates (or an exact 0,0 — the null-island
+// default for missing OSM data) has nothing useful to plot on a map.
+const hasValidCoordinates = (station: Station): boolean =>
+    Number.isFinite(station.latitude) &&
+    Number.isFinite(station.longitude) &&
+    !(station.latitude === 0 && station.longitude === 0);
 
 const RECENT_LOGS_LIMIT = 12;
 const RECENT_LOGS_COLLAPSED_LIMIT = 5;
@@ -159,6 +180,27 @@ const StationDetail: React.FC<StationDetailProps> = ({ stationId }) => {
                     <p className="text-gray-900 dark:text-gray-100 font-semibold">{station.logCount}</p>
                 </div>
             </div>
+
+            {hasValidCoordinates(station) ? (
+                <div className="h-56 mb-6 rounded-md overflow-hidden border border-gray-200 dark:border-gray-700">
+                    <MapContainer
+                        center={[station.latitude, station.longitude]}
+                        zoom={15}
+                        scrollWheelZoom={false}
+                        style={{ height: '100%', width: '100%' }}
+                    >
+                        <TileLayer
+                            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+                            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                        />
+                        <Marker position={[station.latitude, station.longitude]} />
+                    </MapContainer>
+                </div>
+            ) : (
+                <div className="text-center text-gray-500 dark:text-gray-400 h-24 flex items-center justify-center border border-dashed border-gray-300 dark:border-gray-700 rounded-md mb-6">
+                    <p>{t('stationDetail.noLocationData')}</p>
+                </div>
+            )}
 
             <h3 id={`price-history-heading-${stationId}`} className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3">{t('stationDetail.priceHistory')}</h3>
             {chartData.length > 1 ? (

--- a/src/components/__tests__/StationDetail.test.tsx
+++ b/src/components/__tests__/StationDetail.test.tsx
@@ -32,11 +32,19 @@ vi.mock('react-i18next', () => ({
         'stationDetail.noLogsFound': 'No fuel logs found for this station.',
         'stationDetail.showMore': 'Show more',
         'stationDetail.showFewer': 'Show fewer',
+        'stationDetail.noLocationData': 'No location data available for this station.',
         'stationTable.noData': 'N/A', // from stationTable, used by stationDetail
       };
       return translations[key] || key;
     },
   }),
+}));
+
+// Mock react-leaflet to avoid map rendering issues in tests
+vi.mock('react-leaflet', () => ({
+  MapContainer: ({ children }: { children: React.ReactNode }) => <div data-testid="map-container">{children}</div>,
+  TileLayer: () => <div />,
+  Marker: () => <div data-testid="map-marker" />,
 }));
 
 // Mock Recharts components (simplified)
@@ -230,6 +238,47 @@ describe('StationDetail', () => {
 
     await waitFor(() => {
       expect(fetchFuelLogsByStationId).toHaveBeenCalledWith(mockStationId, 12);
+    });
+  });
+
+  it('shows a map centered on the station when valid coordinates are available', async () => {
+    vi.mocked(fetchFuelLogsByStationId).mockResolvedValue(mockLogs);
+    vi.mocked(fetchStationById).mockResolvedValue({
+      id: mockStationId,
+      osmId: 'node/123',
+      name: 'Shell',
+      brand: 'Shell',
+      latitude: 53.349805,
+      longitude: -6.260310,
+      logCount: 2,
+    });
+
+    render(<StationDetail stationId={mockStationId} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('map-container')).toBeInTheDocument();
+      expect(screen.getByTestId('map-marker')).toBeInTheDocument();
+      expect(screen.queryByText('No location data available for this station.')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows a placeholder instead of a map when the station has no valid coordinates', async () => {
+    vi.mocked(fetchFuelLogsByStationId).mockResolvedValue(mockLogs);
+    vi.mocked(fetchStationById).mockResolvedValue({
+      id: mockStationId,
+      osmId: 'node/123',
+      name: 'Shell',
+      brand: 'Shell',
+      latitude: 0,
+      longitude: 0,
+      logCount: 2,
+    });
+
+    render(<StationDetail stationId={mockStationId} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No location data available for this station.')).toBeInTheDocument();
+      expect(screen.queryByTestId('map-container')).not.toBeInTheDocument();
     });
   });
 

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -46,7 +46,8 @@
     "loading": "Tankstellendetails werden geladen...",
     "errorLoading": "Tankstellendetails konnten nicht geladen werden. Bitte versuchen Sie es erneut.",
     "showMore": "{{count}} weitere anzeigen",
-    "showFewer": "Weniger anzeigen"
+    "showFewer": "Weniger anzeigen",
+    "noLocationData": "Für diese Tankstelle sind keine Standortdaten verfügbar."
   },
   "quickLog": {
     "title": "Neuer Kraftstoffeintrag",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -46,7 +46,8 @@
     "loading": "Loading station details...",
     "errorLoading": "Failed to load station details. Please try again.",
     "showMore": "Show {{count}} more",
-    "showFewer": "Show fewer"
+    "showFewer": "Show fewer",
+    "noLocationData": "No location data available for this station."
   },
   "quickLog": {
     "title": "Log New Fuel Entry",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -46,7 +46,8 @@
     "loading": "Cargando los detalles de la gasolinera...",
     "errorLoading": "No se pudieron cargar los detalles de la gasolinera. Inténtalo de nuevo.",
     "showMore": "Mostrar {{count}} más",
-    "showFewer": "Mostrar menos"
+    "showFewer": "Mostrar menos",
+    "noLocationData": "No hay datos de ubicación disponibles para esta gasolinera."
   },
   "quickLog": {
     "title": "Nuevo Registro de Combustible",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -46,7 +46,8 @@
     "loading": "Ladataan aseman tietoja...",
     "errorLoading": "Aseman tietojen lataaminen epäonnistui. Yritä uudelleen.",
     "showMore": "Näytä {{count}} lisää",
-    "showFewer": "Näytä vähemmän"
+    "showFewer": "Näytä vähemmän",
+    "noLocationData": "Tälle asemalle ei ole sijaintitietoja."
   },
   "quickLog": {
     "title": "Kirjaa uusi tankkaus",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -46,7 +46,8 @@
     "loading": "Chargement des détails de la station...",
     "errorLoading": "Impossible de charger les détails de la station. Veuillez réessayer.",
     "showMore": "Afficher {{count}} de plus",
-    "showFewer": "Afficher moins"
+    "showFewer": "Afficher moins",
+    "noLocationData": "Aucune donnée de localisation disponible pour cette station."
   },
   "quickLog": {
     "title": "Nouvelle Saisie de Carburant",

--- a/src/i18n/locales/ga.json
+++ b/src/i18n/locales/ga.json
@@ -46,7 +46,8 @@
     "loading": "Sonraí an stáisiúin á luchtú...",
     "errorLoading": "Theip ar luchtú sonraí an stáisiúin. Bain triail eile as.",
     "showMore": "Taispeáin {{count}} eile",
-    "showFewer": "Taispeáin níos lú"
+    "showFewer": "Taispeáin níos lú",
+    "noLocationData": "Níl sonraí suímh ar fáil don stáisiún seo."
   },
   "quickLog": {
     "title": "Iontráil Breosla Nua",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -46,7 +46,8 @@
     "loading": "スタンドの詳細を読み込み中...",
     "errorLoading": "スタンドの詳細の読み込みに失敗しました。再試行してください。",
     "showMore": "さらに{{count}}件表示",
-    "showFewer": "表示を減らす"
+    "showFewer": "表示を減らす",
+    "noLocationData": "このスタンドの位置情報はありません。"
   },
   "quickLog": {
     "title": "新しい燃料記録",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -46,7 +46,8 @@
     "loading": "주유소 세부 정보를 불러오는 중...",
     "errorLoading": "주유소 세부 정보를 불러오지 못했습니다. 다시 시도해 주세요.",
     "showMore": "{{count}}개 더 보기",
-    "showFewer": "간략히 보기"
+    "showFewer": "간략히 보기",
+    "noLocationData": "이 주유소에 대한 위치 데이터가 없습니다."
   },
   "quickLog": {
     "title": "새 연료 기록",

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -46,7 +46,8 @@
     "loading": "Laster stasjonsdetaljer...",
     "errorLoading": "Kunne ikke laste stasjonsdetaljer. Prøv igjen.",
     "showMore": "Vis {{count}} til",
-    "showFewer": "Vis færre"
+    "showFewer": "Vis færre",
+    "noLocationData": "Ingen posisjonsdata tilgjengelig for denne stasjonen."
   },
   "quickLog": {
     "title": "Logg ny drivstoffoppføring",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -46,7 +46,8 @@
     "loading": "Laddar stationsdetaljer...",
     "errorLoading": "Misslyckades med att ladda stationsdetaljer. Försök igen.",
     "showMore": "Visa {{count}} till",
-    "showFewer": "Visa färre"
+    "showFewer": "Visa färre",
+    "noLocationData": "Inga platsdata tillgängliga för denna station."
   },
   "quickLog": {
     "title": "Logga ny bränslepost",


### PR DESCRIPTION
Closes #126

## Changes
- Adds a ~224px `react-leaflet` map to `StationDetail.tsx`, centered on the selected station's `latitude`/`longitude` with a single marker — reuses the same library and Leaflet icon-fix pattern already established in `FuelMapPage.tsx` rather than adding a new map dependency.
- Stations with missing or `(0, 0)` coordinates (the log-derived fallback's "unknown" default) show a placeholder message instead of a broken/blank map, mirroring the existing `notEnoughDataForChart` pattern used for the price-history chart.
- Added `stationDetail.noLocationData` i18n key with real translations across all 10 locales.
- Respects dark mode via existing border/bg conventions in the file.

## Testing
- Added `StationDetail.test.tsx` coverage for both the map-rendered case (valid coordinates) and the placeholder case (0,0 coordinates) — mocks `react-leaflet` the same way `LogCard.test.tsx` already does.
- Full unit suite passes (179/180 — the one failure is the pre-existing flaky `QuickLogPage` test tracked in #135, unrelated to this change).
- `tsc --noEmit` passes.
- Verified no hardcoded strings via the i18n CI heuristic, locale JSON validity.