### PR TITLE
Resolve #121: Remove feature flag gating on Stations page

### DIFF
--- a/src/components/AuthenticatedApp.tsx
+++ b/src/components/AuthenticatedApp.tsx
@@ -7,7 +7,6 @@ import { Routes, Route, Link, Navigate, useLocation } from 'react-router-dom';
 import InstallPrompt from './InstallPrompt';
 import BottomNav from './BottomNav';
 import SyncStatus from './SyncStatus';
-import { useRemoteConfig } from '../context/RemoteConfigContext';
 
 // Wraps React.lazy with a single reload on chunk fetch failure.
 // This handles the stale-PWA-cache scenario where a new deploy renames
@@ -69,9 +68,6 @@ function AuthenticatedApp(): JSX.Element {
   const { user, logout } = useAuth();
   const location = useLocation();
   const { t } = useTranslation();
-  const { getBoolean } = useRemoteConfig();
-
-  const stationsPageEnabled = getBoolean('feature_stations_page_enabled');
 
   const getNavLinkClass = (path: string): string => {
     const baseClass = "px-3 py-1.5 text-sm font-bold rounded-xl transition-all duration-200";
@@ -97,9 +93,7 @@ function AuthenticatedApp(): JSX.Element {
             <Link to="/import" className={getNavLinkClass("/import")}>{t('nav.import')}</Link>
             <Link to="/profile" className={getNavLinkClass("/profile")}>{t('nav.profile')}</Link>
             <Link to="/map" className={getNavLinkClass("/map")}>{t('nav.map')}</Link>
-            {stationsPageEnabled && (
-              <Link to="/stations" className={getNavLinkClass("/stations")}>{t('nav.stations')}</Link>
-            )}
+            <Link to="/stations" className={getNavLinkClass("/stations")}>{t('nav.stations')}</Link>
           </div>
 
           <div className="flex items-center space-x-3 sm:space-x-4">
@@ -136,9 +130,7 @@ function AuthenticatedApp(): JSX.Element {
             <Route path="/privacy" element={<PrivacyPolicyPage />} />
             <Route path="/about" element={<AboutPage />} />
             <Route path="/map" element={<FuelMapPage />} />
-            {stationsPageEnabled && (
-              <Route path="/stations" element={<StationsPage />} />
-            )}
+            <Route path="/stations" element={<StationsPage />} />
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>
         </Suspense>
@@ -158,7 +150,7 @@ function AuthenticatedApp(): JSX.Element {
       </footer>
 
       {/* Mobile Only Navigation */}
-      <BottomNav stationsPageEnabled={stationsPageEnabled} />
+      <BottomNav />
       
       <InstallPrompt />
     </div>

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -7,21 +7,18 @@ import { useTranslation } from 'react-i18next';
  * Mobile-first bottom navigation component.
  * Positioned fixed at the bottom of the screen.
  */
-const BottomNav = ({ stationsPageEnabled }: { stationsPageEnabled: boolean }): JSX.Element => {
+const BottomNav = (): JSX.Element => {
   const location = useLocation();
   const { t } = useTranslation();
 
-  const baseNavItems = [
+  const navItems = [
     { path: '/', label: t('nav.log'), icon: PlusCircle },
     { path: '/dashboard', label: t('nav.dashboard'), icon: LayoutDashboard },
     { path: '/history', label: t('nav.history'), icon: History },
     { path: '/map', label: t('nav.map'), icon: MapIcon },
+    { path: '/stations', label: t('nav.stations'), icon: Fuel },
     { path: '/profile', label: t('nav.profile'), icon: User },
   ];
-
-  const navItems = stationsPageEnabled
-    ? [...baseNavItems.slice(0, 4), { path: '/stations', label: t('nav.stations'), icon: Fuel }, ...baseNavItems.slice(4)]
-    : baseNavItems;
 
 
   return (

--- a/src/firebase/remoteConfigService.ts
+++ b/src/firebase/remoteConfigService.ts
@@ -10,7 +10,6 @@ const DEFAULT_CONFIG: Record<string, boolean | string | number> = {
   "receiptDigitizationEnabled": false,
   "receiptAutoFillEnabled": false,
   "odometerInputEnabled": false,
-  "feature_stations_page_enabled": false, // New feature flag for Stations page
 };
 
 // --- Initialize Remote Config ---


### PR DESCRIPTION
Closes #121

## Changes
- Removed the `feature_stations_page_enabled` remote-config gate from `AuthenticatedApp.tsx` — the "Stations" nav link, `/stations` route, and the corresponding `BottomNav` mobile nav item are now always present for authenticated users.
- `BottomNav` no longer takes a `stationsPageEnabled` prop; its nav item order is unchanged (Log, Dashboard, History, Map, Stations, Profile).
- Removed `feature_stations_page_enabled` from `remoteConfigService.ts`'s `DEFAULT_CONFIG`.
- Removed the now-unused `useRemoteConfig` import from `AuthenticatedApp.tsx`.

**Follow-up (not done here, no console access from this session):** the `feature_stations_page_enabled` parameter should also be deleted from the Firebase Remote Config console for this project, since the client no longer reads it — leaving it there is harmless (just dead config) but worth a cleanup pass.

## Testing
- `grep` confirms zero remaining references to `feature_stations_page_enabled` or `stationsPageEnabled` anywhere in `src/`.
- `tsc --noEmit` passes.
- Full unit suite passes (180/180).