### PR TITLE
fix(nav): prevent shifting and layout squishing due to long localized labels

### DIFF
--- a/src/components/AuthenticatedApp.tsx
+++ b/src/components/AuthenticatedApp.tsx
@@ -81,7 +81,7 @@ function AuthenticatedApp(): JSX.Element {
       {/* Brand Glass Header */}
       <header className="glass-header">
         <nav className="container mx-auto px-4 sm:px-6 lg:px-8 py-3 flex justify-between items-center">
-          <Link to="/" className="font-display text-2xl font-bold tracking-tight hover:opacity-80 transition-opacity" style={{ letterSpacing: '-0.03em' }}>
+          <Link to="/" className="font-display text-2xl font-bold tracking-tight hover:opacity-80 transition-opacity flex-shrink-0" style={{ letterSpacing: '-0.03em' }}>
             <span className="text-amber-500">fuel</span><span className="text-gray-400 dark:text-gray-600">og</span>
           </Link>
           
@@ -96,7 +96,7 @@ function AuthenticatedApp(): JSX.Element {
             <Link to="/stations" className={getNavLinkClass("/stations")}>{t('nav.stations')}</Link>
           </div>
 
-          <div className="flex items-center space-x-3 sm:space-x-4">
+          <div className="flex items-center space-x-3 sm:space-x-4 flex-shrink-0">
             <ThemeToggle />
             <span className="text-xs font-bold text-gray-400 uppercase tracking-widest hidden lg:inline">
               {user?.displayName?.split(' ')[0] || t('common.user')}

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -23,7 +23,7 @@ const BottomNav = (): JSX.Element => {
 
   return (
     <nav className="sm:hidden glass-nav">
-      <div className="flex justify-around items-center h-16">
+      <div className="grid grid-cols-6 items-center h-16">
         {navItems.map((item) => {
           const Icon = item.icon;
           const isActive = location.pathname === item.path;
@@ -40,7 +40,7 @@ const BottomNav = (): JSX.Element => {
               <div className={`p-1.5 rounded-xl transition-all duration-300 ${isActive ? 'bg-brand-primary/10' : ''}`}>
                 <Icon size={22} strokeWidth={isActive ? 2.5 : 1.75} className={isActive ? 'animate-in zoom-in duration-300' : ''} />
               </div>
-              <span className={`text-[9px] mt-0.5 uppercase font-black tracking-widest transition-all ${isActive ? 'opacity-100 scale-110' : 'opacity-50'}`}>
+              <span className={`text-[9px] mt-0.5 px-1 w-full text-center uppercase font-black tracking-widest transition-all truncate ${isActive ? 'opacity-100 scale-110' : 'opacity-50'}`}>
                 {item.label}
               </span>
             </Link>

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -40,7 +40,7 @@ const BottomNav = (): JSX.Element => {
               <div className={`p-1.5 rounded-xl transition-all duration-300 ${isActive ? 'bg-brand-primary/10' : ''}`}>
                 <Icon size={22} strokeWidth={isActive ? 2.5 : 1.75} className={isActive ? 'animate-in zoom-in duration-300' : ''} />
               </div>
-              <span className={`text-[9px] mt-0.5 px-1 w-full text-center uppercase font-black tracking-widest transition-all truncate ${isActive ? 'opacity-100 scale-110' : 'opacity-50'}`}>
+              <span className={"text-[9px] mt-0.5 px-1 w-full text-center uppercase font-black tracking-widest transition-all truncate " + (isActive ? "opacity-100" : "opacity-50")}>
                 {item.label}
               </span>
             </Link>

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -23,7 +23,7 @@ const BottomNav = (): JSX.Element => {
 
   return (
     <nav className="sm:hidden glass-nav">
-      <div className="grid grid-cols-6 items-center h-16">
+      <div className="grid items-center h-16" style={{ gridTemplateColumns: "repeat(" + navItems.length + ", minmax(0, 1fr))" }}>
         {navItems.map((item) => {
           const Icon = item.icon;
           const isActive = location.pathname === item.path;


### PR DESCRIPTION
Fixes #142. Uses CSS Grid for bottom navigation columns and adds flex-shrink-0 to desktop navigation brand/actions elements.