### PR TITLE
feat: add Admin Console page for sending test notifications

### DIFF
--- a/functions/src/__tests__/devNotifications.test.ts
+++ b/functions/src/__tests__/devNotifications.test.ts
@@ -46,13 +46,36 @@ vi.mock('firebase-admin/firestore', () => ({
     })),
 }));
 
-import { sendTestNotification } from '../devNotifications';
+import { sendTestNotification, checkDeveloperAccess } from '../devNotifications';
 import { HttpsError } from 'firebase-functions/v2/https';
 
 const handler = sendTestNotification as unknown as (req: {
     auth?: { uid: string };
     data: { targetUid: string; title: string; body: string; data?: Record<string, string> };
 }) => Promise<{ sentCount: number; failedCount: number }>;
+
+const accessHandler = checkDeveloperAccess as unknown as (req: {
+    auth?: { uid: string };
+}) => Promise<{ isDeveloper: boolean }>;
+
+describe('checkDeveloperAccess', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockParamValue.mockReturnValue('dev-uid-1, dev-uid-2');
+    });
+
+    it('returns false when unauthenticated', async () => {
+        expect(await accessHandler({})).toEqual({ isDeveloper: false });
+    });
+
+    it('returns false for a uid not in the allowlist', async () => {
+        expect(await accessHandler({ auth: { uid: 'not-a-dev' } })).toEqual({ isDeveloper: false });
+    });
+
+    it('returns true for an allowlisted uid', async () => {
+        expect(await accessHandler({ auth: { uid: 'dev-uid-1' } })).toEqual({ isDeveloper: true });
+    });
+});
 
 describe('sendTestNotification', () => {
     beforeEach(() => {

--- a/functions/src/devNotifications.ts
+++ b/functions/src/devNotifications.ts
@@ -36,6 +36,18 @@ function isAuthorizedDeveloper(uid: string): boolean {
     return allowedUids.includes(uid);
 }
 
+/**
+ * Lets the client check whether the signed-in user is allowed to use the
+ * dev notification tools, so the Admin Console page can gate itself without
+ * exposing the allowlist contents.
+ */
+export const checkDeveloperAccess = onCall<unknown, Promise<{ isDeveloper: boolean }>>(async (request) => {
+    if (!request.auth) {
+        return { isDeveloper: false };
+    }
+    return { isDeveloper: isAuthorizedDeveloper(request.auth.uid) };
+});
+
 export const sendTestNotification = onCall<SendTestNotificationRequest, Promise<SendTestNotificationResponse>>(
     async (request) => {
         if (!request.auth) {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -12,4 +12,4 @@ export { sendMonthlySummary } from './monthlySummary';
 export { processReceipt } from './receiptProcessing';
 export { sendWeeklyDigest } from './weeklyDigest';
 export { checkBudgetAlert } from './budgetAlerts';
-export { sendTestNotification } from './devNotifications';
+export { sendTestNotification, checkDeveloperAccess } from './devNotifications';

--- a/src/components/AuthenticatedApp.tsx
+++ b/src/components/AuthenticatedApp.tsx
@@ -49,6 +49,7 @@ const AboutPage = lazyWithRetry(() => import('../pages/AboutPage'));
 const FuelMapPage = lazyWithRetry(() => import('./FuelMapPage'));
 const StationsPage = lazyWithRetry(() => import('../pages/StationsPage'));
 const DashboardPage = lazyWithRetry(() => import('../pages/DashboardPage'));
+const AdminConsolePage = lazyWithRetry(() => import('../pages/AdminConsolePage'));
 
 // Pages with wide data tables need more horizontal room than the default
 // max-w-5xl content column allows, or their tables overflow into a
@@ -134,6 +135,7 @@ function AuthenticatedApp(): JSX.Element {
             <Route path="/about" element={<AboutPage />} />
             <Route path="/map" element={<FuelMapPage />} />
             <Route path="/stations" element={<StationsPage />} />
+            <Route path="/admin" element={<AdminConsolePage />} />
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>
         </Suspense>

--- a/src/firebase/config.test.ts
+++ b/src/firebase/config.test.ts
@@ -22,6 +22,10 @@ vi.mock('firebase/storage', () => ({
   getStorage: vi.fn().mockReturnValue({}),
 }));
 
+vi.mock('firebase/functions', () => ({
+  getFunctions: vi.fn().mockReturnValue({}),
+}));
+
 vi.mock('firebase/performance', () => ({
   getPerformance: vi.fn().mockReturnValue({ name: 'mock-perf' }),
 }));

--- a/src/firebase/config.ts
+++ b/src/firebase/config.ts
@@ -19,6 +19,7 @@ import {
     FirestoreSettings // Type for settings object
 } from "firebase/firestore";
 import { getStorage, FirebaseStorage } from "firebase/storage";
+import { getFunctions, Functions } from "firebase/functions";
 
 // Config interface (remains the same)
 interface FirebaseConfig {
@@ -56,6 +57,9 @@ const auth: Auth = getAuth(app);
 
 // Initialize Firebase Storage
 const storage: FirebaseStorage = getStorage(app);
+
+// Initialize Cloud Functions client (for callable functions like sendTestNotification)
+const functions: Functions = getFunctions(app);
 
 // --- Initialize Firestore with Offline Persistence Settings ---
 let db: Firestore; // Declare db variable
@@ -127,6 +131,7 @@ export {
   auth,
   db,
   storage,
+  functions,
   analytics,
   perf,
   googleProvider,

--- a/src/pages/AdminConsolePage.tsx
+++ b/src/pages/AdminConsolePage.tsx
@@ -1,0 +1,159 @@
+import { JSX, useState, useEffect, FormEvent } from 'react';
+import { httpsCallable } from 'firebase/functions';
+import { functions } from '../firebase/config';
+import { useAuth } from '../context/AuthContext';
+import { ShieldAlert, Send, Loader2 } from 'lucide-react';
+
+interface SendTestNotificationResponse {
+  sentCount: number;
+  failedCount: number;
+}
+
+function AdminConsolePage(): JSX.Element {
+  const { user } = useAuth();
+  const [accessState, setAccessState] = useState<'checking' | 'denied' | 'granted'>('checking');
+
+  const [targetUid, setTargetUid] = useState('');
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [dataJson, setDataJson] = useState('');
+  const [isSending, setIsSending] = useState(false);
+  const [result, setResult] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
+  useEffect(() => {
+    if (!user) return;
+    const checkAccess = httpsCallable<unknown, { isDeveloper: boolean }>(functions, 'checkDeveloperAccess');
+    checkAccess()
+      .then(res => setAccessState(res.data.isDeveloper ? 'granted' : 'denied'))
+      .catch(() => setAccessState('denied'));
+  }, [user]);
+
+  useEffect(() => {
+    if (user) setTargetUid(user.uid);
+  }, [user]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setResult(null);
+
+    let data: Record<string, string> | undefined;
+    if (dataJson.trim()) {
+      try {
+        data = JSON.parse(dataJson);
+      } catch {
+        setResult({ type: 'error', text: 'Data field must be valid JSON (or left blank).' });
+        return;
+      }
+    }
+
+    setIsSending(true);
+    try {
+      const sendTestNotification = httpsCallable<
+        { targetUid: string; title: string; body: string; data?: Record<string, string> },
+        SendTestNotificationResponse
+      >(functions, 'sendTestNotification');
+      const res = await sendTestNotification({ targetUid, title, body, data });
+      setResult({
+        type: 'success',
+        text: `Sent to ${res.data.sentCount} device(s)${res.data.failedCount > 0 ? `, ${res.data.failedCount} failed` : ''}.`,
+      });
+    } catch (err) {
+      setResult({ type: 'error', text: err instanceof Error ? err.message : 'Failed to send notification.' });
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  if (accessState === 'checking') {
+    return (
+      <div className="flex justify-center items-center min-h-[40vh]">
+        <Loader2 className="w-8 h-8 animate-spin text-amber-500" />
+      </div>
+    );
+  }
+
+  if (accessState === 'denied') {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[40vh] text-center space-y-3">
+        <ShieldAlert className="w-10 h-10 text-red-500" />
+        <p className="text-gray-600 dark:text-gray-400">You don't have access to this page.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-xl mx-auto space-y-6">
+      <div>
+        <h1 className="text-2xl font-display font-bold">Admin Console</h1>
+        <p className="text-sm text-gray-500 dark:text-gray-400">Send a test push notification via FCM.</p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4 bg-white dark:bg-gray-800 shadow-xl rounded-3xl p-6 sm:p-8 border border-gray-100 dark:border-gray-700/50">
+        <div>
+          <label className="block text-sm font-bold mb-1" htmlFor="targetUid">Target UID</label>
+          <input
+            id="targetUid"
+            type="text"
+            value={targetUid}
+            onChange={e => setTargetUid(e.target.value)}
+            required
+            className="w-full px-4 py-3 bg-gray-50 dark:bg-gray-900 border-none rounded-xl focus:ring-2 focus:ring-brand-primary/20 transition-all font-bold text-gray-900 dark:text-white"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-bold mb-1" htmlFor="title">Title</label>
+          <input
+            id="title"
+            type="text"
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+            required
+            className="w-full px-4 py-3 bg-gray-50 dark:bg-gray-900 border-none rounded-xl focus:ring-2 focus:ring-brand-primary/20 transition-all font-bold text-gray-900 dark:text-white"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-bold mb-1" htmlFor="body">Body</label>
+          <textarea
+            id="body"
+            value={body}
+            onChange={e => setBody(e.target.value)}
+            required
+            rows={3}
+            className="w-full px-4 py-3 bg-gray-50 dark:bg-gray-900 border-none rounded-xl focus:ring-2 focus:ring-brand-primary/20 transition-all font-bold text-gray-900 dark:text-white"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-bold mb-1" htmlFor="dataJson">Data (optional JSON)</label>
+          <textarea
+            id="dataJson"
+            value={dataJson}
+            onChange={e => setDataJson(e.target.value)}
+            rows={2}
+            placeholder='{"key": "value"}'
+            className="w-full px-4 py-3 bg-gray-50 dark:bg-gray-900 border-none rounded-xl focus:ring-2 focus:ring-brand-primary/20 transition-all font-mono text-sm text-gray-900 dark:text-white"
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={isSending}
+          className="brand-button-primary flex items-center justify-center gap-2 w-full"
+        >
+          {isSending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Send className="w-4 h-4" />}
+          Send test notification
+        </button>
+
+        {result && (
+          <p className={result.type === 'success' ? 'text-green-600 dark:text-green-400 text-sm' : 'text-red-600 dark:text-red-400 text-sm'}>
+            {result.text}
+          </p>
+        )}
+      </form>
+    </div>
+  );
+}
+
+export default AdminConsolePage;


### PR DESCRIPTION
## Summary
- Adds a new `checkDeveloperAccess` callable (`functions/src/devNotifications.ts`) so the client can ask "am I allowlisted?" without exposing the `DEV_NOTIFICATION_UIDS` list itself.
- Adds a `/admin` route (`src/pages/AdminConsolePage.tsx`) gated by that check: shows a loading state, an "access denied" state for non-allowlisted users, and a small form (target UID, title, body, optional JSON data) for allowlisted developers to call `sendTestNotification` directly from the UI.
- Exposes a `functions` Cloud Functions client instance from `src/firebase/config.ts` (not previously wired up) for the callable SDK calls.
- No nav link added — it's a hidden dev-only route at `/admin`, not meant for regular users to discover.

Builds on #167 (`sendTestNotification`), addresses the remaining piece of #166.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — `AdminConsolePage` chunk splits correctly, builds clean
- [x] Functions test suite (`functions/`) — 55/55 passing, including 3 new tests for `checkDeveloperAccess`
- [x] Root test suite — 196/196 passing (fixed a missing `firebase/functions` mock in `src/firebase/config.test.ts` that the new `functions` export exposed)
- [ ] Manual: visit `/admin` while signed in as your allowlisted UID, send a test notification to your own uid, confirm it arrives