### PR TITLE
fix: recalculate distance reactively to fix flaky QuickLogPage test (#135)

### DIFF
--- a/src/pages/QuickLogPage.tsx
+++ b/src/pages/QuickLogPage.tsx
@@ -204,15 +204,19 @@ function QuickLogPage(): JSX.Element {
     (e: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => { setter(e.target.value); };
 
   const handleOdometerChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const val = e.target.value;
-    setOdometerKmInput(val);
-    
-    const parsedOdo = parseFloat(val);
-    if (!isNaN(parsedOdo) && lastOdometerReading !== null) {
-      const diff = calculateDistance(parsedOdo, lastOdometerReading);
-      setDistanceKmInput(diff !== null ? diff.toFixed(1) : '');
-    }
+    setOdometerKmInput(e.target.value);
   };
+
+  // Recalculate distance whenever the odometer reading or the last known
+  // reading changes, so a late-arriving lastOdometerReading (e.g. slow
+  // network) still auto-fills the distance instead of being silently missed.
+  useEffect(() => {
+    if (!odometerKmInput || lastOdometerReading === null) return;
+    const parsedOdo = parseFloat(odometerKmInput);
+    if (isNaN(parsedOdo)) return;
+    const diff = calculateDistance(parsedOdo, lastOdometerReading);
+    setDistanceKmInput(diff !== null ? diff.toFixed(1) : '');
+  }, [odometerKmInput, lastOdometerReading]);
 
   // --- Exchange Rate Change Handler ---
   const handleRateChange = (e: ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Closes #135

## Root cause
`handleOdometerChange` computed the auto-filled distance synchronously inside the change-event handler using the `lastOdometerReading` state value available *at that instant*. `lastOdometerReading` is itself populated asynchronously (it depends on `selectedVehicleId`, which depends on an earlier async vehicles fetch). If the user (or test) changes the odometer field before that chain resolves, the distance is silently never calculated — even once the reading arrives later, nothing re-triggers the calculation.

This is a real bug (not just test flakiness): on a slow connection a user could type their odometer reading and get no auto-filled distance.

## Fix
Moved the distance calculation out of the change handler and into a `useEffect` keyed on `[odometerKmInput, lastOdometerReading]`, so it recalculates deterministically whenever either value changes, regardless of ordering.

## Testing
- Ran `QuickLogPage.test.tsx` 8x in a loop locally — all green, no flakes.
- Full test suite (182 tests) passes.
- `tsc -b` and `eslint` clean (pre-existing unrelated warning untouched).