### PR TITLE
feat: move CSV import into Profile, add one-time onboarding prompt (#154)

### DIFF
--- a/src/components/AuthenticatedApp.test.tsx
+++ b/src/components/AuthenticatedApp.test.tsx
@@ -27,7 +27,12 @@ vi.mock('firebase/firestore', async (importOriginal) => {
 });
 
 vi.mock('../context/AuthContext', () => ({
-  useAuth: () => ({ user: { displayName: 'Test User', uid: 'u1' }, logout: vi.fn() }),
+  useAuth: () => ({
+    user: { displayName: 'Test User', uid: 'u1' },
+    profile: { hasSeenImportOnboarding: false },
+    updateProfile: vi.fn(),
+    logout: vi.fn(),
+  }),
 }));
 
 vi.mock('../context/ThemeContext', () => ({
@@ -48,5 +53,25 @@ describe('AuthenticatedApp header', () => {
     );
 
     expect(screen.getByLabelText('language.label')).toBeInTheDocument();
+  });
+
+  it('no longer shows Import as a top-level nav destination (#154)', () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <AuthenticatedApp />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText('nav.import')).not.toBeInTheDocument();
+  });
+
+  it('shows the import onboarding prompt for a user who has not seen it (#154)', () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <AuthenticatedApp />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('importOnboarding.heading')).toBeInTheDocument();
   });
 });

--- a/src/components/AuthenticatedApp.tsx
+++ b/src/components/AuthenticatedApp.tsx
@@ -8,6 +8,7 @@ import { Routes, Route, Link, Navigate, useLocation } from 'react-router-dom';
 import InstallPrompt from './InstallPrompt';
 import BottomNav from './BottomNav';
 import SyncStatus from './SyncStatus';
+import ImportOnboardingPrompt from './ImportOnboardingPrompt';
 
 // Wraps React.lazy with a single reload on chunk fetch failure.
 // This handles the stale-PWA-cache scenario where a new deploy renames
@@ -91,7 +92,6 @@ function AuthenticatedApp(): JSX.Element {
             <Link to="/" className={getNavLinkClass("/")}>{t('nav.log')}</Link>
             <Link to="/dashboard" className={getNavLinkClass("/dashboard")}>{t('nav.dashboard')}</Link>
             <Link to="/history" className={getNavLinkClass("/history")}>{t('nav.history')}</Link>
-            <Link to="/import" className={getNavLinkClass("/import")}>{t('nav.import')}</Link>
             <Link to="/profile" className={getNavLinkClass("/profile")}>{t('nav.profile')}</Link>
             <Link to="/map" className={getNavLinkClass("/map")}>{t('nav.map')}</Link>
             <Link to="/stations" className={getNavLinkClass("/stations")}>{t('nav.stations')}</Link>
@@ -121,6 +121,7 @@ function AuthenticatedApp(): JSX.Element {
       <main className={`flex-grow container mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8 w-full min-w-0 ${
         WIDE_LAYOUT_PATHS.has(location.pathname.replace(/\/$/, '')) ? 'max-w-7xl' : 'max-w-5xl'
       }`}>
+        <ImportOnboardingPrompt />
         <ErrorBoundary>
         <Suspense fallback={<PageLoader />}>
           <Routes>

--- a/src/components/ImportOnboardingPrompt.test.tsx
+++ b/src/components/ImportOnboardingPrompt.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ImportOnboardingPrompt from './ImportOnboardingPrompt';
+
+const mockUpdateProfile = vi.fn();
+let mockProfile: { hasSeenImportOnboarding?: boolean } | null = {};
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../context/AuthContext', () => ({
+  useAuth: () => ({ profile: mockProfile, updateProfile: mockUpdateProfile }),
+}));
+
+function renderPrompt() {
+  return render(
+    <MemoryRouter>
+      <ImportOnboardingPrompt />
+    </MemoryRouter>
+  );
+}
+
+describe('ImportOnboardingPrompt (#154)', () => {
+  beforeEach(() => {
+    mockUpdateProfile.mockClear();
+    mockProfile = {};
+  });
+
+  it('renders the prompt for a profile that has not seen onboarding', () => {
+    renderPrompt();
+    expect(screen.getByText('importOnboarding.heading')).toBeInTheDocument();
+  });
+
+  it('does not render once hasSeenImportOnboarding is true', () => {
+    mockProfile = { hasSeenImportOnboarding: true };
+    const { container } = renderPrompt();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('does not render when profile is not loaded yet', () => {
+    mockProfile = null;
+    const { container } = renderPrompt();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('persists dismissal via updateProfile when the dismiss button is clicked', () => {
+    renderPrompt();
+    fireEvent.click(screen.getByLabelText('importOnboarding.dismiss'));
+    expect(mockUpdateProfile).toHaveBeenCalledWith({ hasSeenImportOnboarding: true });
+  });
+
+  it('persists dismissal via updateProfile when the import CTA is followed', () => {
+    renderPrompt();
+    fireEvent.click(screen.getByText('importOnboarding.cta'));
+    expect(mockUpdateProfile).toHaveBeenCalledWith({ hasSeenImportOnboarding: true });
+  });
+});

--- a/src/components/ImportOnboardingPrompt.test.tsx
+++ b/src/components/ImportOnboardingPrompt.test.tsx
@@ -3,7 +3,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import ImportOnboardingPrompt from './ImportOnboardingPrompt';
 
-const mockUpdateProfile = vi.fn();
+const mockUpdateProfile = vi.fn().mockResolvedValue(undefined);
 let mockProfile: { hasSeenImportOnboarding?: boolean } | null = {};
 
 vi.mock('react-i18next', () => ({
@@ -25,6 +25,7 @@ function renderPrompt() {
 describe('ImportOnboardingPrompt (#154)', () => {
   beforeEach(() => {
     mockUpdateProfile.mockClear();
+    mockUpdateProfile.mockResolvedValue(undefined);
     mockProfile = {};
   });
 

--- a/src/components/ImportOnboardingPrompt.tsx
+++ b/src/components/ImportOnboardingPrompt.tsx
@@ -1,0 +1,47 @@
+import { JSX } from 'react';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { UploadCloud, X } from 'lucide-react';
+import { useAuth } from '../context/AuthContext';
+
+/**
+ * One-time banner nudging new users toward the CSV import flow (#154).
+ * Shown until the user dismisses it or follows the import link; persisted
+ * via `hasSeenImportOnboarding` on the user's profile so it never reappears.
+ */
+function ImportOnboardingPrompt(): JSX.Element | null {
+  const { t } = useTranslation();
+  const { profile, updateProfile } = useAuth();
+
+  if (!profile || profile.hasSeenImportOnboarding) return null;
+
+  const dismiss = () => {
+    updateProfile({ hasSeenImportOnboarding: true });
+  };
+
+  return (
+    <div className="bg-indigo-50 dark:bg-indigo-900/20 border border-indigo-200 dark:border-indigo-800 rounded-xl p-4 mb-6 flex items-start gap-3">
+      <UploadCloud size={20} className="text-indigo-600 dark:text-indigo-400 shrink-0 mt-0.5" />
+      <div className="flex-grow">
+        <p className="text-sm font-bold text-indigo-900 dark:text-indigo-200">{t('importOnboarding.heading')}</p>
+        <p className="text-xs text-indigo-700/80 dark:text-indigo-300/80 mt-1">{t('importOnboarding.description')}</p>
+        <Link
+          to="/import"
+          onClick={dismiss}
+          className="inline-block mt-3 text-xs font-bold text-white bg-indigo-600 hover:bg-indigo-700 rounded-lg px-3 py-1.5 transition-colors"
+        >
+          {t('importOnboarding.cta')}
+        </Link>
+      </div>
+      <button
+        onClick={dismiss}
+        aria-label={t('importOnboarding.dismiss')}
+        className="text-indigo-400 hover:text-indigo-600 dark:hover:text-indigo-200 shrink-0"
+      >
+        <X size={18} />
+      </button>
+    </div>
+  );
+}
+
+export default ImportOnboardingPrompt;

--- a/src/components/ImportOnboardingPrompt.tsx
+++ b/src/components/ImportOnboardingPrompt.tsx
@@ -16,7 +16,9 @@ function ImportOnboardingPrompt(): JSX.Element | null {
   if (!profile || profile.hasSeenImportOnboarding) return null;
 
   const dismiss = () => {
-    updateProfile({ hasSeenImportOnboarding: true });
+    updateProfile({ hasSeenImportOnboarding: true }).catch((error) => {
+      console.error('Failed to persist import onboarding dismissal:', error);
+    });
   };
 
   return (

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -14,6 +14,8 @@ interface UserProfile {
   monthlyBudget?: number;
   /** Whether the user has opted in to the weekly fuel digest push notification. */
   notificationsEnabled?: boolean;
+  /** Whether the one-time CSV import onboarding prompt has been shown/dismissed. */
+  hasSeenImportOnboarding?: boolean;
 }
 
 // Define the shape of the context value

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -5,8 +5,7 @@
     "map": "Karte",
     "profile": "Profil",
     "stations": "Tankstellen",
-    "dashboard": "Übersicht",
-    "import": "Import"
+    "dashboard": "Übersicht"
   },
   "login": {
     "tagline": "Präzise Kraftstoffverfolgung",
@@ -251,6 +250,11 @@
     "monthlyBudgetPlaceholder": "Kein Budget festgelegt",
     "measurementUnits": "Maßeinheiten",
     "measurementUnitsSoon": "Demnächst: Umschalten zwischen Metrisch (Km/L) und Imperial (MPG).",
+    "dataImport": {
+      "heading": "Datenimport",
+      "description": "Erfasst du Tankdaten schon anderswo? Importiere deine bisherigen Einträge aus einer CSV-Datei.",
+      "cta": "Zum Import"
+    },
     "vehicleFleet": "Fahrzeugflotte",
     "vehicleFleetSubtext": "Verwalten Sie Ihre Autos und Mietwagen.",
     "showArchived": "Archivierte anzeigen ({{count}})",
@@ -364,6 +368,12 @@
       "insufficientColumns": "Zeile {{row}}: Unzureichende Spaltenanzahl.",
       "foundErrors": "{{count}} Fehler bei der Verarbeitung gefunden. Erste Fehler: {{errors}}"
     }
+  },
+  "importOnboarding": {
+    "heading": "Importiere deine bestehenden Tankprotokolle",
+    "description": "Erfasst du Tankdaten schon anderswo? Importiere deine bisherigen Einträge per CSV-Datei in wenigen Klicks.",
+    "cta": "Jetzt importieren",
+    "dismiss": "Schließen"
   },
   "apiTokens": {
     "title": "API-Zugang",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -5,8 +5,7 @@
     "map": "Map",
     "profile": "Profile",
     "stations": "Stations",
-    "dashboard": "Dashboard",
-    "import": "Import"
+    "dashboard": "Dashboard"
   },
   "login": {
     "tagline": "Precision Fuel Tracking",
@@ -251,6 +250,11 @@
     "monthlyBudgetPlaceholder": "No budget set",
     "measurementUnits": "Measurement Units",
     "measurementUnitsSoon": "Coming soon: Toggle between Metric (Km/L) and Imperial (MPG) defaults.",
+    "dataImport": {
+      "heading": "Data Import",
+      "description": "Already tracking fuel elsewhere? Import your past logs from a CSV file.",
+      "cta": "Go to Import"
+    },
     "maintenance": {
       "heading": "Maintenance",
       "migrateStations": "Link Stations",
@@ -364,6 +368,12 @@
       "insufficientColumns": "Row {{row}}: Insufficient columns.",
       "foundErrors": "Found {{count}} errors during parsing. First few: {{errors}}"
     }
+  },
+  "importOnboarding": {
+    "heading": "Import your existing fuel logs",
+    "description": "Already tracking fuel elsewhere? Import your past logs from a CSV file in a few clicks.",
+    "cta": "Import now",
+    "dismiss": "Dismiss"
   },
   "apiTokens": {
     "title": "API Access",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -5,8 +5,7 @@
     "map": "Mapa",
     "profile": "Perfil",
     "stations": "Gasolineras",
-    "dashboard": "Panel",
-    "import": "Importar"
+    "dashboard": "Panel"
   },
   "login": {
     "tagline": "Seguimiento de Combustible Preciso",
@@ -251,6 +250,11 @@
     "monthlyBudgetPlaceholder": "Sin presupuesto",
     "measurementUnits": "Unidades de Medida",
     "measurementUnitsSoon": "Próximamente: Cambio entre Métrico (Km/L) e Imperial (MPG).",
+    "dataImport": {
+      "heading": "Importación de Datos",
+      "description": "¿Ya llevas un registro de combustible en otro lugar? Importa tus registros anteriores desde un archivo CSV.",
+      "cta": "Ir a Importar"
+    },
     "vehicleFleet": "Flota de Vehículos",
     "vehicleFleetSubtext": "Administra tus coches y alquileres.",
     "showArchived": "Mostrar Archivados ({{count}})",
@@ -364,6 +368,12 @@
       "insufficientColumns": "Fila {{row}}: Columnas insuficientes.",
       "foundErrors": "Se encontraron {{count}} errores durante el análisis. Primeros errores: {{errors}}"
     }
+  },
+  "importOnboarding": {
+    "heading": "Importa tus registros de combustible existentes",
+    "description": "¿Ya llevas un registro de combustible en otro lugar? Importa tus registros anteriores desde un archivo CSV en pocos clics.",
+    "cta": "Importar ahora",
+    "dismiss": "Cerrar"
   },
   "apiTokens": {
     "title": "Acceso API",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -5,8 +5,7 @@
     "map": "Kartta",
     "profile": "Profiili",
     "stations": "Asemat",
-    "dashboard": "Yleiskatsaus",
-    "import": "Tuo"
+    "dashboard": "Yleiskatsaus"
   },
   "login": {
     "tagline": "Tarkka polttoaineen seuranta",
@@ -251,6 +250,11 @@
     "monthlyBudgetPlaceholder": "Budjettia ei asetettu",
     "measurementUnits": "Mittayksiköt",
     "measurementUnitsSoon": "Tulossa pian: Vaihda metrisen (Km/L) ja imperiaalisen (MPG) välillä.",
+    "dataImport": {
+      "heading": "Tietojen tuonti",
+      "description": "Seuraatko polttoaineenkulutusta jo muualla? Tuo aiemmat merkinnät CSV-tiedostosta.",
+      "cta": "Siirry tuontiin"
+    },
     "vehicleFleet": "Ajoneuvot",
     "vehicleFleetSubtext": "Hallitse autojasi.",
     "showArchived": "Näytä arkistoidut ({{count}})",
@@ -364,6 +368,12 @@
       "insufficientColumns": "Rivi {{row}}: Liian vähän sarakkeita.",
       "foundErrors": "Löytyi {{count}} virhettä jäsennyksen aikana. Ensimmäiset: {{errors}}"
     }
+  },
+  "importOnboarding": {
+    "heading": "Tuo aiemmat polttoainemerkinnät",
+    "description": "Seuraatko polttoaineenkulutusta jo muualla? Tuo aiemmat merkinnät CSV-tiedostosta muutamalla klikkauksella.",
+    "cta": "Tuo nyt",
+    "dismiss": "Sulje"
   },
   "apiTokens": {
     "title": "API-pääsy",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -5,8 +5,7 @@
     "map": "Carte",
     "profile": "Profil",
     "stations": "Stations",
-    "dashboard": "Tableau de bord",
-    "import": "Importer"
+    "dashboard": "Tableau de bord"
   },
   "login": {
     "tagline": "Suivi de Carburant Précis",
@@ -251,6 +250,11 @@
     "monthlyBudgetPlaceholder": "Aucun budget défini",
     "measurementUnits": "Unités de Mesure",
     "measurementUnitsSoon": "Bientôt : Basculer entre Métrique (Km/L) et Impérial (MPG).",
+    "dataImport": {
+      "heading": "Importation de Données",
+      "description": "Vous suivez déjà votre consommation ailleurs ? Importez vos anciens relevés depuis un fichier CSV.",
+      "cta": "Aller à l'import"
+    },
     "vehicleFleet": "Flotte de Véhicules",
     "vehicleFleetSubtext": "Gérez vos voitures et locations.",
     "showArchived": "Afficher les Archivés ({{count}})",
@@ -364,6 +368,12 @@
       "insufficientColumns": "Ligne {{row}} : Colonnes insuffisantes.",
       "foundErrors": "{{count}} erreurs trouvées lors de l'analyse. Premières erreurs : {{errors}}"
     }
+  },
+  "importOnboarding": {
+    "heading": "Importez vos pleins existants",
+    "description": "Vous suivez déjà votre consommation ailleurs ? Importez vos anciens relevés depuis un fichier CSV en quelques clics.",
+    "cta": "Importer maintenant",
+    "dismiss": "Fermer"
   },
   "apiTokens": {
     "title": "Accès API",

--- a/src/i18n/locales/ga.json
+++ b/src/i18n/locales/ga.json
@@ -5,8 +5,7 @@
     "map": "Léarscáil",
     "profile": "Próifíl",
     "stations": "Stáisiúin",
-    "dashboard": "Painéal",
-    "import": "Iompórtáil"
+    "dashboard": "Painéal"
   },
   "login": {
     "tagline": "Rianú Breosla Cruinn",
@@ -251,6 +250,11 @@
     "monthlyBudgetPlaceholder": "Níl buiséad socraithe",
     "measurementUnits": "Aonaid Tomhais",
     "measurementUnitsSoon": "Le teacht: Malartú idir Méadrach (Km/L) agus Impiriúil (MPG).",
+    "dataImport": {
+      "heading": "Iompórtáil Sonraí",
+      "description": "An bhfuil tú ag rianú breosla in áit eile cheana féin? Iompórtáil do shean-logaí ó chomhad CSV.",
+      "cta": "Téigh chuig Iompórtáil"
+    },
     "vehicleFleet": "Cabhlach Feithiclí",
     "vehicleFleetSubtext": "Bainistigh do charranna agus do charrthaisligh.",
     "showArchived": "Taispeáin Cartlannaithe ({{count}})",
@@ -364,6 +368,12 @@
       "insufficientColumns": "Ró {{row}}: Colúin neamhleor.",
       "foundErrors": "Aimsíodh {{count}} earráid le linn an parsála. An chéad chúpla: {{errors}}"
     }
+  },
+  "importOnboarding": {
+    "heading": "Iompórtáil do logaí breosla atá ann",
+    "description": "An bhfuil tú ag rianú breosla in áit eile cheana féin? Iompórtáil do shean-logaí ó chomhad CSV i gcúpla cliceáil.",
+    "cta": "Iompórtáil anois",
+    "dismiss": "Dún"
   },
   "apiTokens": {
     "title": "Rochtain API",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -5,8 +5,7 @@
     "map": "地図",
     "profile": "プロフィール",
     "stations": "ガソリンスタンド",
-    "dashboard": "ダッシュボード",
-    "import": "インポート"
+    "dashboard": "ダッシュボード"
   },
   "login": {
     "tagline": "精確な燃料追跡",
@@ -251,6 +250,11 @@
     "monthlyBudgetPlaceholder": "予算未設定",
     "measurementUnits": "測定単位",
     "measurementUnitsSoon": "近日公開：メートル法 (Km/L) とヤード・ポンド法 (MPG) の切り替え。",
+    "dataImport": {
+      "heading": "データインポート",
+      "description": "他の場所で既に燃料を記録していますか？CSVファイルから過去の記録をインポートできます。",
+      "cta": "インポートへ"
+    },
     "vehicleFleet": "車両フリート",
     "vehicleFleetSubtext": "あなたの車やレンタカーを管理します。",
     "showArchived": "アーカイブ済みを表示 ({{count}})",
@@ -364,6 +368,12 @@
       "insufficientColumns": "{{row}}行目：列が不足しています。",
       "foundErrors": "解析中に{{count}}個のエラーが見つかりました。最初の数件：{{errors}}"
     }
+  },
+  "importOnboarding": {
+    "heading": "既存の燃料記録をインポート",
+    "description": "他の場所で既に燃料を記録していますか？CSVファイルから過去の記録を数クリックでインポートできます。",
+    "cta": "今すぐインポート",
+    "dismiss": "閉じる"
   },
   "apiTokens": {
     "title": "APIアクセス",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -5,8 +5,7 @@
     "map": "지도",
     "profile": "프로필",
     "stations": "주유소",
-    "dashboard": "대시보드",
-    "import": "가져오기"
+    "dashboard": "대시보드"
   },
   "login": {
     "tagline": "정밀한 연료 추적",
@@ -251,6 +250,11 @@
     "monthlyBudgetPlaceholder": "예산 미설정",
     "measurementUnits": "측정 단위",
     "measurementUnitsSoon": "출시 예정: 미터법 (Km/L)과 야드파운드법 (MPG) 간 전환.",
+    "dataImport": {
+      "heading": "데이터 가져오기",
+      "description": "다른 곳에서 이미 주유 기록을 관리하고 있나요? CSV 파일에서 과거 기록을 가져올 수 있습니다.",
+      "cta": "가져오기로 이동"
+    },
     "vehicleFleet": "차량 목록",
     "vehicleFleetSubtext": "내 차와 렌터카를 관리합니다.",
     "showArchived": "보관된 항목 표시 ({{count}})",
@@ -364,6 +368,12 @@
       "insufficientColumns": "{{row}}행: 열이 부족합니다.",
       "foundErrors": "구문 분석 중 {{count}}개의 오류가 발견되었습니다. 처음 몇 개: {{errors}}"
     }
+  },
+  "importOnboarding": {
+    "heading": "기존 주유 기록 가져오기",
+    "description": "다른 곳에서 이미 주유 기록을 관리하고 있나요? CSV 파일에서 몇 번의 클릭으로 과거 기록을 가져올 수 있습니다.",
+    "cta": "지금 가져오기",
+    "dismiss": "닫기"
   },
   "apiTokens": {
     "title": "API 액세스",

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -5,8 +5,7 @@
     "map": "Kart",
     "profile": "Profil",
     "stations": "Stasjoner",
-    "dashboard": "Oversikt",
-    "import": "Importer"
+    "dashboard": "Oversikt"
   },
   "login": {
     "tagline": "Presisjon i drivstoffsporing",
@@ -251,6 +250,11 @@
     "monthlyBudgetPlaceholder": "Ingen budsjett angitt",
     "measurementUnits": "Måleenheter",
     "measurementUnitsSoon": "Kommer snart: Bytt mellom metrisk (Km/L) og imperisk (MPG) standard.",
+    "dataImport": {
+      "heading": "Dataimport",
+      "description": "Sporer du allerede drivstoff et annet sted? Importer dine tidligere logger fra en CSV-fil.",
+      "cta": "Gå til import"
+    },
     "vehicleFleet": "Bilpark",
     "vehicleFleetSubtext": "Administrer bilene dine.",
     "showArchived": "Vis arkiverte ({{count}})",
@@ -364,6 +368,12 @@
       "insufficientColumns": "Rad {{row}}: Utilstrekkelige kolonner.",
       "foundErrors": "Fant {{count}} feil under analyse. Første få: {{errors}}"
     }
+  },
+  "importOnboarding": {
+    "heading": "Importer dine eksisterende drivstofflogger",
+    "description": "Sporer du allerede drivstoff et annet sted? Importer dine tidligere logger fra en CSV-fil med noen få klikk.",
+    "cta": "Importer nå",
+    "dismiss": "Lukk"
   },
   "apiTokens": {
     "title": "API-tilgang",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -5,8 +5,7 @@
     "map": "Karta",
     "profile": "Profil",
     "stations": "Stationer",
-    "dashboard": "Översikt",
-    "import": "Importera"
+    "dashboard": "Översikt"
   },
   "login": {
     "tagline": "Precision i bränsleuppföljning",
@@ -251,6 +250,11 @@
     "monthlyBudgetPlaceholder": "Ingen budget angiven",
     "measurementUnits": "Måttenheter",
     "measurementUnitsSoon": "Kommer snart: Växla mellan metrisk (Km/L) och imperisk (MPG) standard.",
+    "dataImport": {
+      "heading": "Dataimport",
+      "description": "Spårar du redan bränsle någon annanstans? Importera dina tidigare loggar från en CSV-fil.",
+      "cta": "Gå till import"
+    },
     "vehicleFleet": "Vagnpark",
     "vehicleFleetSubtext": "Hantera dina bilar och hyrbilar.",
     "showArchived": "Visa arkiverade ({{count}})",
@@ -364,6 +368,12 @@
       "insufficientColumns": "Rad {{row}}: Otillräckliga kolumner.",
       "foundErrors": "Hittade {{count}} fel under analysen. Första få: {{errors}}"
     }
+  },
+  "importOnboarding": {
+    "heading": "Importera dina befintliga tankningsloggar",
+    "description": "Spårar du redan bränsle någon annanstans? Importera dina tidigare loggar från en CSV-fil med några klick.",
+    "cta": "Importera nu",
+    "dismiss": "Stäng"
   },
   "apiTokens": {
     "title": "API-åtkomst",

--- a/src/pages/ProfilePage.test.tsx
+++ b/src/pages/ProfilePage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { getDocs } from 'firebase/firestore';
 import ProfilePage from './ProfilePage';
+import { MemoryRouter } from 'react-router-dom';
 
 const mockT = (key: string, opts?: Record<string, unknown>) => {
   if (opts && 'defaultValue' in opts) return opts.defaultValue as string;
@@ -59,19 +60,19 @@ describe('ProfilePage monthly budget field', () => {
   });
 
   it('renders empty when no budget is set', async () => {
-    render(<ProfilePage />);
+    render(<MemoryRouter><ProfilePage /></MemoryRouter>);
     await waitFor(() => expect(screen.getByPlaceholderText('profile.monthlyBudgetPlaceholder')).toBeInTheDocument());
     expect((screen.getByPlaceholderText('profile.monthlyBudgetPlaceholder') as HTMLInputElement).value).toBe('');
   });
 
   it('seeds the field from an existing budget', async () => {
     mockProfile = { homeCurrency: 'EUR', monthlyBudget: 150 };
-    render(<ProfilePage />);
+    render(<MemoryRouter><ProfilePage /></MemoryRouter>);
     await waitFor(() => expect((screen.getByPlaceholderText('profile.monthlyBudgetPlaceholder') as HTMLInputElement).value).toBe('150'));
   });
 
   it('saves a valid budget on blur', async () => {
-    render(<ProfilePage />);
+    render(<MemoryRouter><ProfilePage /></MemoryRouter>);
     const input = await screen.findByPlaceholderText('profile.monthlyBudgetPlaceholder');
 
     fireEvent.change(input, { target: { value: '200' } });
@@ -82,7 +83,7 @@ describe('ProfilePage monthly budget field', () => {
 
   it('clears the budget (saves 0) when the field is emptied', async () => {
     mockProfile = { homeCurrency: 'EUR', monthlyBudget: 150 };
-    render(<ProfilePage />);
+    render(<MemoryRouter><ProfilePage /></MemoryRouter>);
     const input = await screen.findByPlaceholderText('profile.monthlyBudgetPlaceholder');
     await waitFor(() => expect((input as HTMLInputElement).value).toBe('150'));
 
@@ -94,7 +95,7 @@ describe('ProfilePage monthly budget field', () => {
 
   it('treats invalid/negative input as no budget', async () => {
     mockProfile = { homeCurrency: 'EUR', monthlyBudget: 150 };
-    render(<ProfilePage />);
+    render(<MemoryRouter><ProfilePage /></MemoryRouter>);
     const input = await screen.findByPlaceholderText('profile.monthlyBudgetPlaceholder');
     await waitFor(() => expect((input as HTMLInputElement).value).toBe('150'));
 
@@ -106,7 +107,7 @@ describe('ProfilePage monthly budget field', () => {
 
   it('does not call updateProfile if the value is unchanged', async () => {
     mockProfile = { homeCurrency: 'EUR', monthlyBudget: 150 };
-    render(<ProfilePage />);
+    render(<MemoryRouter><ProfilePage /></MemoryRouter>);
     const input = await screen.findByPlaceholderText('profile.monthlyBudgetPlaceholder');
     await waitFor(() => expect((input as HTMLInputElement).value).toBe('150'));
 
@@ -117,14 +118,14 @@ describe('ProfilePage monthly budget field', () => {
 
   it('shows a browser-permission warning when notifications are denied', async () => {
     mockFCMState = { isEnabled: false, isLoading: false, permissionDenied: true };
-    render(<ProfilePage />);
+    render(<MemoryRouter><ProfilePage /></MemoryRouter>);
     await waitFor(() => {
       expect(screen.getByText(/Notifications are blocked for this site/)).toBeInTheDocument();
     });
   });
 
   it('does not show the permission warning when notifications are not denied', async () => {
-    render(<ProfilePage />);
+    render(<MemoryRouter><ProfilePage /></MemoryRouter>);
     await waitFor(() => expect(screen.getByText('Weekly fuel digest')).toBeInTheDocument());
     expect(screen.queryByText(/Notifications are blocked for this site/)).not.toBeInTheDocument();
   });

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -3,7 +3,8 @@ import { collection, addDoc, query, where, getDocs, deleteDoc, doc, writeBatch, 
 import { db } from '../firebase/config';
 import { useAuth } from '../context/AuthContext';
 import { Vehicle, VehicleFuelType } from '../utils/types';
-import { Car, Archive, Trash2, CheckCircle2, AlertCircle, PlusCircle, RefreshCw, Settings, Coins, Bell, BellOff, Wallet } from 'lucide-react';
+import { Car, Archive, Trash2, CheckCircle2, AlertCircle, PlusCircle, RefreshCw, Settings, Coins, Bell, BellOff, Wallet, UploadCloud } from 'lucide-react';
+import { Link } from 'react-router-dom';
 import ApiTokenManager from '../components/ApiTokenManager';
 import { useFCMToken } from '../hooks/useFCMToken';
 import { COMMON_CURRENCIES } from '../utils/currencyApi';
@@ -469,6 +470,26 @@ function ProfilePage(): JSX.Element {
             {t('profile.notifications.permissionDenied', { defaultValue: 'Notifications are blocked for this site in your browser settings. Enable them in your browser\'s site permissions, then try again.' })}
           </p>
         )}
+      </div>
+
+      {/* Data Import Section */}
+      <div className="bg-white dark:bg-gray-900 rounded-3xl p-6 sm:p-8 shadow-sm border border-gray-100 dark:border-gray-800">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="w-10 h-10 rounded-2xl bg-indigo-50 dark:bg-indigo-900/20 flex items-center justify-center">
+            <UploadCloud className="w-5 h-5 text-indigo-500" />
+          </div>
+          <h3 className="text-xl font-black tracking-tight">{t('profile.dataImport.heading')}</h3>
+        </div>
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-gray-500 dark:text-gray-400 max-w-md">{t('profile.dataImport.description')}</p>
+          <Link
+            to="/import"
+            className="flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-bold transition-colors bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-400 hover:bg-indigo-200 dark:hover:bg-indigo-900/50 shrink-0"
+          >
+            <UploadCloud className="w-4 h-4" />
+            {t('profile.dataImport.cta')}
+          </Link>
+        </div>
       </div>
 
       {/* API Access Section */}


### PR DESCRIPTION
Closes #154

## Problem
`ImportPage` was a permanent top-level nav destination for an action users typically do once, right after signup — wasting nav space and compounding the mobile crowding from #141, with no onboarding nudge for new users.

## Fix
- Removed `/import` from `AuthenticatedApp`'s desktop nav. The route itself is untouched, so existing `/import` deep links/bookmarks keep working.
- Added a "Data Import" section to `ProfilePage.tsx` (same card style as Notifications/Maintenance) linking to `/import`.
- Added `ImportOnboardingPrompt`, a dismissible banner rendered in the authenticated app shell (above all routed pages, so it's visible regardless of the user's landing page). It nudges users to import existing data, with a CTA into `/import` and a dismiss button.
- Persisted via a new `hasSeenImportOnboarding` flag on `UserProfile` (`AuthContext.tsx`), written through the existing `updateProfile`, so the prompt never reappears once shown/dismissed.
- Added `importOnboarding.*` and `profile.dataImport.*` i18n keys across all 10 locales, and removed the now-unused `nav.import` key from all locales.

## Testing
- Added `ImportOnboardingPrompt.test.tsx` (renders when unseen, hidden once seen, hidden while profile is loading, dismiss button and CTA both persist the flag).
- Added tests to `AuthenticatedApp.test.tsx` asserting Import is no longer a nav destination and the onboarding banner renders for a fresh profile.
- `ProfilePage.test.tsx` updated to wrap renders in `MemoryRouter` (now required since the page renders a `Link` unconditionally).
- Full suite: 193/193 tests pass. `tsc -b` and `eslint` clean. Verified i18n key-parity and placeholder checks locally (matches CI's `i18n-check.yml` logic).