### PR TITLE
Resolve #109: Cost-per-litre trend line on HistoryPage chart

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -137,7 +137,8 @@
       "vehicleComparison": "Fahrzeugvergleich",
       "avgL100km": "Ø L/100km",
       "avgCostPerLitre": "Ø Preis/Liter",
-      "totalSpend": "Gesamtausgaben"
+      "totalSpend": "Gesamtausgaben",
+      "pricePerLitre": "Preis/L"
     },
     "logDetails": {
       "heading": "Eintragsdetails",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -137,7 +137,8 @@
       "vehicleComparison": "Vehicle Comparison",
       "avgL100km": "Avg L/100km",
       "avgCostPerLitre": "Avg Cost/Litre",
-      "totalSpend": "Total Spend"
+      "totalSpend": "Total Spend",
+      "pricePerLitre": "Price / L"
     },
     "logDetails": {
       "heading": "Log Details",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -137,7 +137,8 @@
       "vehicleComparison": "Comparación de vehículos",
       "avgL100km": "Prom. L/100km",
       "avgCostPerLitre": "Prom. precio/litro",
-      "totalSpend": "Gasto total"
+      "totalSpend": "Gasto total",
+      "pricePerLitre": "Precio/L"
     },
     "logDetails": {
       "heading": "Detalles del Registro",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -137,7 +137,8 @@
       "vehicleComparison": "Ajoneuvovertailu",
       "avgL100km": "Keskiarvo l/100km",
       "avgCostPerLitre": "Keskihinta/litra",
-      "totalSpend": "Kokonaiskulut"
+      "totalSpend": "Kokonaiskulut",
+      "pricePerLitre": "Hinta/l"
     },
     "logDetails": {
       "heading": "Login tiedot",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -137,7 +137,8 @@
       "vehicleComparison": "Comparaison des véhicules",
       "avgL100km": "Moy. L/100km",
       "avgCostPerLitre": "Prix moy./litre",
-      "totalSpend": "Dépense totale"
+      "totalSpend": "Dépense totale",
+      "pricePerLitre": "Prix/L"
     },
     "logDetails": {
       "heading": "Détails des Saisies",

--- a/src/i18n/locales/ga.json
+++ b/src/i18n/locales/ga.json
@@ -137,7 +137,8 @@
       "vehicleComparison": "Comparáid Feithiclí",
       "avgL100km": "Meán L/100km",
       "avgCostPerLitre": "Meánphraghas/lítear",
-      "totalSpend": "Caiteachas Iomlán"
+      "totalSpend": "Caiteachas Iomlán",
+      "pricePerLitre": "Praghas/L"
     },
     "logDetails": {
       "heading": "Sonraí Iontrálacha",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -137,7 +137,8 @@
       "vehicleComparison": "車両比較",
       "avgL100km": "平均 L/100km",
       "avgCostPerLitre": "平均 価格/リットル",
-      "totalSpend": "合計支出"
+      "totalSpend": "合計支出",
+      "pricePerLitre": "価格/L"
     },
     "logDetails": {
       "heading": "記録詳細",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -137,7 +137,8 @@
       "vehicleComparison": "차량 비교",
       "avgL100km": "평균 L/100km",
       "avgCostPerLitre": "평균 가격/리터",
-      "totalSpend": "총 지출"
+      "totalSpend": "총 지출",
+      "pricePerLitre": "가격/L"
     },
     "logDetails": {
       "heading": "기록 세부정보",

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -137,7 +137,8 @@
       "vehicleComparison": "Kjøretøysammenligning",
       "avgL100km": "Snitt l/100km",
       "avgCostPerLitre": "Snittpris/liter",
-      "totalSpend": "Totale utgifter"
+      "totalSpend": "Totale utgifter",
+      "pricePerLitre": "Pris/l"
     },
     "logDetails": {
       "heading": "Loggdetaljer",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -137,7 +137,8 @@
       "vehicleComparison": "Fordonsjämförelse",
       "avgL100km": "Snitt L/100km",
       "avgCostPerLitre": "Snittpris/liter",
-      "totalSpend": "Totala utgifter"
+      "totalSpend": "Totala utgifter",
+      "pricePerLitre": "Pris/L"
     },
     "logDetails": {
       "heading": "Loggdetaljer",

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -86,6 +86,16 @@ function HistoryPage(): JSX.Element {
     // --- Lifetime Aggregation Stats ---
     const [lifetimeStats, setLifetimeStats] = useState<LifetimeStats | null>(null);
 
+    // --- Main Chart Series Visibility (toggled via Legend click) ---
+    const [hiddenChartSeries, setHiddenChartSeries] = useState<Set<string>>(new Set());
+    const toggleChartSeries = (dataKey: string) => {
+        setHiddenChartSeries(prev => {
+            const next = new Set(prev);
+            if (next.has(dataKey)) next.delete(dataKey); else next.add(dataKey);
+            return next;
+        });
+    };
+
     // --- Multi-Vehicle Comparison Stats ---
     const [vehicleComparisonStats, setVehicleComparisonStats] = useState<VehicleComparisonDatum[]>([]);
 
@@ -561,7 +571,15 @@ function HistoryPage(): JSX.Element {
                         <LineChart data={chartData} margin={{ top: 5, right: 20, left: -10, bottom: 5 }}>
                             <CartesianGrid strokeDasharray="3 3" stroke={theme === 'dark' ? '#4A5568' : '#e0e0e0'} />
                             <XAxis dataKey="date" tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }} angle={-30} textAnchor="end" height={50} interval="preserveStartEnd" />
-                            <YAxis tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }} domain={['auto', 'auto']} label={{ value: 'MPG (UK)', angle: -90, position: 'insideLeft', offset: 10, style: { fontSize: '12px', fill: theme === 'dark' ? '#cbd5e0' : '#6b7280' } }} />
+                            <YAxis yAxisId="left" tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }} domain={['auto', 'auto']} label={{ value: 'MPG (UK)', angle: -90, position: 'insideLeft', offset: 10, style: { fontSize: '12px', fill: theme === 'dark' ? '#cbd5e0' : '#6b7280' } }} />
+                            <YAxis
+                                yAxisId="right"
+                                orientation="right"
+                                tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }}
+                                domain={['auto', 'auto']}
+                                tickFormatter={(value: number) => value.toFixed(3)}
+                                label={{ value: `${t('history.charts.pricePerLitre')} (${homeCurrencySymbol})`, angle: 90, position: 'insideRight', offset: 10, style: { fontSize: '12px', fill: theme === 'dark' ? '#cbd5e0' : '#6b7280' } }}
+                            />
                             <Tooltip
                                 contentStyle={{
                                     fontSize: '12px',
@@ -570,10 +588,16 @@ function HistoryPage(): JSX.Element {
                                     color: theme === 'dark' ? 'white' : 'black',
                                     border: theme === 'dark' ? '1px solid #4A5568' : '1px solid #e0e0e0'
                                 }}
-                                formatter={(value: number) => value?.toFixed(2)}
+                                formatter={(value: number, name: string) => name === t('history.charts.pricePerLitre')
+                                    ? `${homeCurrencySymbol}${value.toFixed(3)}`
+                                    : value?.toFixed(2)}
                             />
-                            <Legend wrapperStyle={{ fontSize: '12px', paddingTop: '10px', color: theme === 'dark' ? 'white' : 'black' }} />
-                            <Line type="monotone" dataKey="mpg" name="MPG (UK)" stroke="#8884d8" strokeWidth={2} activeDot={{ r: 6 }} connectNulls />
+                            <Legend
+                                wrapperStyle={{ fontSize: '12px', paddingTop: '10px', color: theme === 'dark' ? 'white' : 'black', cursor: 'pointer' }}
+                                onClick={(e) => toggleChartSeries(e.dataKey as string)}
+                            />
+                            <Line yAxisId="left" type="monotone" dataKey="mpg" name="MPG (UK)" stroke="#8884d8" strokeWidth={2} activeDot={{ r: 6 }} connectNulls hide={hiddenChartSeries.has('mpg')} />
+                            <Line yAxisId="right" type="monotone" dataKey="fuelPrice" name={t('history.charts.pricePerLitre')} stroke="#F59E0B" strokeWidth={2} activeDot={{ r: 6 }} connectNulls hide={hiddenChartSeries.has('fuelPrice')} />
                         </LineChart>
                     </ResponsiveContainer>
                 </div>


### PR DESCRIPTION
Closes #109

## Changes
- Adds a second Y-axis "Price / L" line to the existing MPG-over-time `LineChart` in `HistoryPage.tsx`, using the `fuelPrice` (cost/fuelAmountLiters) field already computed in `chartData`.
- Colored `#F59E0B` (amber) to match the brand palette, displayed in the user's home currency symbol, rounded to 3 decimal places (both in the right Y-axis tick formatter and the tooltip).
- Added a click-to-toggle `Legend` so either series (MPG or Price/L) can be hidden independently, via Recharts' `Line` `hide` prop and new `hiddenChartSeries` state.
- `chartData` already derives from `filteredLogs`, which already respects the vehicle filter — so the new line is automatically scoped to the selected vehicle with no extra filtering logic.
- Existing MPG line behavior (left axis, color, tooltip) is unchanged.
- Added `history.charts.pricePerLitre` i18n key with real translations across all 10 locales.

## Testing
- `tsc --noEmit` passes.
- Full unit suite passes (180/180, run automatically via the repo's pre-commit hook too).
- Verified no hardcoded strings via the i18n CI heuristic, locale JSON validity.