### PR TITLE
feat: add sendTestNotification callable for developer test notifications

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -75,5 +75,12 @@ service cloud.firestore {
     match /budgetAlerts/{alertId} {
       allow read, write: if false;
     }
+
+    // Audit trail for the sendTestNotification dev tool: written only by
+    // that Cloud Function via the Admin SDK (which bypasses these rules).
+    // No client access needed or allowed.
+    match /testNotifications/{notificationId} {
+      allow read, write: if false;
+    }
   }
 }

--- a/functions/src/__tests__/devNotifications.test.ts
+++ b/functions/src/__tests__/devNotifications.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('firebase-functions/v2/https', async () => {
+    class HttpsError extends Error {
+        code: string;
+        constructor(code: string, message: string) {
+            super(message);
+            this.code = code;
+        }
+    }
+    return {
+        onCall: vi.fn((handler: (req: unknown) => unknown) => handler),
+        HttpsError,
+    };
+});
+
+const { mockParamValue } = vi.hoisted(() => ({ mockParamValue: vi.fn() }));
+vi.mock('firebase-functions/params', () => ({
+    defineString: vi.fn(() => ({ value: mockParamValue })),
+}));
+
+const mockMessagingSend = vi.fn();
+vi.mock('firebase-admin/messaging', () => ({
+    getMessaging: vi.fn(() => ({ send: mockMessagingSend })),
+}));
+
+const { mockTokensGet, mockTestNotificationsAdd } = vi.hoisted(() => ({
+    mockTokensGet: vi.fn(),
+    mockTestNotificationsAdd: vi.fn(),
+}));
+
+vi.mock('firebase-admin/firestore', () => ({
+    getFirestore: vi.fn(() => ({
+        collection: vi.fn((col: string) => {
+            if (col === 'fcmTokens') {
+                const q: Record<string, unknown> = {};
+                q.where = vi.fn(() => q);
+                q.get = mockTokensGet;
+                return q;
+            }
+            if (col === 'testNotifications') {
+                return { add: mockTestNotificationsAdd };
+            }
+            throw new Error(`Unexpected collection: ${col}`);
+        }),
+    })),
+}));
+
+import { sendTestNotification } from '../devNotifications';
+import { HttpsError } from 'firebase-functions/v2/https';
+
+const handler = sendTestNotification as unknown as (req: {
+    auth?: { uid: string };
+    data: { targetUid: string; title: string; body: string; data?: Record<string, string> };
+}) => Promise<{ sentCount: number; failedCount: number }>;
+
+describe('sendTestNotification', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockParamValue.mockReturnValue('dev-uid-1, dev-uid-2');
+    });
+
+    it('rejects unauthenticated requests', async () => {
+        await expect(
+            handler({ data: { targetUid: 'u1', title: 't', body: 'b' } })
+        ).rejects.toThrow(HttpsError);
+    });
+
+    it('rejects callers not in the allowlist', async () => {
+        await expect(
+            handler({ auth: { uid: 'not-a-dev' }, data: { targetUid: 'u1', title: 't', body: 'b' } })
+        ).rejects.toThrow(HttpsError);
+    });
+
+    it('rejects missing targetUid/title/body', async () => {
+        await expect(
+            handler({ auth: { uid: 'dev-uid-1' }, data: { targetUid: '', title: 't', body: 'b' } })
+        ).rejects.toThrow(HttpsError);
+    });
+
+    it('throws not-found when the target user has no registered tokens', async () => {
+        mockTokensGet.mockResolvedValue({ empty: true, docs: [] });
+        await expect(
+            handler({ auth: { uid: 'dev-uid-1' }, data: { targetUid: 'u1', title: 't', body: 'b' } })
+        ).rejects.toThrow(HttpsError);
+    });
+
+    it('sends to all of the target user\'s tokens and logs an audit record', async () => {
+        mockTokensGet.mockResolvedValue({
+            empty: false,
+            docs: [
+                { data: () => ({ token: 'tok-1', userId: 'u1' }) },
+                { data: () => ({ token: 'tok-2', userId: 'u1' }) },
+            ],
+        });
+        mockMessagingSend.mockResolvedValue('message-id');
+
+        const result = await handler({
+            auth: { uid: 'dev-uid-1' },
+            data: { targetUid: 'u1', title: 'Test', body: 'Hello', data: { foo: 'bar' } },
+        });
+
+        expect(result).toEqual({ sentCount: 2, failedCount: 0 });
+        expect(mockMessagingSend).toHaveBeenCalledTimes(2);
+        expect(mockMessagingSend).toHaveBeenCalledWith(
+            expect.objectContaining({ token: 'tok-1', notification: { title: 'Test', body: 'Hello' }, data: { foo: 'bar' } })
+        );
+        expect(mockTestNotificationsAdd).toHaveBeenCalledWith(
+            expect.objectContaining({ sentBy: 'dev-uid-1', targetUid: 'u1', sentCount: 2, failedCount: 0 })
+        );
+    });
+
+    it('reports partial failures without throwing', async () => {
+        mockTokensGet.mockResolvedValue({
+            empty: false,
+            docs: [
+                { data: () => ({ token: 'tok-1', userId: 'u1' }) },
+                { data: () => ({ token: 'tok-2', userId: 'u1' }) },
+            ],
+        });
+        mockMessagingSend.mockResolvedValueOnce('message-id').mockRejectedValueOnce(new Error('invalid token'));
+
+        const result = await handler({
+            auth: { uid: 'dev-uid-1' },
+            data: { targetUid: 'u1', title: 'Test', body: 'Hello' },
+        });
+
+        expect(result).toEqual({ sentCount: 1, failedCount: 1 });
+    });
+});

--- a/functions/src/devNotifications.ts
+++ b/functions/src/devNotifications.ts
@@ -1,0 +1,96 @@
+// functions/src/devNotifications.ts
+//
+// Callable function letting developers send an arbitrary FCM push to a
+// specific user's registered device(s), for testing/debugging the
+// notification pipeline without contriving real trigger conditions
+// (crossing a budget threshold, waiting for the weekly digest cron, etc).
+//
+// Restricted to UIDs listed in the DEV_NOTIFICATION_UIDS deploy-time param —
+// set via `firebase functions:secrets:set` or `firebase deploy --only
+// functions --set-params` with a comma-separated list of developer UIDs.
+
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { defineString } from 'firebase-functions/params';
+import { getFirestore } from 'firebase-admin/firestore';
+import { getMessaging } from 'firebase-admin/messaging';
+
+const DEV_NOTIFICATION_UIDS = defineString('DEV_NOTIFICATION_UIDS', { default: '' });
+
+interface SendTestNotificationRequest {
+    targetUid: string;
+    title: string;
+    body: string;
+    data?: Record<string, string>;
+}
+
+interface SendTestNotificationResponse {
+    sentCount: number;
+    failedCount: number;
+}
+
+function isAuthorizedDeveloper(uid: string): boolean {
+    const allowedUids = DEV_NOTIFICATION_UIDS.value()
+        .split(',')
+        .map(u => u.trim())
+        .filter(Boolean);
+    return allowedUids.includes(uid);
+}
+
+export const sendTestNotification = onCall<SendTestNotificationRequest, Promise<SendTestNotificationResponse>>(
+    async (request) => {
+        if (!request.auth) {
+            throw new HttpsError('unauthenticated', 'Must be signed in.');
+        }
+        if (!isAuthorizedDeveloper(request.auth.uid)) {
+            throw new HttpsError('permission-denied', 'Not authorized to send test notifications.');
+        }
+
+        const { targetUid, title, body, data } = request.data;
+        if (!targetUid || typeof targetUid !== 'string') {
+            throw new HttpsError('invalid-argument', 'targetUid is required.');
+        }
+        if (!title || typeof title !== 'string' || !body || typeof body !== 'string') {
+            throw new HttpsError('invalid-argument', 'title and body are required.');
+        }
+
+        const db = getFirestore();
+        const messaging = getMessaging();
+
+        const tokensSnap = await db.collection('fcmTokens').where('userId', '==', targetUid).get();
+        if (tokensSnap.empty) {
+            throw new HttpsError('not-found', `No registered FCM tokens for uid ${targetUid}.`);
+        }
+
+        const results = await Promise.allSettled(
+            tokensSnap.docs.map(tokenDoc =>
+                messaging.send({
+                    token: tokenDoc.data().token as string,
+                    notification: { title, body },
+                    data,
+                    webpush: {
+                        notification: {
+                            icon: '/icons/icon-192x192.png',
+                            badge: '/icons/icon-72x72.png',
+                        },
+                    },
+                })
+            )
+        );
+
+        const sentCount = results.filter(r => r.status === 'fulfilled').length;
+        const failedCount = results.length - sentCount;
+
+        await db.collection('testNotifications').add({
+            sentBy: request.auth.uid,
+            targetUid,
+            title,
+            body,
+            data: data ?? null,
+            sentCount,
+            failedCount,
+            createdAt: new Date(),
+        });
+
+        return { sentCount, failedCount };
+    }
+);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -12,3 +12,4 @@ export { sendMonthlySummary } from './monthlySummary';
 export { processReceipt } from './receiptProcessing';
 export { sendWeeklyDigest } from './weeklyDigest';
 export { checkBudgetAlert } from './budgetAlerts';
+export { sendTestNotification } from './devNotifications';


### PR DESCRIPTION
## Summary
- Adds a `sendTestNotification` callable Cloud Function (`functions/src/devNotifications.ts`) that lets an allowlisted developer trigger an arbitrary FCM push (title/body/data) to a target user's registered device(s), reusing the existing token-lookup pattern from `budgetAlerts.ts`/`weeklyDigest.ts`.
- Authorization is via a `DEV_NOTIFICATION_UIDS` deploy-time param (comma-separated UIDs) — unauthenticated or non-listed callers get a `permission-denied`/`unauthenticated` error.
- Every send is logged to a new `testNotifications` Firestore collection (sentBy, targetUid, payload, sentCount/failedCount) for an audit trail; Firestore rules deny all client read/write on it (Admin SDK only, same pattern as `budgetAlerts`).
- Returns `{ sentCount, failedCount }`, sending to all of a user's registered devices and tolerating partial per-device failures.

Closes #166

## Test plan
- [x] `npx tsc --noEmit` in `functions/` — clean
- [x] `npx vitest run` in `functions/` — 52/52 passing, including 6 new tests covering: unauthenticated rejection, non-allowlisted caller rejection, missing-field validation, not-found when target has no tokens, multi-device send + audit log, partial-failure handling
- [x] Root test suite (run via pre-commit hook) — passing
- [ ] Manual: deploy to a project with `DEV_NOTIFICATION_UIDS` set to your own uid and call `sendTestNotification` from the Firebase console/SDK against a logged-in test account