### PR TITLE
Resolve #108: Persist notification opt-in and gate weekly digest

### DIFF
--- a/functions/src/__tests__/weeklyDigest.test.ts
+++ b/functions/src/__tests__/weeklyDigest.test.ts
@@ -58,10 +58,43 @@ describe('sendWeeklyDigest', () => {
         expect(mockSend).not.toHaveBeenCalled();
     });
 
+    it('skips users who have not opted in (notificationsEnabled !== true)', async () => {
+        mockFcmGet.mockResolvedValue({
+            empty: false,
+            docs: [{ data: () => ({ userId: 'user1', token: 'fcm-token-123' }) }],
+        });
+        mockProfileGet.mockResolvedValue({
+            exists: true,
+            data: () => ({ homeCurrency: 'EUR', notificationsEnabled: false }),
+        });
+
+        await handler();
+
+        expect(mockSend).not.toHaveBeenCalled();
+        // Never even needs to aggregate fuel logs for an opted-out user.
+        expect(mockAggGet).not.toHaveBeenCalled();
+    });
+
+    it('skips users with no profile document (no explicit opt-in)', async () => {
+        mockFcmGet.mockResolvedValue({
+            empty: false,
+            docs: [{ data: () => ({ userId: 'user1', token: 'fcm-token-123' }) }],
+        });
+        mockProfileGet.mockResolvedValue({ exists: false, data: () => undefined });
+
+        await handler();
+
+        expect(mockSend).not.toHaveBeenCalled();
+    });
+
     it('skips users with no activity in the past 7 days', async () => {
         mockFcmGet.mockResolvedValue({
             empty: false,
             docs: [{ data: () => ({ userId: 'user1', token: 'fcm-token-123' }) }],
+        });
+        mockProfileGet.mockResolvedValue({
+            exists: true,
+            data: () => ({ homeCurrency: 'EUR', notificationsEnabled: true }),
         });
         mockAggGet.mockResolvedValue({
             data: () => ({ logCount: 0, totalSpent: 0, totalLitres: 0, totalKm: 0 }),
@@ -72,17 +105,17 @@ describe('sendWeeklyDigest', () => {
         expect(mockSend).not.toHaveBeenCalled();
     });
 
-    it('sends a push notification for users with activity', async () => {
+    it('sends a push notification for opted-in users with activity', async () => {
         mockFcmGet.mockResolvedValue({
             empty: false,
             docs: [{ data: () => ({ userId: 'user1', token: 'fcm-token-abc' }) }],
         });
-        mockAggGet.mockResolvedValue({
-            data: () => ({ logCount: 3, totalSpent: 90.5, totalLitres: 60.0, totalKm: 400 }),
-        });
         mockProfileGet.mockResolvedValue({
             exists: true,
-            data: () => ({ homeCurrency: 'EUR' }),
+            data: () => ({ homeCurrency: 'EUR', notificationsEnabled: true }),
+        });
+        mockAggGet.mockResolvedValue({
+            data: () => ({ logCount: 3, totalSpent: 90.5, totalLitres: 60.0, totalKm: 400 }),
         });
 
         await handler();
@@ -95,15 +128,15 @@ describe('sendWeeklyDigest', () => {
         expect(call.notification.body).toContain('EUR 90.50');
     });
 
-    it('defaults to EUR when no user profile exists', async () => {
+    it('defaults to EUR when the opted-in profile has no homeCurrency set', async () => {
         mockFcmGet.mockResolvedValue({
             empty: false,
             docs: [{ data: () => ({ userId: 'user2', token: 'fcm-token-xyz' }) }],
         });
+        mockProfileGet.mockResolvedValue({ exists: true, data: () => ({ notificationsEnabled: true }) });
         mockAggGet.mockResolvedValue({
             data: () => ({ logCount: 1, totalSpent: 50, totalLitres: 30, totalKm: 200 }),
         });
-        mockProfileGet.mockResolvedValue({ exists: false, data: () => null });
 
         await handler();
 
@@ -119,10 +152,13 @@ describe('sendWeeklyDigest', () => {
                 { data: () => ({ userId: 'user2', token: 'token-b' }) },
             ],
         });
+        mockProfileGet.mockResolvedValue({
+            exists: true,
+            data: () => ({ homeCurrency: 'EUR', notificationsEnabled: true }),
+        });
         mockAggGet.mockResolvedValue({
             data: () => ({ logCount: 2, totalSpent: 40, totalLitres: 25, totalKm: 150 }),
         });
-        mockProfileGet.mockResolvedValue({ exists: false, data: () => null });
 
         mockSend
             .mockRejectedValueOnce(new Error('token invalid'))

--- a/functions/src/weeklyDigest.ts
+++ b/functions/src/weeklyDigest.ts
@@ -30,6 +30,11 @@ export const sendWeeklyDigest = onSchedule('every monday 08:00', async () => {
         tokensSnap.docs.map(async (tokenDoc) => {
             const { userId, token } = tokenDoc.data() as { userId: string; token: string };
 
+            // notificationsEnabled on the user's profile is the source of truth for
+            // opt-in/opt-out — a leftover or stale fcmTokens doc shouldn't imply consent.
+            const profileDoc = await db.collection('userProfiles').doc(userId).get();
+            if (profileDoc.data()?.notificationsEnabled !== true) return;
+
             // Aggregate stats for the past 7 days
             const aggSnap = await db
                 .collection('fuelLogs')
@@ -49,7 +54,6 @@ export const sendWeeklyDigest = onSchedule('every monday 08:00', async () => {
             // Skip if no activity this week
             if (logCount === 0) return;
 
-            const profileDoc = await db.collection('userProfiles').doc(userId).get();
             const homeCurrency: string = profileDoc.exists ? (profileDoc.data()?.homeCurrency ?? 'EUR') : 'EUR';
 
             const totalSpent = agg.totalSpent ?? 0;

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -12,6 +12,8 @@ interface UserProfile {
   tester_group: boolean;
   /** Optional monthly fuel spend budget, in homeCurrency. Unset = no budget alerts. */
   monthlyBudget?: number;
+  /** Whether the user has opted in to the weekly fuel digest push notification. */
+  notificationsEnabled?: boolean;
 }
 
 // Define the shape of the context value

--- a/src/hooks/useFCMToken.ts
+++ b/src/hooks/useFCMToken.ts
@@ -10,6 +10,8 @@ export interface FCMTokenState {
     isEnabled: boolean;
     /** Whether a permission/token request is in progress */
     isLoading: boolean;
+    /** True after the browser notification permission was explicitly denied */
+    permissionDenied: boolean;
     /** Enable notifications: request permission and persist FCM token */
     enable: () => Promise<void>;
     /** Disable notifications: delete stored FCM token */
@@ -17,9 +19,10 @@ export interface FCMTokenState {
 }
 
 export function useFCMToken(): FCMTokenState {
-    const { user } = useAuth();
+    const { user, updateProfile } = useAuth();
     const [isEnabled, setIsEnabled] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
+    const [permissionDenied, setPermissionDenied] = useState(false);
 
     // Check on mount whether the user already has a stored token
     useEffect(() => {
@@ -42,9 +45,15 @@ export function useFCMToken(): FCMTokenState {
     const enable = useCallback(async () => {
         if (!user) return;
         setIsLoading(true);
+        setPermissionDenied(false);
         try {
             const token = await requestNotificationPermission();
-            if (!token) return;
+            if (!token) {
+                if (typeof Notification !== 'undefined' && Notification.permission === 'denied') {
+                    setPermissionDenied(true);
+                }
+                return;
+            }
 
             // Store token in Firestore — document ID is the token itself for easy upsert
             await setDoc(doc(db, 'fcmTokens', token), {
@@ -54,13 +63,17 @@ export function useFCMToken(): FCMTokenState {
                 createdAt: serverTimestamp(),
                 updatedAt: serverTimestamp(),
             });
+            // notificationsEnabled on the profile is the source of truth the
+            // weeklyDigest Cloud Function checks before sending, separate
+            // from token presence (a stale token shouldn't imply consent).
+            await updateProfile({ notificationsEnabled: true });
             setIsEnabled(true);
         } catch (err) {
             console.error('Failed to enable notifications:', err);
         } finally {
             setIsLoading(false);
         }
-    }, [user]);
+    }, [user, updateProfile]);
 
     const disable = useCallback(async () => {
         if (!user) return;
@@ -69,13 +82,14 @@ export function useFCMToken(): FCMTokenState {
             const q = query(collection(db, 'fcmTokens'), where('userId', '==', user.uid));
             const snap = await getDocs(q);
             await Promise.all(snap.docs.map(d => deleteDoc(d.ref)));
+            await updateProfile({ notificationsEnabled: false });
             setIsEnabled(false);
         } catch (err) {
             console.error('Failed to disable notifications:', err);
         } finally {
             setIsLoading(false);
         }
-    }, [user]);
+    }, [user, updateProfile]);
 
-    return { isEnabled, isLoading, enable, disable };
+    return { isEnabled, isLoading, permissionDenied, enable, disable };
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -300,7 +300,8 @@
       "weeklyDigest": "Wöchentliche Kraftstoffzusammenfassung",
       "weeklyDigestDesc": "Push-Benachrichtigung jeden Montag mit Ihrer wöchentlichen Kraftstoffzusammenfassung.",
       "disable": "Deaktivieren",
-      "enable": "Aktivieren"
+      "enable": "Aktivieren",
+      "permissionDenied": "Benachrichtigungen sind für diese Website in Ihren Browsereinstellungen blockiert. Aktivieren Sie sie in den Website-Berechtigungen Ihres Browsers und versuchen Sie es erneut."
     },
     "maintenance": {
       "heading": "Maintenance",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -309,7 +309,8 @@
       "weeklyDigest": "Weekly fuel digest",
       "weeklyDigestDesc": "Push notification every Monday with your weekly fuel summary.",
       "disable": "Disable",
-      "enable": "Enable"
+      "enable": "Enable",
+      "permissionDenied": "Notifications are blocked for this site in your browser settings. Enable them in your browser's site permissions, then try again."
     }
   },
   "receipt": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -300,7 +300,8 @@
       "weeklyDigest": "Resumen semanal de combustible",
       "weeklyDigestDesc": "Notificación push cada lunes con tu resumen semanal de combustible.",
       "disable": "Desactivar",
-      "enable": "Activar"
+      "enable": "Activar",
+      "permissionDenied": "Las notificaciones están bloqueadas para este sitio en la configuración de tu navegador. Habilítalas en los permisos del sitio de tu navegador e inténtalo de nuevo."
     },
     "maintenance": {
       "heading": "Maintenance",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -300,7 +300,8 @@
       "weeklyDigest": "Viikoittainen polttoaineyhteenveto",
       "weeklyDigestDesc": "Push-ilmoitus joka maanantai viikoittaisella polttoaineyhteenvedollasi.",
       "disable": "Poista käytöstä",
-      "enable": "Ota käyttöön"
+      "enable": "Ota käyttöön",
+      "permissionDenied": "Ilmoitukset on estetty tälle sivustolle selaimesi asetuksissa. Ota ne käyttöön selaimesi sivustoluvissa ja yritä uudelleen."
     },
     "maintenance": {
       "heading": "Maintenance",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -300,7 +300,8 @@
       "weeklyDigest": "Récapitulatif hebdomadaire de carburant",
       "weeklyDigestDesc": "Notification push chaque lundi avec votre récapitulatif hebdomadaire de carburant.",
       "disable": "Désactiver",
-      "enable": "Activer"
+      "enable": "Activer",
+      "permissionDenied": "Les notifications sont bloquées pour ce site dans les paramètres de votre navigateur. Activez-les dans les autorisations de site de votre navigateur, puis réessayez."
     },
     "maintenance": {
       "heading": "Maintenance",

--- a/src/i18n/locales/ga.json
+++ b/src/i18n/locales/ga.json
@@ -300,7 +300,8 @@
       "weeklyDigest": "Achoimre breosla seachtainiúil",
       "weeklyDigestDesc": "Fógra brúite gach Luan le do achoimre breosla seachtainiúil.",
       "disable": "Díchumasaigh",
-      "enable": "Cumasaigh"
+      "enable": "Cumasaigh",
+      "permissionDenied": "Tá fógraí coiscthe don suíomh seo i socruithe do bhrabhsálaí. Cumasaigh iad i gceadanna suímh do bhrabhsálaí, ansin bain triail eile as."
     },
     "maintenance": {
       "heading": "Maintenance",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -300,7 +300,8 @@
       "weeklyDigest": "週間燃料サマリー",
       "weeklyDigestDesc": "毎週月曜日に週間燃料サマリーをプッシュ通知でお届けします。",
       "disable": "無効にする",
-      "enable": "有効にする"
+      "enable": "有効にする",
+      "permissionDenied": "このサイトの通知はブラウザの設定でブロックされています。ブラウザのサイト権限で通知を有効にしてから、再度お試しください。"
     },
     "maintenance": {
       "heading": "Maintenance",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -300,7 +300,8 @@
       "weeklyDigest": "주간 연료 요약",
       "weeklyDigestDesc": "매주 월요일 주간 연료 요약을 푸시 알림으로 받아보세요.",
       "disable": "비활성화",
-      "enable": "활성화"
+      "enable": "활성화",
+      "permissionDenied": "이 사이트의 알림이 브라우저 설정에서 차단되어 있습니다. 브라우저의 사이트 권한에서 알림을 활성화한 후 다시 시도하세요."
     },
     "maintenance": {
       "heading": "Maintenance",

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -300,7 +300,8 @@
       "weeklyDigest": "Ukentlig drivstoffsammendrag",
       "weeklyDigestDesc": "Push-varsel hver mandag med ditt ukentlige drivstoffsammendrag.",
       "disable": "Deaktiver",
-      "enable": "Aktiver"
+      "enable": "Aktiver",
+      "permissionDenied": "Varsler er blokkert for dette nettstedet i nettleserinnstillingene dine. Aktiver dem i nettleserens nettstedstillatelser, og prøv igjen."
     },
     "maintenance": {
       "heading": "Maintenance",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -300,7 +300,8 @@
       "weeklyDigest": "Veckovis bränsleöversikt",
       "weeklyDigestDesc": "Push-avisering varje måndag med din veckovisa bränsleöversikt.",
       "disable": "Inaktivera",
-      "enable": "Aktivera"
+      "enable": "Aktivera",
+      "permissionDenied": "Aviseringar är blockerade för denna webbplats i dina webbläsarinställningar. Aktivera dem i webbläsarens webbplatsbehörigheter och försök igen."
     },
     "maintenance": {
       "heading": "Maintenance",

--- a/src/pages/ProfilePage.test.tsx
+++ b/src/pages/ProfilePage.test.tsx
@@ -20,8 +20,9 @@ vi.mock('../context/AuthContext', () => ({
   useAuth: () => ({ user: mockUser, profile: mockProfile, updateProfile: mockUpdateProfile }),
 }));
 
+let mockFCMState = { isEnabled: false, isLoading: false, permissionDenied: false };
 vi.mock('../hooks/useFCMToken', () => ({
-  useFCMToken: () => ({ isEnabled: false, isLoading: false, enable: vi.fn(), disable: vi.fn() }),
+  useFCMToken: () => ({ ...mockFCMState, enable: vi.fn(), disable: vi.fn() }),
 }));
 
 vi.mock('../components/ApiTokenManager', () => ({ default: () => <div /> }));
@@ -53,6 +54,7 @@ describe('ProfilePage monthly budget field', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockProfile = { homeCurrency: 'EUR' };
+    mockFCMState = { isEnabled: false, isLoading: false, permissionDenied: false };
     vi.mocked(getDocs).mockResolvedValue(mockSnapshot([]) as never);
   });
 
@@ -111,5 +113,19 @@ describe('ProfilePage monthly budget field', () => {
     fireEvent.blur(input);
 
     expect(mockUpdateProfile).not.toHaveBeenCalled();
+  });
+
+  it('shows a browser-permission warning when notifications are denied', async () => {
+    mockFCMState = { isEnabled: false, isLoading: false, permissionDenied: true };
+    render(<ProfilePage />);
+    await waitFor(() => {
+      expect(screen.getByText(/Notifications are blocked for this site/)).toBeInTheDocument();
+    });
+  });
+
+  it('does not show the permission warning when notifications are not denied', async () => {
+    render(<ProfilePage />);
+    await waitFor(() => expect(screen.getByText('Weekly fuel digest')).toBeInTheDocument());
+    expect(screen.queryByText(/Notifications are blocked for this site/)).not.toBeInTheDocument();
   });
 });

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -14,7 +14,7 @@ import { migrateUserLogsToStations } from '../utils/migrationService';
 function ProfilePage(): JSX.Element {
   const { user, profile, updateProfile } = useAuth();
   const { t } = useTranslation();
-  const { isEnabled: notificationsEnabled, isLoading: notificationsLoading, enable: enableNotifications, disable: disableNotifications } = useFCMToken();
+  const { isEnabled: notificationsEnabled, isLoading: notificationsLoading, permissionDenied: notificationsPermissionDenied, enable: enableNotifications, disable: disableNotifications } = useFCMToken();
   const [vehicles, setVehicles] = useState<Vehicle[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [isSaving, setIsUpdating] = useState<boolean>(false);
@@ -464,6 +464,11 @@ function ProfilePage(): JSX.Element {
               : t('profile.notifications.enable', { defaultValue: 'Enable' })}
           </button>
         </div>
+        {notificationsPermissionDenied && (
+          <p className="mt-4 text-sm text-red-600 dark:text-red-400">
+            {t('profile.notifications.permissionDenied', { defaultValue: 'Notifications are blocked for this site in your browser settings. Enable them in your browser\'s site permissions, then try again.' })}
+          </p>
+        )}
       </div>
 
       {/* API Access Section */}


### PR DESCRIPTION
Closes #108

## Context
The Notifications toggle already existed in `ProfilePage.tsx` (wired to `useFCMToken`), but it only wrote to the `fcmTokens` collection — there was no explicit `notificationsEnabled` flag on the user's profile, and the `weeklyDigest` Cloud Function sent to every registered token unconditionally.

## Changes
- Added `notificationsEnabled?: boolean` to `UserProfile` (`AuthContext.tsx`).
- `useFCMToken`'s `enable()`/`disable()` now persist `notificationsEnabled: true`/`false` via the existing `updateProfile()`, alongside the existing `fcmTokens` document create/delete — this is the explicit source of truth for opt-in/opt-out, since a leftover or stale token shouldn't imply consent on its own.
- Added a `permissionDenied` state to `useFCMToken`, set when the browser notification permission is explicitly denied. `ProfilePage.tsx` now shows a message directing the user to their browser's site permissions in that case.
- `weeklyDigest` Cloud Function now checks `notificationsEnabled === true` on the user's profile *before* aggregating fuel logs or sending — opted-out users (or users with no profile at all) are skipped entirely, without even running the Firestore aggregation query for them.

## Testing
- Updated `functions/src/__tests__/weeklyDigest.test.ts`: added two new tests (skips non-opted-in users, skips users with no profile doc) and updated the existing "sends/skips" tests to set `notificationsEnabled: true` where a send is expected. All 7 tests pass.
- Added two new `ProfilePage.test.tsx` tests covering the permission-denied warning (shown/not shown). All 8 tests pass.
- `tsc --noEmit` passes for both the main app and `functions/`.
- Full unit suite passes (182/182).
- Verified no hardcoded strings via the i18n CI heuristic, locale JSON validity.