### PR TITLE
Resolve #110: Multi-vehicle efficiency comparison chart

### DIFF
--- a/src/firebase/remoteConfigService.ts
+++ b/src/firebase/remoteConfigService.ts
@@ -10,6 +10,7 @@ const DEFAULT_CONFIG: Record<string, boolean | string | number> = {
   "receiptDigitizationEnabled": false,
   "receiptAutoFillEnabled": false,
   "odometerInputEnabled": false,
+  "vehicleComparisonEnabled": false,
 };
 
 // --- Initialize Remote Config ---

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -133,7 +133,11 @@
     "charts": {
       "mpgOverTime": "MPG (UK) im Zeitverlauf (Gefiltert)",
       "costPerLitreOverTime": "Kraftstoffkosten pro Liter im Zeitverlauf (Gefiltert)",
-      "needMoreData": "Mindestens zwei Einträge im gefilterten Bereich sind erforderlich, um Trends anzuzeigen."
+      "needMoreData": "Mindestens zwei Einträge im gefilterten Bereich sind erforderlich, um Trends anzuzeigen.",
+      "vehicleComparison": "Fahrzeugvergleich",
+      "avgL100km": "Ø L/100km",
+      "avgCostPerLitre": "Ø Preis/Liter",
+      "totalSpend": "Gesamtausgaben"
     },
     "logDetails": {
       "heading": "Eintragsdetails",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -133,7 +133,11 @@
     "charts": {
       "mpgOverTime": "MPG (UK) Over Time (Filtered)",
       "costPerLitreOverTime": "Fuel Cost Per Litre Over Time (Filtered)",
-      "needMoreData": "Need at least two logs in the filtered range to show trends."
+      "needMoreData": "Need at least two logs in the filtered range to show trends.",
+      "vehicleComparison": "Vehicle Comparison",
+      "avgL100km": "Avg L/100km",
+      "avgCostPerLitre": "Avg Cost/Litre",
+      "totalSpend": "Total Spend"
     },
     "logDetails": {
       "heading": "Log Details",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -133,7 +133,11 @@
     "charts": {
       "mpgOverTime": "MPG (UK) a lo Largo del Tiempo (Filtrado)",
       "costPerLitreOverTime": "Coste de Combustible por Litro a lo Largo del Tiempo (Filtrado)",
-      "needMoreData": "Se necesitan al menos dos registros en el rango filtrado para mostrar tendencias."
+      "needMoreData": "Se necesitan al menos dos registros en el rango filtrado para mostrar tendencias.",
+      "vehicleComparison": "Comparación de vehículos",
+      "avgL100km": "Prom. L/100km",
+      "avgCostPerLitre": "Prom. precio/litro",
+      "totalSpend": "Gasto total"
     },
     "logDetails": {
       "heading": "Detalles del Registro",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -133,7 +133,11 @@
     "charts": {
       "mpgOverTime": "MPG (UK) ajan myötä (suodatettu)",
       "costPerLitreOverTime": "Polttoaineen hinta per litra ajan myötä (suodatettu)",
-      "needMoreData": "Tarvitaan vähintään kaksi lokia trendien näyttämiseksi."
+      "needMoreData": "Tarvitaan vähintään kaksi lokia trendien näyttämiseksi.",
+      "vehicleComparison": "Ajoneuvovertailu",
+      "avgL100km": "Keskiarvo l/100km",
+      "avgCostPerLitre": "Keskihinta/litra",
+      "totalSpend": "Kokonaiskulut"
     },
     "logDetails": {
       "heading": "Login tiedot",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -133,7 +133,11 @@
     "charts": {
       "mpgOverTime": "MPG (UK) dans le Temps (Filtré)",
       "costPerLitreOverTime": "Coût du Carburant par Litre dans le Temps (Filtré)",
-      "needMoreData": "Au moins deux saisies dans la plage filtrée sont nécessaires pour afficher les tendances."
+      "needMoreData": "Au moins deux saisies dans la plage filtrée sont nécessaires pour afficher les tendances.",
+      "vehicleComparison": "Comparaison des véhicules",
+      "avgL100km": "Moy. L/100km",
+      "avgCostPerLitre": "Prix moy./litre",
+      "totalSpend": "Dépense totale"
     },
     "logDetails": {
       "heading": "Détails des Saisies",

--- a/src/i18n/locales/ga.json
+++ b/src/i18n/locales/ga.json
@@ -133,7 +133,11 @@
     "charts": {
       "mpgOverTime": "MPG (UK) Thar Am (Scagtha)",
       "costPerLitreOverTime": "Costas Breosla In Aghaidh an Lítir Thar Am (Scagtha)",
-      "needMoreData": "Teastaíonn dhá iontráil ar a laghad sa raon scagtha le treochtaí a thaispeáint."
+      "needMoreData": "Teastaíonn dhá iontráil ar a laghad sa raon scagtha le treochtaí a thaispeáint.",
+      "vehicleComparison": "Comparáid Feithiclí",
+      "avgL100km": "Meán L/100km",
+      "avgCostPerLitre": "Meánphraghas/lítear",
+      "totalSpend": "Caiteachas Iomlán"
     },
     "logDetails": {
       "heading": "Sonraí Iontrálacha",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -133,7 +133,11 @@
     "charts": {
       "mpgOverTime": "MPG (UK) の推移（フィルター済み）",
       "costPerLitreOverTime": "リットルあたり燃料コストの推移（フィルター済み）",
-      "needMoreData": "トレンドを表示するには、フィルター範囲内に少なくとも2件の記録が必要です。"
+      "needMoreData": "トレンドを表示するには、フィルター範囲内に少なくとも2件の記録が必要です。",
+      "vehicleComparison": "車両比較",
+      "avgL100km": "平均 L/100km",
+      "avgCostPerLitre": "平均 価格/リットル",
+      "totalSpend": "合計支出"
     },
     "logDetails": {
       "heading": "記録詳細",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -133,7 +133,11 @@
     "charts": {
       "mpgOverTime": "MPG (UK) 시간 추이 (필터됨)",
       "costPerLitreOverTime": "리터당 연료 비용 시간 추이 (필터됨)",
-      "needMoreData": "트렌드를 표시하려면 필터된 범위에 최소 두 개의 기록이 필요합니다."
+      "needMoreData": "트렌드를 표시하려면 필터된 범위에 최소 두 개의 기록이 필요합니다.",
+      "vehicleComparison": "차량 비교",
+      "avgL100km": "평균 L/100km",
+      "avgCostPerLitre": "평균 가격/리터",
+      "totalSpend": "총 지출"
     },
     "logDetails": {
       "heading": "기록 세부정보",

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -133,7 +133,11 @@
     "charts": {
       "mpgOverTime": "MPG (UK) over tid (filtrert)",
       "costPerLitreOverTime": "Drivstoffkostnad per liter over tid (filtrert)",
-      "needMoreData": "Trenger minst to logger i det filtrerte området for å vise trender."
+      "needMoreData": "Trenger minst to logger i det filtrerte området for å vise trender.",
+      "vehicleComparison": "Kjøretøysammenligning",
+      "avgL100km": "Snitt l/100km",
+      "avgCostPerLitre": "Snittpris/liter",
+      "totalSpend": "Totale utgifter"
     },
     "logDetails": {
       "heading": "Loggdetaljer",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -133,7 +133,11 @@
     "charts": {
       "mpgOverTime": "MPG (UK) över tid (filtrerat)",
       "costPerLitreOverTime": "Bränslekostnad per liter över tid (filtrerat)",
-      "needMoreData": "Behöver minst två loggar i det filtrerade intervallet för att visa trender."
+      "needMoreData": "Behöver minst två loggar i det filtrerade intervallet för att visa trender.",
+      "vehicleComparison": "Fordonsjämförelse",
+      "avgL100km": "Snitt L/100km",
+      "avgCostPerLitre": "Snittpris/liter",
+      "totalSpend": "Totala utgifter"
     },
     "logDetails": {
       "heading": "Loggdetaljer",

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -12,7 +12,7 @@ import { db } from '../firebase/config';
 import { useAuth } from '../context/AuthContext';
 // Import Recharts components for charting
 import {
-    LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
+    LineChart, Line, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
 } from 'recharts';
 // Import icons
 import { FileText, Banknote, Droplets, Route, Fuel } from 'lucide-react';
@@ -30,6 +30,14 @@ import { sanitizeUrl } from '../utils/sanitize';
 import { formatDate } from '../utils/formatDate';
 import { fetchUserStations } from '../firebase/firestoreService';
 import { Station } from '../utils/types';
+
+interface VehicleComparisonDatum {
+    vehicleId: string;
+    name: string;
+    avgL100km: number;
+    avgCostPerLitre: number;
+    totalSpend: number;
+}
 
 // --- React Component ---
 function HistoryPage(): JSX.Element {
@@ -49,6 +57,7 @@ function HistoryPage(): JSX.Element {
     const totalSpentDisplayEnabled = getBoolean("totalSpentDisplayEnabled");
     const receiptDigitizationEnabled = getBoolean("receiptDigitizationEnabled");
     const odometerInputEnabled = getBoolean("odometerInputEnabled");
+    const vehicleComparisonEnabled = getBoolean("vehicleComparisonEnabled");
 
     const [logs, setLogs] = useState<Log[]>([]); // Holds the array of ALL fetched fuel logs for the user
     const [stations, setStations] = useState<Station[]>([]); // Holds station info
@@ -77,6 +86,9 @@ function HistoryPage(): JSX.Element {
     // --- Lifetime Aggregation Stats ---
     const [lifetimeStats, setLifetimeStats] = useState<LifetimeStats | null>(null);
 
+    // --- Multi-Vehicle Comparison Stats ---
+    const [vehicleComparisonStats, setVehicleComparisonStats] = useState<VehicleComparisonDatum[]>([]);
+
     // --- Fetch Vehicles Effect ---
     useEffect(() => {
         if (!user) { setVehicles([]); return; }
@@ -104,6 +116,36 @@ function HistoryPage(): JSX.Element {
             .then(setLifetimeStats)
             .catch(err => console.error('Error fetching lifetime stats:', err));
     }, [user, filterVehicleId]);
+
+    // --- Fetch Per-Vehicle Comparison Stats ---
+    // One getLifetimeStats aggregation call per active vehicle (no raw document reads).
+    useEffect(() => {
+        if (!user || !vehicleComparisonEnabled) { setVehicleComparisonStats([]); return; }
+        const activeVehicles = vehicles.filter(v => !v.isArchived);
+        if (activeVehicles.length < 2) { setVehicleComparisonStats([]); return; }
+
+        let cancelled = false;
+        Promise.all(
+            activeVehicles.map(vehicle =>
+                getLifetimeStats(user.uid, vehicle.id).then(stats => ({ vehicle, stats }))
+            )
+        )
+            .then(results => {
+                if (cancelled) return;
+                const withLogs = results.filter(({ stats }) => stats.logCount > 0);
+                if (withLogs.length < 2) { setVehicleComparisonStats([]); return; }
+                setVehicleComparisonStats(withLogs.map(({ vehicle, stats }) => ({
+                    vehicleId: vehicle.id,
+                    name: vehicle.name,
+                    avgL100km: stats.totalDistanceKm > 0 ? (stats.totalLitres / stats.totalDistanceKm) * 100 : 0,
+                    avgCostPerLitre: stats.totalLitres > 0 ? stats.totalCost / stats.totalLitres : 0,
+                    totalSpend: stats.totalCost,
+                })));
+            })
+            .catch(err => console.error('Error fetching vehicle comparison stats:', err));
+
+        return () => { cancelled = true; };
+    }, [user, vehicles, vehicleComparisonEnabled]);
 
     // --- State for View Toggle ---
     const [viewMode, setViewMode] = useState<ViewMode>('table'); // Default to table view
@@ -558,6 +600,40 @@ function HistoryPage(): JSX.Element {
                             <Legend wrapperStyle={{ fontSize: '12px', paddingTop: '10px', color: theme === 'dark' ? 'white' : 'black' }} />
                             <Line type="monotone" dataKey="fuelPrice" name="Cost Per Litre" stroke="#82ca9d" strokeWidth={2} activeDot={{ r: 6 }} connectNulls />
                         </LineChart>
+                    </ResponsiveContainer>
+                </div>
+            )}
+
+            {/* Multi-vehicle efficiency/cost comparison, behind vehicleComparisonEnabled flag */}
+            {vehicleComparisonEnabled && vehicleComparisonStats.length >= 2 && (
+                <div className="bg-white dark:bg-gray-800 shadow-lg rounded-xl p-4 sm:p-6 border border-gray-200 dark:border-gray-700 mt-8">
+                    <h3 className="text-lg font-medium text-gray-700 dark:text-gray-300 mb-4">{t('history.charts.vehicleComparison')}</h3>
+                    <ResponsiveContainer width="100%" height={300}>
+                        <BarChart data={vehicleComparisonStats} margin={{ top: 5, right: 20, left: -10, bottom: 5 }}>
+                            <CartesianGrid strokeDasharray="3 3" stroke={theme === 'dark' ? '#4A5568' : '#e0e0e0'} />
+                            <XAxis dataKey="name" tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }} />
+                            <YAxis
+                                yAxisId="left"
+                                tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }}
+                            />
+                            <YAxis
+                                yAxisId="right"
+                                orientation="right"
+                                tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }}
+                            />
+                            <Tooltip
+                                contentStyle={{ fontSize: '12px', padding: '5px', backgroundColor: theme === 'dark' ? '#2D3748' : 'white', color: theme === 'dark' ? 'white' : 'black', border: theme === 'dark' ? '1px solid #4A5568' : '1px solid #e0e0e0' }}
+                                formatter={(value: number, name: string) => name === t('history.charts.totalSpend')
+                                    ? `${homeCurrencySymbol}${value.toFixed(2)}`
+                                    : name === t('history.charts.avgCostPerLitre')
+                                        ? `${homeCurrencySymbol}${value.toFixed(3)}`
+                                        : value.toFixed(2)}
+                            />
+                            <Legend wrapperStyle={{ fontSize: '12px', paddingTop: '10px', color: theme === 'dark' ? 'white' : 'black' }} />
+                            <Bar yAxisId="left" dataKey="avgL100km" name={t('history.charts.avgL100km')} fill="#8884d8" />
+                            <Bar yAxisId="left" dataKey="avgCostPerLitre" name={t('history.charts.avgCostPerLitre')} fill="#82ca9d" />
+                            <Bar yAxisId="right" dataKey="totalSpend" name={t('history.charts.totalSpend')} fill="#fbbf24" />
+                        </BarChart>
                     </ResponsiveContainer>
                 </div>
             )}


### PR DESCRIPTION
Closes #110

## Changes
- Adds a "Compare vehicles" bar chart to `HistoryPage.tsx`, behind a new `vehicleComparisonEnabled` remote-config flag (default `false`).
- Renders one cluster per active (non-archived) vehicle with three bars: avg L/100km, avg cost/litre, and total spend (currency symbol from the user's profile). Total spend uses a secondary right-side Y axis since it's on a much larger scale than the per-litre/per-100km metrics.
- Each vehicle's stats come from a single `getLifetimeStats(userId, vehicleId)` call — Firestore server-side aggregation, no extra raw document reads beyond the existing pattern already used for the page's own lifetime stats.
- The chart only renders once at least 2 active vehicles each have at least one log (vehicles with zero logs, or archived vehicles, are excluded).
- Added `history.charts.vehicleComparison/avgL100km/avgCostPerLitre/totalSpend` i18n keys with real translations across all 10 locales.

## Testing
- `tsc --noEmit` passes.
- Full unit suite passes (179/180 — the 1 failure is the pre-existing flaky `QuickLogPage` test tracked in #135, unrelated to this change).
- No existing test file for `HistoryPage.tsx` (consistent with the rest of that file — added no new test scaffolding here either, to match existing project conventions for this specific file).
- Verified no hardcoded strings via the i18n CI heuristic, locale JSON validity.