### PR TITLE
Resolve #150: Group map markers by station, themed pin icon

### DIFF
--- a/src/components/FuelMapPage.tsx
+++ b/src/components/FuelMapPage.tsx
@@ -14,7 +14,8 @@ import { fetchFuelLocations, fetchUserStations } from '../firebase/firestoreServ
 import { Log, Station } from '../utils/types';
 import { formatDate } from '../utils/formatDate';
 import { useTheme } from '../context/ThemeContext';
-import { MAP_TILES } from '../utils/mapConstants';
+import { MAP_TILES, createStationIcon } from '../utils/mapConstants';
+import { useTranslation } from 'react-i18next';
 
 // --- Icon Fix (points to public assets) ---
 const iconRetinaUrl = '/marker-icon-2x.png';
@@ -81,6 +82,7 @@ const LocateControl = () => {
 
 const FuelMapPage: React.FC = () => {
   const { theme } = useTheme();
+  const { t } = useTranslation();
   const [locations, setLocations] = useState<Log[]>([]);
   const [stations, setStations] = useState<Station[]>([]);
   const [loading, setLoading] = useState(true);
@@ -110,18 +112,22 @@ const FuelMapPage: React.FC = () => {
       return locations.filter(loc => loc.latitude !== undefined && loc.longitude !== undefined);
   }, [locations]);
 
-  // Group logs by latitude & longitude
+  // Group logs by stationId — the canonical grouping key, since a station's
+  // stored coordinates and a log's raw GPS reading are independent values
+  // that don't reliably round to the same key. Logs with no stationId
+  // (pre-station-association logs, or low-GPS-accuracy logs that skipped
+  // association) fall back to coordinate-rounding so they still appear on
+  // the map, grouped separately and flagged as unassigned.
   const stationGroups = useMemo(() => {
-     const stationsByCoord = new Map<string, Station>();
-     stations.forEach(s => {
-         stationsByCoord.set(`${s.latitude.toFixed(4)}_${s.longitude.toFixed(4)}`, s);
-     });
+     const stationsById = new Map(stations.map(s => [s.id, s]));
 
      const groups: { [key: string]: { logs: Log[], station?: Station } } = {};
      validLocations.forEach(log => {
-         const key = `${log.latitude!.toFixed(4)}_${log.longitude!.toFixed(4)}`;
+         const key = log.stationId
+             ? `station-${log.stationId}`
+             : `coord-${log.latitude!.toFixed(4)}_${log.longitude!.toFixed(4)}`;
          if (!groups[key]) {
-             groups[key] = { logs: [], station: stationsByCoord.get(key) };
+             groups[key] = { logs: [], station: log.stationId ? stationsById.get(log.stationId) : undefined };
          }
          groups[key].logs.push(log);
      });
@@ -172,7 +178,7 @@ const FuelMapPage: React.FC = () => {
               : [firstLog.latitude!, firstLog.longitude!];
               
             return (
-              <Marker key={key} position={pos}>
+              <Marker key={key} position={pos} icon={createStationIcon(!group.station)}>
                 <Popup>
                   <div className="p-1 min-w-[180px]">
                     <div className="flex flex-col mb-2 pb-1 border-b border-gray-200 dark:border-gray-700">
@@ -182,6 +188,11 @@ const FuelMapPage: React.FC = () => {
                                 {group.station?.name || firstLog.brand || 'N/A'}
                             </span>
                         </div>
+                        {!group.station && (
+                            <div className="mt-1 text-[10px] text-gray-400 font-bold uppercase">
+                                {t('common.unassignedLocation')}
+                            </div>
+                        )}
                         {group.station?.avgPrice && (
                             <div className="mt-1 flex items-center text-[10px] text-green-600 dark:text-green-400 font-bold uppercase">
                                 <span>Avg Price: €{group.station.avgPrice.toFixed(3)}/L</span>

--- a/src/components/StationDetail.tsx
+++ b/src/components/StationDetail.tsx
@@ -13,7 +13,7 @@ import { Log, Station } from '../utils/types';
 import { fetchFuelLogsByStationId, fetchStationById } from '../firebase/firestoreService';
 import { formatDate } from '../utils/formatDate';
 import { useTheme } from '../context/ThemeContext';
-import { MAP_TILES } from '../utils/mapConstants';
+import { MAP_TILES, createStationIcon } from '../utils/mapConstants';
 
 // Leaflet's default marker icon URLs are broken under bundlers like Vite;
 // point them at the public assets instead. Safe to call more than once
@@ -196,7 +196,7 @@ const StationDetail: React.FC<StationDetailProps> = ({ stationId }) => {
                             attribution={MAP_TILES.attribution}
                             url={theme === 'dark' ? MAP_TILES.dark : MAP_TILES.light}
                         />
-                        <Marker position={[station.latitude, station.longitude]} />
+                        <Marker position={[station.latitude, station.longitude]} icon={createStationIcon()} />
                     </MapContainer>
                 </div>
             ) : (

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -440,7 +440,8 @@
     "somethingWentWrong": "Etwas ist schiefgelaufen",
     "unexpectedError": "Ein unerwarteter Fehler ist aufgetreten.",
     "tryAgain": "Erneut versuchen",
-    "loadingMapData": "Kartendaten werden geladen..."
+    "loadingMapData": "Kartendaten werden geladen...",
+    "unassignedLocation": "Nicht zugeordneter Standort"
   },
   "language": {
     "label": "Sprache",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -440,7 +440,8 @@
     "somethingWentWrong": "Something went wrong",
     "unexpectedError": "An unexpected error occurred.",
     "tryAgain": "Try again",
-    "loadingMapData": "Loading map data..."
+    "loadingMapData": "Loading map data...",
+    "unassignedLocation": "Unassigned location"
   },
   "language": {
     "label": "Language",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -440,7 +440,8 @@
     "somethingWentWrong": "Algo salió mal",
     "unexpectedError": "Se produjo un error inesperado.",
     "tryAgain": "Intentar de nuevo",
-    "loadingMapData": "Cargando datos del mapa..."
+    "loadingMapData": "Cargando datos del mapa...",
+    "unassignedLocation": "Ubicación sin asignar"
   },
   "language": {
     "label": "Idioma",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -440,7 +440,8 @@
     "somethingWentWrong": "Jokin menu pieleen",
     "unexpectedError": "Tapahtui odottamaton virhe.",
     "tryAgain": "Yritä uudelleen",
-    "loadingMapData": "Ladataan karttatietoja..."
+    "loadingMapData": "Ladataan karttatietoja...",
+    "unassignedLocation": "Ei kohdistettu sijainti"
   },
   "language": {
     "label": "Kieli",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -440,7 +440,8 @@
     "somethingWentWrong": "Quelque chose s'est mal passé",
     "unexpectedError": "Une erreur inattendue s'est produite.",
     "tryAgain": "Réessayer",
-    "loadingMapData": "Chargement des données de la carte..."
+    "loadingMapData": "Chargement des données de la carte...",
+    "unassignedLocation": "Emplacement non assigné"
   },
   "language": {
     "label": "Langue",

--- a/src/i18n/locales/ga.json
+++ b/src/i18n/locales/ga.json
@@ -440,7 +440,8 @@
     "somethingWentWrong": "Tharla earráid",
     "unexpectedError": "Tharla earráid gan choinne.",
     "tryAgain": "Bain triail eile as",
-    "loadingMapData": "Sonraí léarscáile á luchtú..."
+    "loadingMapData": "Sonraí léarscáile á luchtú...",
+    "unassignedLocation": "Suíomh Gan Sannadh"
   },
   "language": {
     "label": "Teanga",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -440,7 +440,8 @@
     "somethingWentWrong": "問題が発生しました",
     "unexpectedError": "予期しないエラーが発生しました。",
     "tryAgain": "再試行",
-    "loadingMapData": "地図データを読み込み中..."
+    "loadingMapData": "地図データを読み込み中...",
+    "unassignedLocation": "未割り当ての位置"
   },
   "language": {
     "label": "言語",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -440,7 +440,8 @@
     "somethingWentWrong": "문제가 발생했습니다",
     "unexpectedError": "예기치 않은 오류가 발생했습니다.",
     "tryAgain": "다시 시도",
-    "loadingMapData": "지도 데이터를 불러오는 중..."
+    "loadingMapData": "지도 데이터를 불러오는 중...",
+    "unassignedLocation": "할당되지 않은 위치"
   },
   "language": {
     "label": "언어",

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -440,7 +440,8 @@
     "somethingWentWrong": "Noe gikk feil",
     "unexpectedError": "En uventet feil oppstod.",
     "tryAgain": "Prøv igjen",
-    "loadingMapData": "Laster kartdata..."
+    "loadingMapData": "Laster kartdata...",
+    "unassignedLocation": "Ikke tilordnet sted"
   },
   "language": {
     "label": "Språk",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -440,7 +440,8 @@
     "somethingWentWrong": "Något gick fel",
     "unexpectedError": "Ett oväntat fel inträffade.",
     "tryAgain": "Försök igen",
-    "loadingMapData": "Laddar kartdata..."
+    "loadingMapData": "Laddar kartdata...",
+    "unassignedLocation": "Otilldelad plats"
   },
   "language": {
     "label": "Språk",

--- a/src/utils/mapConstants.ts
+++ b/src/utils/mapConstants.ts
@@ -1,3 +1,5 @@
+import L from 'leaflet';
+
 /**
  * Shared map tile provider configuration.
  * Uses CartoDB Positron for light theme and CartoDB Dark Matter for dark theme
@@ -8,3 +10,38 @@ export const MAP_TILES = {
   dark: 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png',
   attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
 };
+
+// Lucide's "fuel" icon path data, inlined so map markers don't need a React
+// render pass — Leaflet markers are plain DOM, not React elements.
+const FUEL_ICON_SVG = `
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="3" x2="15" y1="22" y2="22"></line>
+  <line x1="4" x2="14" y1="9" y2="9"></line>
+  <path d="M14 22V4a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v18"></path>
+  <path d="M14 13h2a2 2 0 0 1 2 2v2a2 2 0 0 0 2 2a2 2 0 0 0 2-2V9.83a2 2 0 0 0-.59-1.42L18 5"></path>
+</svg>
+`;
+
+/**
+ * A themed station marker: an amber pin (matching the brand palette) with
+ * the same "fuel pump" glyph used for the Stations nav item, in place of
+ * Leaflet's generic default pin. `unassigned` renders a muted grey variant
+ * for logs with coordinates but no associated Station document, so they
+ * remain visually distinct on the map rather than looking like a normal
+ * station.
+ */
+export const createStationIcon = (unassigned = false): L.DivIcon => L.divIcon({
+  className: 'fuelog-station-marker',
+  html: `
+    <div style="
+      width: 28px; height: 28px; border-radius: 50%;
+      background: ${unassigned ? '#9ca3af' : '#f59e0b'};
+      border: 2px solid white;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.4);
+      display: flex; align-items: center; justify-content: center;
+    ">${FUEL_ICON_SVG}</div>
+  `,
+  iconSize: [28, 28],
+  iconAnchor: [14, 14],
+  popupAnchor: [0, -14],
+});


### PR DESCRIPTION
Closes #150

## Changes
- `FuelMapPage.tsx`'s `stationGroups` now keys primarily on `log.stationId` (already stored on `Log`) instead of rounding raw GPS coordinates to 4 decimal places — fixes fragmented pins for the same physical station caused by GPS drift not exactly matching the station's stored coordinates.
- Logs with valid coordinates but no `stationId` still render on the map, grouped by coordinate-rounding as a fallback, with a clear "Unassigned location" badge in the popup and a muted grey marker instead of the normal amber one.
- Added `createStationIcon()` to `src/utils/mapConstants.ts` — a themed amber "fuel pump" marker (Lucide's `fuel` icon inlined as SVG, since Leaflet markers are plain DOM) replacing the default Leaflet pin, applied to both `FuelMapPage` and `StationDetail`'s station-location map (#126).
- Confirmed the backfill path already exists: `migrateUserLogsToStations` (`src/utils/migrationService.ts`) finds the nearest station for logs missing `stationId` and is already wired up in `ProfilePage.tsx` with test coverage — no new migration code needed.
- Added `common.unassignedLocation` i18n key with translations across all 10 locales.

## Testing
- `tsc --noEmit` passes.
- Full unit suite passes (179/180 — the 1 failure is the pre-existing flaky `QuickLogPage` test tracked in #135, unrelated to this change).
- No existing test file for `FuelMapPage.tsx`; `StationDetail.test.tsx` (15 tests) still passes unchanged.
- Verified no hardcoded strings via the i18n CI heuristic, locale JSON validity.