### PR TITLE
fix: drop Dashboard from mobile bottom nav to reduce crowding (#141)

### DIFF
--- a/src/components/BottomNav.test.tsx
+++ b/src/components/BottomNav.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect } from 'vitest';
+import BottomNav from './BottomNav';
+
+describe('BottomNav', () => {
+  it('renders exactly 5 destinations to keep tap targets comfortable on mobile (#141)', () => {
+    render(
+      <MemoryRouter>
+        <BottomNav />
+      </MemoryRouter>
+    );
+
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(5);
+  });
+
+  it('links to Log, History, Map, Stations, and Profile, but not Dashboard', () => {
+    render(
+      <MemoryRouter>
+        <BottomNav />
+      </MemoryRouter>
+    );
+
+    const hrefs = screen.getAllByRole('link').map((link) => link.getAttribute('href'));
+    expect(hrefs).toEqual(['/', '/history', '/map', '/stations', '/profile']);
+    expect(hrefs).not.toContain('/dashboard');
+  });
+});

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,6 +1,6 @@
 import { JSX } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { History, Map as MapIcon, User, PlusCircle, Fuel, LayoutDashboard } from 'lucide-react';
+import { History, Map as MapIcon, User, PlusCircle, Fuel } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 /**
@@ -11,9 +11,11 @@ const BottomNav = (): JSX.Element => {
   const location = useLocation();
   const { t } = useTranslation();
 
+  // Dashboard is intentionally omitted from the mobile bottom nav to keep
+  // tap targets and labels comfortable at narrow widths (#141). It remains
+  // reachable on mobile via a link on the Log page, and via the desktop top nav.
   const navItems = [
     { path: '/', label: t('nav.log'), icon: PlusCircle },
-    { path: '/dashboard', label: t('nav.dashboard'), icon: LayoutDashboard },
     { path: '/history', label: t('nav.history'), icon: History },
     { path: '/map', label: t('nav.map'), icon: MapIcon },
     { path: '/stations', label: t('nav.stations'), icon: Fuel },

--- a/src/pages/QuickLogPage.test.tsx
+++ b/src/pages/QuickLogPage.test.tsx
@@ -6,6 +6,7 @@ import { getLastOdometerReading, getOrCreateStation, updateStationMetrics } from
 import { extractDataFromReceipt } from '../utils/gemini';
 import { findNearestStation, isAccurateEnoughForStationMatch } from '../utils/locationService';
 import QuickLogPage from './QuickLogPage';
+import { MemoryRouter } from 'react-router-dom';
 
 const mockT = (key: string, opts?: Record<string, unknown>) => {
   const template = opts && 'defaultValue' in opts ? (opts.defaultValue as string) : key;
@@ -105,7 +106,7 @@ describe('QuickLogPage', () => {
   });
 
   it('saves a fuel log with the correct payload on the happy path', async () => {
-    render(<QuickLogPage />);
+    render(<MemoryRouter><QuickLogPage /></MemoryRouter>);
 
     await waitFor(() => expect(screen.getByLabelText('quickLog.fields.totalCost')).toBeInTheDocument());
 
@@ -133,7 +134,7 @@ describe('QuickLogPage', () => {
   });
 
   it('shows a validation error when required fields are missing', async () => {
-    render(<QuickLogPage />);
+    render(<MemoryRouter><QuickLogPage /></MemoryRouter>);
 
     await waitFor(() => expect(screen.getByLabelText('quickLog.fields.totalCost')).toBeInTheDocument());
 
@@ -146,7 +147,7 @@ describe('QuickLogPage', () => {
   it('auto-populates distance from the odometer reading when a prior reading exists', async () => {
     vi.mocked(getLastOdometerReading).mockResolvedValue(10000);
 
-    render(<QuickLogPage />);
+    render(<MemoryRouter><QuickLogPage /></MemoryRouter>);
 
     await waitFor(() => expect(screen.getByLabelText('quickLog.fields.odometer')).toBeInTheDocument());
 
@@ -160,7 +161,7 @@ describe('QuickLogPage', () => {
   it('fetches the exchange rate and stores originalCost + exchangeRate when a non-home currency is selected', async () => {
     vi.mocked(fetchExchangeRate).mockResolvedValue(1.1);
 
-    render(<QuickLogPage />);
+    render(<MemoryRouter><QuickLogPage /></MemoryRouter>);
 
     await waitFor(() => expect(screen.getByLabelText('quickLog.fields.currency')).toBeInTheDocument());
 
@@ -189,7 +190,7 @@ describe('QuickLogPage', () => {
   it('extracts and pre-fills form fields from a receipt image', async () => {
     vi.mocked(extractDataFromReceipt).mockResolvedValue({ cost: 42.5, fuelAmountLiters: 28, brand: 'Esso' });
 
-    render(<QuickLogPage />);
+    render(<MemoryRouter><QuickLogPage /></MemoryRouter>);
 
     await waitFor(() => expect(screen.getByLabelText('quickLog.fields.totalCost')).toBeInTheDocument());
 
@@ -221,7 +222,7 @@ describe('QuickLogPage', () => {
       vi.mocked(isAccurateEnoughForStationMatch).mockReturnValue(false);
       setGeolocationAccuracy(500);
 
-      render(<QuickLogPage />);
+      render(<MemoryRouter><QuickLogPage /></MemoryRouter>);
 
       await waitFor(() => expect(screen.getByLabelText('quickLog.fields.totalCost')).toBeInTheDocument());
 
@@ -246,7 +247,7 @@ describe('QuickLogPage', () => {
       vi.mocked(isAccurateEnoughForStationMatch).mockReturnValue(true);
       setGeolocationAccuracy(20);
 
-      render(<QuickLogPage />);
+      render(<MemoryRouter><QuickLogPage /></MemoryRouter>);
 
       await waitFor(() => expect(screen.getByLabelText('quickLog.fields.totalCost')).toBeInTheDocument());
 
@@ -264,7 +265,7 @@ describe('QuickLogPage', () => {
       vi.mocked(isAccurateEnoughForStationMatch).mockReturnValue(false);
       setGeolocationAccuracy(500);
 
-      render(<QuickLogPage />);
+      render(<MemoryRouter><QuickLogPage /></MemoryRouter>);
       await waitFor(() => expect(screen.getByLabelText('quickLog.fields.totalCost')).toBeInTheDocument());
 
       fireEvent.change(screen.getByLabelText('quickLog.fields.totalCost'), { target: { value: '50' } });
@@ -314,7 +315,7 @@ describe('QuickLogPage', () => {
       })
     );
 
-    render(<QuickLogPage />);
+    render(<MemoryRouter><QuickLogPage /></MemoryRouter>);
 
     await waitFor(() => expect(screen.getByLabelText('quickLog.fields.totalCost')).toBeInTheDocument());
 

--- a/src/pages/QuickLogPage.tsx
+++ b/src/pages/QuickLogPage.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '../context/AuthContext';
 import { fetchExchangeRate, COMMON_CURRENCIES } from '../utils/currencyApi';
 import { Vehicle, FuelLogData } from '../utils/types';
 import { Link } from 'react-router-dom';
+import { LayoutDashboard } from 'lucide-react';
 import { useRemoteConfig } from '../context/RemoteConfigContext';
 import { uploadReceipt } from '../firebase/storageService';
 import { getLastOdometerReading, getOrCreateStation, updateStationMetrics } from '../firebase/firestoreService';
@@ -409,7 +410,16 @@ function QuickLogPage(): JSX.Element {
   return (
     <div className="container mx-auto max-w-lg px-4">
         <div className="bg-white dark:bg-gray-800 shadow-lg rounded-xl p-6 sm:p-8 border border-gray-200 dark:border-gray-700">
-            <h2 className="text-2xl font-bold text-gray-800 dark:text-white mb-6 text-center">{t('quickLog.title')}</h2>
+            <div className="flex items-center justify-center gap-2 mb-6">
+              <h2 className="text-2xl font-bold text-gray-800 dark:text-white text-center">{t('quickLog.title')}</h2>
+              <Link
+                to="/dashboard"
+                aria-label={t('nav.dashboard')}
+                className="sm:hidden text-gray-400 dark:text-gray-500 hover:text-brand-primary transition-colors"
+              >
+                <LayoutDashboard size={20} />
+              </Link>
+            </div>
 
             {isLoadingVehicles ? (
               <div className="text-center py-8">

--- a/src/pages/QuickLogPage.tsx
+++ b/src/pages/QuickLogPage.tsx
@@ -415,7 +415,7 @@ function QuickLogPage(): JSX.Element {
               <Link
                 to="/dashboard"
                 aria-label={t('nav.dashboard')}
-                className="sm:hidden text-gray-400 dark:text-gray-500 hover:text-brand-primary transition-colors"
+                className="sm:hidden p-2 -m-2 text-gray-400 dark:text-gray-500 hover:text-brand-primary transition-colors"
               >
                 <LayoutDashboard size={20} />
               </Link>


### PR DESCRIPTION
Closes #141

## Problem
`BottomNav.tsx` rendered 6 always-visible items (Log, Dashboard, History, Map, Stations, Profile), which is cramped at common mobile widths (360-414px) per typical bottom-nav UX guidance (~5 max).

## Fix
- Removed Dashboard from the bottom nav, bringing it down to 5 items: Log, History, Map, Stations, Profile.
- Added a small Dashboard shortcut icon next to the title on the Log page (mobile-only, `sm:hidden`) so Dashboard remains reachable from mobile without a dedicated bottom-nav slot.
- Desktop top nav (`AuthenticatedApp.tsx`) is untouched and still links to all 6 destinations.

## Testing
- Added `BottomNav.test.tsx` asserting exactly 5 links and the expected hrefs (excluding `/dashboard`).
- Existing `QuickLogPage.test.tsx` updated to wrap renders in `MemoryRouter` (now required since the page renders a `Link` unconditionally).
- Full suite: 184/184 tests pass. `tsc -b` and `eslint` clean (pre-existing unrelated warning untouched).