### PR TITLE
Move analytics charts and lifetime stats from History to Dashboard

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -495,5 +495,21 @@
     "subtitle": "Zum Startbildschirm hinzufügen für einfachen Zugriff",
     "later": "Später",
     "install": "Installieren"
+  },
+  "admin": {
+    "accessDenied": "You don't have access to this page.",
+    "title": "Admin Console",
+    "subtitle": "Send a test push notification via FCM.",
+    "fields": {
+      "targetUid": "Target UID",
+      "title": "Title",
+      "body": "Body",
+      "dataJson": "Data (optional JSON)"
+    },
+    "invalidJson": "Data field must be valid JSON (or left blank).",
+    "sendButton": "Send test notification",
+    "sendSuccess": "Sent to {{sentCount}} device(s){{failedSuffix}}.",
+    "sendFailedSuffix": ", {{failedCount}} failed",
+    "sendError": "Failed to send notification."
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -495,5 +495,21 @@
     "subtitle": "Add to home screen for easy access",
     "later": "Later",
     "install": "Install"
+  },
+  "admin": {
+    "accessDenied": "You don't have access to this page.",
+    "title": "Admin Console",
+    "subtitle": "Send a test push notification via FCM.",
+    "fields": {
+      "targetUid": "Target UID",
+      "title": "Title",
+      "body": "Body",
+      "dataJson": "Data (optional JSON)"
+    },
+    "invalidJson": "Data field must be valid JSON (or left blank).",
+    "sendButton": "Send test notification",
+    "sendSuccess": "Sent to {{sentCount}} device(s){{failedSuffix}}.",
+    "sendFailedSuffix": ", {{failedCount}} failed",
+    "sendError": "Failed to send notification."
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -495,5 +495,21 @@
     "subtitle": "Añádelo a la pantalla de inicio para un acceso fácil",
     "later": "Más tarde",
     "install": "Instalar"
+  },
+  "admin": {
+    "accessDenied": "You don't have access to this page.",
+    "title": "Admin Console",
+    "subtitle": "Send a test push notification via FCM.",
+    "fields": {
+      "targetUid": "Target UID",
+      "title": "Title",
+      "body": "Body",
+      "dataJson": "Data (optional JSON)"
+    },
+    "invalidJson": "Data field must be valid JSON (or left blank).",
+    "sendButton": "Send test notification",
+    "sendSuccess": "Sent to {{sentCount}} device(s){{failedSuffix}}.",
+    "sendFailedSuffix": ", {{failedCount}} failed",
+    "sendError": "Failed to send notification."
   }
 }

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -495,5 +495,21 @@
     "subtitle": "Lisää aloitusnäytölle helppoa käyttöä varten",
     "later": "Myöhemmin",
     "install": "Asenna"
+  },
+  "admin": {
+    "accessDenied": "You don't have access to this page.",
+    "title": "Admin Console",
+    "subtitle": "Send a test push notification via FCM.",
+    "fields": {
+      "targetUid": "Target UID",
+      "title": "Title",
+      "body": "Body",
+      "dataJson": "Data (optional JSON)"
+    },
+    "invalidJson": "Data field must be valid JSON (or left blank).",
+    "sendButton": "Send test notification",
+    "sendSuccess": "Sent to {{sentCount}} device(s){{failedSuffix}}.",
+    "sendFailedSuffix": ", {{failedCount}} failed",
+    "sendError": "Failed to send notification."
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -495,5 +495,21 @@
     "subtitle": "Ajouter à l'écran d'accueil pour un accès facile",
     "later": "Plus tard",
     "install": "Installer"
+  },
+  "admin": {
+    "accessDenied": "You don't have access to this page.",
+    "title": "Admin Console",
+    "subtitle": "Send a test push notification via FCM.",
+    "fields": {
+      "targetUid": "Target UID",
+      "title": "Title",
+      "body": "Body",
+      "dataJson": "Data (optional JSON)"
+    },
+    "invalidJson": "Data field must be valid JSON (or left blank).",
+    "sendButton": "Send test notification",
+    "sendSuccess": "Sent to {{sentCount}} device(s){{failedSuffix}}.",
+    "sendFailedSuffix": ", {{failedCount}} failed",
+    "sendError": "Failed to send notification."
   }
 }

--- a/src/i18n/locales/ga.json
+++ b/src/i18n/locales/ga.json
@@ -495,5 +495,21 @@
     "subtitle": "Cuir leis an scáileán baile le haghaidh rochtain éasca",
     "later": "Ar ball",
     "install": "Suiteáil"
+  },
+  "admin": {
+    "accessDenied": "You don't have access to this page.",
+    "title": "Admin Console",
+    "subtitle": "Send a test push notification via FCM.",
+    "fields": {
+      "targetUid": "Target UID",
+      "title": "Title",
+      "body": "Body",
+      "dataJson": "Data (optional JSON)"
+    },
+    "invalidJson": "Data field must be valid JSON (or left blank).",
+    "sendButton": "Send test notification",
+    "sendSuccess": "Sent to {{sentCount}} device(s){{failedSuffix}}.",
+    "sendFailedSuffix": ", {{failedCount}} failed",
+    "sendError": "Failed to send notification."
   }
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -495,5 +495,21 @@
     "subtitle": "ホーム画面に追加して簡単にアクセス",
     "later": "後で",
     "install": "インストール"
+  },
+  "admin": {
+    "accessDenied": "You don't have access to this page.",
+    "title": "Admin Console",
+    "subtitle": "Send a test push notification via FCM.",
+    "fields": {
+      "targetUid": "Target UID",
+      "title": "Title",
+      "body": "Body",
+      "dataJson": "Data (optional JSON)"
+    },
+    "invalidJson": "Data field must be valid JSON (or left blank).",
+    "sendButton": "Send test notification",
+    "sendSuccess": "Sent to {{sentCount}} device(s){{failedSuffix}}.",
+    "sendFailedSuffix": ", {{failedCount}} failed",
+    "sendError": "Failed to send notification."
   }
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -495,5 +495,21 @@
     "subtitle": "쉽게 접근하려면 홈 화면에 추가하세요",
     "later": "나중에",
     "install": "설치"
+  },
+  "admin": {
+    "accessDenied": "You don't have access to this page.",
+    "title": "Admin Console",
+    "subtitle": "Send a test push notification via FCM.",
+    "fields": {
+      "targetUid": "Target UID",
+      "title": "Title",
+      "body": "Body",
+      "dataJson": "Data (optional JSON)"
+    },
+    "invalidJson": "Data field must be valid JSON (or left blank).",
+    "sendButton": "Send test notification",
+    "sendSuccess": "Sent to {{sentCount}} device(s){{failedSuffix}}.",
+    "sendFailedSuffix": ", {{failedCount}} failed",
+    "sendError": "Failed to send notification."
   }
 }

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -495,5 +495,21 @@
     "subtitle": "Legg til på startskjermen for enkel tilgang",
     "later": "Senere",
     "install": "Installer"
+  },
+  "admin": {
+    "accessDenied": "You don't have access to this page.",
+    "title": "Admin Console",
+    "subtitle": "Send a test push notification via FCM.",
+    "fields": {
+      "targetUid": "Target UID",
+      "title": "Title",
+      "body": "Body",
+      "dataJson": "Data (optional JSON)"
+    },
+    "invalidJson": "Data field must be valid JSON (or left blank).",
+    "sendButton": "Send test notification",
+    "sendSuccess": "Sent to {{sentCount}} device(s){{failedSuffix}}.",
+    "sendFailedSuffix": ", {{failedCount}} failed",
+    "sendError": "Failed to send notification."
   }
 }

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -495,5 +495,21 @@
     "subtitle": "Lägg till på hemskärmen för enkel åtkomst",
     "later": "Senare",
     "install": "Installera"
+  },
+  "admin": {
+    "accessDenied": "You don't have access to this page.",
+    "title": "Admin Console",
+    "subtitle": "Send a test push notification via FCM.",
+    "fields": {
+      "targetUid": "Target UID",
+      "title": "Title",
+      "body": "Body",
+      "dataJson": "Data (optional JSON)"
+    },
+    "invalidJson": "Data field must be valid JSON (or left blank).",
+    "sendButton": "Send test notification",
+    "sendSuccess": "Sent to {{sentCount}} device(s){{failedSuffix}}.",
+    "sendFailedSuffix": ", {{failedCount}} failed",
+    "sendError": "Failed to send notification."
   }
 }

--- a/src/pages/AdminConsolePage.tsx
+++ b/src/pages/AdminConsolePage.tsx
@@ -1,4 +1,5 @@
 import { JSX, useState, useEffect, FormEvent } from 'react';
+import { useTranslation } from 'react-i18next';
 import { httpsCallable } from 'firebase/functions';
 import { functions } from '../firebase/config';
 import { useAuth } from '../context/AuthContext';
@@ -10,6 +11,7 @@ interface SendTestNotificationResponse {
 }
 
 function AdminConsolePage(): JSX.Element {
+  const { t } = useTranslation();
   const { user } = useAuth();
   const [accessState, setAccessState] = useState<'checking' | 'denied' | 'granted'>('checking');
 
@@ -41,7 +43,7 @@ function AdminConsolePage(): JSX.Element {
       try {
         data = JSON.parse(dataJson);
       } catch {
-        setResult({ type: 'error', text: 'Data field must be valid JSON (or left blank).' });
+        setResult({ type: 'error', text: t('admin.invalidJson') });
         return;
       }
     }
@@ -55,10 +57,13 @@ function AdminConsolePage(): JSX.Element {
       const res = await sendTestNotification({ targetUid, title, body, data });
       setResult({
         type: 'success',
-        text: `Sent to ${res.data.sentCount} device(s)${res.data.failedCount > 0 ? `, ${res.data.failedCount} failed` : ''}.`,
+        text: t('admin.sendSuccess', {
+          sentCount: res.data.sentCount,
+          failedSuffix: res.data.failedCount > 0 ? t('admin.sendFailedSuffix', { failedCount: res.data.failedCount }) : '',
+        }),
       });
     } catch (err) {
-      setResult({ type: 'error', text: err instanceof Error ? err.message : 'Failed to send notification.' });
+      setResult({ type: 'error', text: err instanceof Error ? err.message : t('admin.sendError') });
     } finally {
       setIsSending(false);
     }
@@ -76,7 +81,7 @@ function AdminConsolePage(): JSX.Element {
     return (
       <div className="flex flex-col items-center justify-center min-h-[40vh] text-center space-y-3">
         <ShieldAlert className="w-10 h-10 text-red-500" />
-        <p className="text-gray-600 dark:text-gray-400">You don't have access to this page.</p>
+        <p className="text-gray-600 dark:text-gray-400">{t('admin.accessDenied')}</p>
       </div>
     );
   }
@@ -84,13 +89,13 @@ function AdminConsolePage(): JSX.Element {
   return (
     <div className="max-w-xl mx-auto space-y-6">
       <div>
-        <h1 className="text-2xl font-display font-bold">Admin Console</h1>
-        <p className="text-sm text-gray-500 dark:text-gray-400">Send a test push notification via FCM.</p>
+        <h1 className="text-2xl font-display font-bold">{t('admin.title')}</h1>
+        <p className="text-sm text-gray-500 dark:text-gray-400">{t('admin.subtitle')}</p>
       </div>
 
       <form onSubmit={handleSubmit} className="space-y-4 bg-white dark:bg-gray-800 shadow-xl rounded-3xl p-6 sm:p-8 border border-gray-100 dark:border-gray-700/50">
         <div>
-          <label className="block text-sm font-bold mb-1" htmlFor="targetUid">Target UID</label>
+          <label className="block text-sm font-bold mb-1" htmlFor="targetUid">{t('admin.fields.targetUid')}</label>
           <input
             id="targetUid"
             type="text"
@@ -102,7 +107,7 @@ function AdminConsolePage(): JSX.Element {
         </div>
 
         <div>
-          <label className="block text-sm font-bold mb-1" htmlFor="title">Title</label>
+          <label className="block text-sm font-bold mb-1" htmlFor="title">{t('admin.fields.title')}</label>
           <input
             id="title"
             type="text"
@@ -114,7 +119,7 @@ function AdminConsolePage(): JSX.Element {
         </div>
 
         <div>
-          <label className="block text-sm font-bold mb-1" htmlFor="body">Body</label>
+          <label className="block text-sm font-bold mb-1" htmlFor="body">{t('admin.fields.body')}</label>
           <textarea
             id="body"
             value={body}
@@ -126,7 +131,7 @@ function AdminConsolePage(): JSX.Element {
         </div>
 
         <div>
-          <label className="block text-sm font-bold mb-1" htmlFor="dataJson">Data (optional JSON)</label>
+          <label className="block text-sm font-bold mb-1" htmlFor="dataJson">{t('admin.fields.dataJson')}</label>
           <textarea
             id="dataJson"
             value={dataJson}
@@ -143,7 +148,7 @@ function AdminConsolePage(): JSX.Element {
           className="brand-button-primary flex items-center justify-center gap-2 w-full"
         >
           {isSending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Send className="w-4 h-4" />}
-          Send test notification
+          {t('admin.sendButton')}
         </button>
 
         {result && (

--- a/src/pages/DashboardPage.test.tsx
+++ b/src/pages/DashboardPage.test.tsx
@@ -25,12 +25,14 @@ vi.mock('../context/ThemeContext', () => ({
   useTheme: () => ({ theme: 'light' }),
 }));
 
+const mockGetBoolean = vi.fn(() => false);
 vi.mock('../context/RemoteConfigContext', () => ({
-  useRemoteConfig: () => ({ getBoolean: vi.fn(() => false) }),
+  useRemoteConfig: () => ({ getBoolean: mockGetBoolean }),
 }));
 
+const mockGetLifetimeStats = vi.fn().mockResolvedValue({ totalCost: 0, totalLitres: 0, totalDistanceKm: 0, logCount: 0 });
 vi.mock('../firebase/aggregationService', () => ({
-  getLifetimeStats: vi.fn().mockResolvedValue({ totalCost: 0, totalLitres: 0, totalDistanceKm: 0, logCount: 0 }),
+  getLifetimeStats: (...args: unknown[]) => mockGetLifetimeStats(...args),
 }));
 
 vi.mock('firebase/firestore', async (importOriginal) => {
@@ -72,6 +74,8 @@ function mockSnapshot(docs: { id: string; data: Record<string, unknown> }[]) {
 describe('DashboardPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetBoolean.mockReturnValue(false);
+    mockGetLifetimeStats.mockResolvedValue({ totalCost: 0, totalLitres: 0, totalDistanceKm: 0, logCount: 0 });
   });
 
   it('renders the empty state when the user has no logs', async () => {
@@ -136,5 +140,62 @@ describe('DashboardPage', () => {
     render(<DashboardPage />);
 
     await waitFor(() => expect(screen.getByText('Failed to load dashboard data. Please try again.')).toBeInTheDocument());
+  });
+
+  it('renders lifetime stats and the MPG/price trend chart when enough logs exist', async () => {
+    const now = new Date();
+    mockGetLifetimeStats.mockResolvedValue({ totalCost: 123.45, totalLitres: 67.8, totalDistanceKm: 910, logCount: 12 });
+    vi.mocked(getDocs)
+      .mockResolvedValueOnce(mockSnapshot([]) as never) // vehicles
+      .mockResolvedValueOnce(mockSnapshot([
+        { id: 'log1', data: { userId: 'user-1', timestamp: Timestamp.fromDate(now), cost: 50, distanceKm: 400, fuelAmountLiters: 25 } },
+        { id: 'log2', data: { userId: 'user-1', timestamp: Timestamp.fromDate(now), cost: 30, distanceKm: 200, fuelAmountLiters: 15 } },
+      ]) as never); // logs
+
+    render(<DashboardPage />);
+
+    await waitFor(() => expect(screen.getByText('€123.45')).toBeInTheDocument());
+    expect(screen.getByText('67.8L')).toBeInTheDocument();
+    expect(screen.getByText('910km')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getByTestId('line-chart')).toBeInTheDocument();
+  });
+
+  it('renders the multi-vehicle comparison chart when the feature flag is enabled and stats exist', async () => {
+    mockGetBoolean.mockImplementation((key: string) => key === 'vehicleComparisonEnabled');
+    const now = new Date();
+    const vehicles = [
+      { id: 'v1', name: 'Car 1', make: 'Toyota', userId: 'user-1', isArchived: false },
+      { id: 'v2', name: 'Car 2', make: 'Honda', userId: 'user-1', isArchived: false },
+    ];
+    mockGetLifetimeStats.mockImplementation((_uid: string, vehicleId?: string) => {
+      if (vehicleId === 'v1') return Promise.resolve({ totalCost: 100, totalLitres: 50, totalDistanceKm: 500, logCount: 5 });
+      if (vehicleId === 'v2') return Promise.resolve({ totalCost: 200, totalLitres: 80, totalDistanceKm: 800, logCount: 8 });
+      return Promise.resolve({ totalCost: 0, totalLitres: 0, totalDistanceKm: 0, logCount: 0 });
+    });
+    vi.mocked(getDocs)
+      .mockResolvedValueOnce(mockSnapshot(vehicles.map(v => ({ id: v.id, data: v }))) as never) // vehicles
+      .mockResolvedValueOnce(mockSnapshot([
+        { id: 'log1', data: { userId: 'user-1', timestamp: Timestamp.fromDate(now), cost: 50, distanceKm: 400, fuelAmountLiters: 25 } },
+      ]) as never); // logs
+
+    render(<DashboardPage />);
+
+    await waitFor(() => expect(screen.getAllByTestId('bar-chart').length).toBeGreaterThan(1));
+  });
+
+  it('renders the cost-per-litre chart when its feature flag is enabled', async () => {
+    mockGetBoolean.mockImplementation((key: string) => key === 'costPerLitreGraphEnabled');
+    const now = new Date();
+    vi.mocked(getDocs)
+      .mockResolvedValueOnce(mockSnapshot([]) as never) // vehicles
+      .mockResolvedValueOnce(mockSnapshot([
+        { id: 'log1', data: { userId: 'user-1', timestamp: Timestamp.fromDate(now), cost: 50, distanceKm: 400, fuelAmountLiters: 25 } },
+        { id: 'log2', data: { userId: 'user-1', timestamp: Timestamp.fromDate(now), cost: 30, distanceKm: 200, fuelAmountLiters: 15 } },
+      ]) as never); // logs
+
+    render(<DashboardPage />);
+
+    await waitFor(() => expect(screen.getAllByTestId('line-chart').length).toBe(2));
   });
 });

--- a/src/pages/DashboardPage.test.tsx
+++ b/src/pages/DashboardPage.test.tsx
@@ -25,6 +25,14 @@ vi.mock('../context/ThemeContext', () => ({
   useTheme: () => ({ theme: 'light' }),
 }));
 
+vi.mock('../context/RemoteConfigContext', () => ({
+  useRemoteConfig: () => ({ getBoolean: vi.fn(() => false) }),
+}));
+
+vi.mock('../firebase/aggregationService', () => ({
+  getLifetimeStats: vi.fn().mockResolvedValue({ totalCost: 0, totalLitres: 0, totalDistanceKm: 0, logCount: 0 }),
+}));
+
 vi.mock('firebase/firestore', async (importOriginal) => {
   const actual = await importOriginal<typeof import('firebase/firestore')>();
   return {
@@ -43,10 +51,13 @@ vi.mock('../firebase/config', () => ({
 vi.mock('recharts', () => ({
   BarChart: ({ children }: { children?: ReactNode }) => <div data-testid="bar-chart">{children}</div>,
   Bar: () => <div />,
+  LineChart: ({ children }: { children?: ReactNode }) => <div data-testid="line-chart">{children}</div>,
+  Line: () => <div />,
   XAxis: () => <div />,
   YAxis: () => <div />,
   CartesianGrid: () => <div />,
   Tooltip: () => <div />,
+  Legend: () => <div />,
   ResponsiveContainer: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
 }));
 

--- a/src/pages/DashboardPage.test.tsx
+++ b/src/pages/DashboardPage.test.tsx
@@ -25,7 +25,7 @@ vi.mock('../context/ThemeContext', () => ({
   useTheme: () => ({ theme: 'light' }),
 }));
 
-const mockGetBoolean = vi.fn(() => false);
+const mockGetBoolean = vi.fn((_key: string) => false);
 vi.mock('../context/RemoteConfigContext', () => ({
   useRemoteConfig: () => ({ getBoolean: mockGetBoolean }),
 }));
@@ -162,7 +162,7 @@ describe('DashboardPage', () => {
   });
 
   it('renders the multi-vehicle comparison chart when the feature flag is enabled and stats exist', async () => {
-    mockGetBoolean.mockImplementation((key: string) => key === 'vehicleComparisonEnabled');
+    mockGetBoolean.mockImplementation((key: string): boolean => key === 'vehicleComparisonEnabled');
     const now = new Date();
     const vehicles = [
       { id: 'v1', name: 'Car 1', make: 'Toyota', userId: 'user-1', isArchived: false },
@@ -185,7 +185,7 @@ describe('DashboardPage', () => {
   });
 
   it('renders the cost-per-litre chart when its feature flag is enabled', async () => {
-    mockGetBoolean.mockImplementation((key: string) => key === 'costPerLitreGraphEnabled');
+    mockGetBoolean.mockImplementation((key: string): boolean => key === 'costPerLitreGraphEnabled');
     const now = new Date();
     vi.mocked(getDocs)
       .mockResolvedValueOnce(mockSnapshot([]) as never) // vehicles

--- a/src/pages/DashboardPage.test.tsx
+++ b/src/pages/DashboardPage.test.tsx
@@ -25,7 +25,7 @@ vi.mock('../context/ThemeContext', () => ({
   useTheme: () => ({ theme: 'light' }),
 }));
 
-const mockGetBoolean = vi.fn((_key: string) => false);
+const mockGetBoolean = vi.fn<(key: string) => boolean>(() => false);
 vi.mock('../context/RemoteConfigContext', () => ({
   useRemoteConfig: () => ({ getBoolean: mockGetBoolean }),
 }));

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -3,15 +3,26 @@ import { JSX, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { collection, query, where, getDocs, Timestamp } from 'firebase/firestore';
 import {
-    BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer
+    BarChart, Bar, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
 } from 'recharts';
-import { Banknote, Droplets, Gauge } from 'lucide-react';
+import { Banknote, Droplets, Gauge, Route, Fuel } from 'lucide-react';
 import { db } from '../firebase/config';
 import { useAuth } from '../context/AuthContext';
 import { useTheme } from '../context/ThemeContext';
-import { Log, FuelLogData, Vehicle } from '../utils/types';
-import { getMonthlyTotals, getNumericFuelPrice } from '../utils/calculations';
+import { useRemoteConfig } from '../context/RemoteConfigContext';
+import { getLifetimeStats, LifetimeStats } from '../firebase/aggregationService';
+import { Log, FuelLogData, Vehicle, ChartDataPoint } from '../utils/types';
+import { getMonthlyTotals, getNumericFuelPrice, getNumericMPG } from '../utils/calculations';
 import { COMMON_CURRENCIES } from '../utils/currencyApi';
+import { formatDate } from '../utils/formatDate';
+
+interface VehicleComparisonDatum {
+    vehicleId: string;
+    name: string;
+    avgL100km: number;
+    avgCostPerLitre: number;
+    totalSpend: number;
+}
 
 const MONTHS_BACK = 6;
 
@@ -20,14 +31,30 @@ function DashboardPage(): JSX.Element {
     const { theme } = useTheme();
     const { t } = useTranslation();
 
+    const { getBoolean } = useRemoteConfig();
+
     const homeCurrency = profile?.homeCurrency || 'EUR';
     const homeCurrencySymbol = COMMON_CURRENCIES.find(c => c.code === homeCurrency)?.symbol || homeCurrency;
+
+    const costPerLitreGraphEnabled = getBoolean("costPerLitreGraphEnabled");
+    const vehicleComparisonEnabled = getBoolean("vehicleComparisonEnabled");
 
     const [logs, setLogs] = useState<Log[]>([]);
     const [vehicles, setVehicles] = useState<Vehicle[]>([]);
     const [selectedVehicleId, setSelectedVehicleId] = useState<string>('');
     const [isLoading, setIsLoading] = useState<boolean>(true);
     const [error, setError] = useState<string | null>(null);
+
+    const [lifetimeStats, setLifetimeStats] = useState<LifetimeStats | null>(null);
+    const [vehicleComparisonStats, setVehicleComparisonStats] = useState<VehicleComparisonDatum[]>([]);
+    const [hiddenChartSeries, setHiddenChartSeries] = useState<Set<string>>(new Set());
+    const toggleChartSeries = (dataKey: string) => {
+        setHiddenChartSeries(prev => {
+            const next = new Set(prev);
+            if (next.has(dataKey)) next.delete(dataKey); else next.add(dataKey);
+            return next;
+        });
+    };
 
     useEffect(() => {
         if (!user) { setVehicles([]); return; }
@@ -93,7 +120,53 @@ function DashboardPage(): JSX.Element {
         return () => { cancelled = true; };
     }, [user, selectedVehicleId, t]);
 
+    useEffect(() => {
+        if (!user) { setLifetimeStats(null); return; }
+        getLifetimeStats(user.uid, selectedVehicleId || undefined)
+            .then(setLifetimeStats)
+            .catch(err => console.error('Error fetching lifetime stats:', err));
+    }, [user, selectedVehicleId]);
+
+    useEffect(() => {
+        if (!user || !vehicleComparisonEnabled) { setVehicleComparisonStats([]); return; }
+        if (vehicles.length < 2) { setVehicleComparisonStats([]); return; }
+
+        let cancelled = false;
+        Promise.all(
+            vehicles.map(vehicle =>
+                getLifetimeStats(user.uid, vehicle.id).then(stats => ({ vehicle, stats }))
+            )
+        )
+            .then(results => {
+                if (cancelled) return;
+                const withLogs = results.filter(({ stats }) => stats.logCount > 0);
+                if (withLogs.length < 2) { setVehicleComparisonStats([]); return; }
+                setVehicleComparisonStats(withLogs.map(({ vehicle, stats }) => ({
+                    vehicleId: vehicle.id,
+                    name: vehicle.name,
+                    avgL100km: stats.totalDistanceKm > 0 ? (stats.totalLitres / stats.totalDistanceKm) * 100 : 0,
+                    avgCostPerLitre: stats.totalLitres > 0 ? stats.totalCost / stats.totalLitres : 0,
+                    totalSpend: stats.totalCost,
+                })));
+            })
+            .catch(err => console.error('Error fetching vehicle comparison stats:', err));
+
+        return () => { cancelled = true; };
+    }, [user, vehicles, vehicleComparisonEnabled]);
+
     const monthlyTotals = useMemo(() => getMonthlyTotals(logs, MONTHS_BACK), [logs]);
+
+    const trendChartData = useMemo((): ChartDataPoint[] => {
+        if (!logs || logs.length === 0) return [];
+        const sortedLogs = [...logs].sort((a, b) => a.timestamp.toMillis() - b.timestamp.toMillis());
+        return sortedLogs.map(log => ({
+            date: log.timestamp?.toDate() ? formatDate(log.timestamp.toDate()) : 'N/A',
+            timestampValue: log.timestamp?.toMillis(),
+            mpg: getNumericMPG(log.distanceKm, log.fuelAmountLiters),
+            cost: log.cost > 0 ? log.cost : null,
+            fuelPrice: getNumericFuelPrice(log.cost, log.fuelAmountLiters)
+        }));
+    }, [logs]);
 
     const monthFormatter = useMemo(
         () => new Intl.DateTimeFormat(undefined, { month: 'short' }),
@@ -209,6 +282,144 @@ function DashboardPage(): JSX.Element {
                             </BarChart>
                         </ResponsiveContainer>
                     </div>
+
+                    {/* --- Lifetime Stats (Server-side aggregation, no full data download) --- */}
+                    {lifetimeStats && (
+                        <div>
+                            <p className="text-xs font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider mb-3">
+                                {t('history.lifetimeStats.heading', { defaultValue: 'Lifetime Totals' })}
+                            </p>
+                            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                                <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-4 flex flex-col items-center gap-2 hover:shadow-md transition-all duration-200">
+                                    <div className="p-2 rounded-lg bg-brand-primary/10 text-brand-primary">
+                                        <Banknote size={18} />
+                                    </div>
+                                    <p className="text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider text-center">{t('history.lifetimeStats.totalSpent', { defaultValue: 'Total Spent' })}</p>
+                                    <p className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white font-mono tracking-tighter">{homeCurrencySymbol}{lifetimeStats.totalCost.toFixed(2)}</p>
+                                </div>
+                                <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-4 flex flex-col items-center gap-2 hover:shadow-md transition-all duration-200">
+                                    <div className="p-2 rounded-lg bg-brand-primary/10 text-brand-primary">
+                                        <Droplets size={18} />
+                                    </div>
+                                    <p className="text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider text-center">{t('history.lifetimeStats.totalLitres', { defaultValue: 'Total Litres' })}</p>
+                                    <p className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white font-mono tracking-tighter">{lifetimeStats.totalLitres.toFixed(1)}L</p>
+                                </div>
+                                <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-4 flex flex-col items-center gap-2 hover:shadow-md transition-all duration-200">
+                                    <div className="p-2 rounded-lg bg-brand-primary/10 text-brand-primary">
+                                        <Route size={18} />
+                                    </div>
+                                    <p className="text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider text-center">{t('history.lifetimeStats.totalDistance', { defaultValue: 'Total Distance' })}</p>
+                                    <p className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white font-mono tracking-tighter">{lifetimeStats.totalDistanceKm.toFixed(0)}km</p>
+                                </div>
+                                <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-4 flex flex-col items-center gap-2 hover:shadow-md transition-all duration-200">
+                                    <div className="p-2 rounded-lg bg-brand-primary/10 text-brand-primary">
+                                        <Fuel size={18} />
+                                    </div>
+                                    <p className="text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider text-center">{t('history.lifetimeStats.logCount', { defaultValue: 'Fill-ups' })}</p>
+                                    <p className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white font-mono tracking-tighter">{lifetimeStats.logCount}</p>
+                                </div>
+                            </div>
+                        </div>
+                    )}
+
+                    {/* --- MPG / Price Trend Chart --- */}
+                    {trendChartData.length > 1 && (
+                        <div className="bg-white dark:bg-gray-800 shadow-lg rounded-xl p-4 sm:p-6 border border-gray-200 dark:border-gray-700">
+                            <h3 className="text-lg font-medium text-gray-700 dark:text-gray-300 mb-4">{t('history.charts.mpgOverTime')}</h3>
+                            <ResponsiveContainer width="100%" height={300}>
+                                <LineChart data={trendChartData} margin={{ top: 5, right: 20, left: -10, bottom: 5 }}>
+                                    <CartesianGrid strokeDasharray="3 3" stroke={theme === 'dark' ? '#4A5568' : '#e0e0e0'} />
+                                    <XAxis dataKey="date" tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }} angle={-30} textAnchor="end" height={50} interval="preserveStartEnd" />
+                                    <YAxis yAxisId="left" tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }} domain={['auto', 'auto']} label={{ value: 'MPG (UK)', angle: -90, position: 'insideLeft', offset: 10, style: { fontSize: '12px', fill: theme === 'dark' ? '#cbd5e0' : '#6b7280' } }} />
+                                    <YAxis
+                                        yAxisId="right"
+                                        orientation="right"
+                                        tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }}
+                                        domain={['auto', 'auto']}
+                                        tickFormatter={(value: number) => value.toFixed(3)}
+                                        label={{ value: `${t('history.charts.pricePerLitre')} (${homeCurrencySymbol})`, angle: 90, position: 'insideRight', offset: 10, style: { fontSize: '12px', fill: theme === 'dark' ? '#cbd5e0' : '#6b7280' } }}
+                                    />
+                                    <Tooltip
+                                        contentStyle={{
+                                            fontSize: '12px',
+                                            padding: '5px',
+                                            backgroundColor: theme === 'dark' ? '#2D3748' : 'white',
+                                            color: theme === 'dark' ? 'white' : 'black',
+                                            border: theme === 'dark' ? '1px solid #4A5568' : '1px solid #e0e0e0'
+                                        }}
+                                        formatter={(value: number, name: string) => name === t('history.charts.pricePerLitre')
+                                            ? `${homeCurrencySymbol}${value.toFixed(3)}`
+                                            : value?.toFixed(2)}
+                                    />
+                                    <Legend
+                                        wrapperStyle={{ fontSize: '12px', paddingTop: '10px', color: theme === 'dark' ? 'white' : 'black', cursor: 'pointer' }}
+                                        onClick={(e) => toggleChartSeries(e.dataKey as string)}
+                                    />
+                                    <Line yAxisId="left" type="monotone" dataKey="mpg" name="MPG (UK)" stroke="#8884d8" strokeWidth={2} activeDot={{ r: 6 }} connectNulls hide={hiddenChartSeries.has('mpg')} />
+                                    <Line yAxisId="right" type="monotone" dataKey="fuelPrice" name={t('history.charts.pricePerLitre')} stroke="#F59E0B" strokeWidth={2} activeDot={{ r: 6 }} connectNulls hide={hiddenChartSeries.has('fuelPrice')} />
+                                </LineChart>
+                            </ResponsiveContainer>
+                        </div>
+                    )}
+
+                    {/* Conditionally render Cost Per Litre Graph if feature flag is enabled and data exists */}
+                    {costPerLitreGraphEnabled && trendChartData.length > 1 && (
+                        <div className="bg-white dark:bg-gray-800 shadow-lg rounded-xl p-4 sm:p-6 border border-gray-200 dark:border-gray-700">
+                            <h3 className="text-lg font-medium text-gray-700 dark:text-gray-300 mb-4">{t('history.charts.costPerLitreOverTime')}</h3>
+                            <ResponsiveContainer width="100%" height={300}>
+                                <LineChart data={trendChartData} margin={{ top: 5, right: 20, left: -10, bottom: 5 }}>
+                                    <CartesianGrid strokeDasharray="3 3" stroke={theme === 'dark' ? '#4A5568' : '#e0e0e0'} />
+                                    <XAxis dataKey="date" tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }} angle={-30} textAnchor="end" height={50} interval="preserveStartEnd" />
+                                    <YAxis
+                                        tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }}
+                                        domain={['auto', 'auto']}
+                                        label={{ value: 'Cost Per Litre (€)', angle: -90, position: 'insideLeft', offset: 10, style: { fontSize: '12px', fill: theme === 'dark' ? '#cbd5e0' : '#6b7280' } }}
+                                        tickFormatter={(value) => value.toFixed(3)}
+                                    />
+                                    <Tooltip
+                                        contentStyle={{ fontSize: '12px', padding: '5px', backgroundColor: theme === 'dark' ? '#2D3748' : 'white', color: theme === 'dark' ? 'white' : 'black', border: theme === 'dark' ? '1px solid #4A5568' : '1px solid #e0e0e0' }}
+                                        formatter={(value: number) => `€${value.toFixed(3)}`}
+                                    />
+                                    <Legend wrapperStyle={{ fontSize: '12px', paddingTop: '10px', color: theme === 'dark' ? 'white' : 'black' }} />
+                                    <Line type="monotone" dataKey="fuelPrice" name="Cost Per Litre" stroke="#82ca9d" strokeWidth={2} activeDot={{ r: 6 }} connectNulls />
+                                </LineChart>
+                            </ResponsiveContainer>
+                        </div>
+                    )}
+
+                    {/* Multi-vehicle efficiency/cost comparison, behind vehicleComparisonEnabled flag */}
+                    {vehicleComparisonEnabled && vehicleComparisonStats.length >= 2 && (
+                        <div className="bg-white dark:bg-gray-800 shadow-lg rounded-xl p-4 sm:p-6 border border-gray-200 dark:border-gray-700">
+                            <h3 className="text-lg font-medium text-gray-700 dark:text-gray-300 mb-4">{t('history.charts.vehicleComparison')}</h3>
+                            <ResponsiveContainer width="100%" height={300}>
+                                <BarChart data={vehicleComparisonStats} margin={{ top: 5, right: 20, left: -10, bottom: 5 }}>
+                                    <CartesianGrid strokeDasharray="3 3" stroke={theme === 'dark' ? '#4A5568' : '#e0e0e0'} />
+                                    <XAxis dataKey="name" tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }} />
+                                    <YAxis
+                                        yAxisId="left"
+                                        tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }}
+                                    />
+                                    <YAxis
+                                        yAxisId="right"
+                                        orientation="right"
+                                        tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }}
+                                    />
+                                    <Tooltip
+                                        contentStyle={{ fontSize: '12px', padding: '5px', backgroundColor: theme === 'dark' ? '#2D3748' : 'white', color: theme === 'dark' ? 'white' : 'black', border: theme === 'dark' ? '1px solid #4A5568' : '1px solid #e0e0e0' }}
+                                        formatter={(value: number, name: string) => name === t('history.charts.totalSpend')
+                                            ? `${homeCurrencySymbol}${value.toFixed(2)}`
+                                            : name === t('history.charts.avgCostPerLitre')
+                                                ? `${homeCurrencySymbol}${value.toFixed(3)}`
+                                                : value.toFixed(2)}
+                                    />
+                                    <Legend wrapperStyle={{ fontSize: '12px', paddingTop: '10px', color: theme === 'dark' ? 'white' : 'black' }} />
+                                    <Bar yAxisId="left" dataKey="avgL100km" name={t('history.charts.avgL100km')} fill="#8884d8" />
+                                    <Bar yAxisId="left" dataKey="avgCostPerLitre" name={t('history.charts.avgCostPerLitre')} fill="#82ca9d" />
+                                    <Bar yAxisId="right" dataKey="totalSpend" name={t('history.charts.totalSpend')} fill="#fbbf24" />
+                                </BarChart>
+                            </ResponsiveContainer>
+                        </div>
+                    )}
                 </>
             )}
         </div>

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -6,20 +6,15 @@ import {
     collection, query, where, orderBy, onSnapshot, getDocs,
     doc, deleteDoc, updateDoc, DocumentData, QuerySnapshot
 } from "firebase/firestore";
-import { getLifetimeStats, LifetimeStats } from '../firebase/aggregationService';
 // Import Firebase config and Auth hook
 import { db } from '../firebase/config';
 import { useAuth } from '../context/AuthContext';
-// Import Recharts components for charting
-import {
-    LineChart, Line, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
-} from 'recharts';
 // Import icons
-import { FileText, Banknote, Droplets, Route, Fuel } from 'lucide-react';
+import { FileText } from 'lucide-react';
 // Import the LogCard component
 import LogCard from '../components/LogCard'; // Adjust path if necessary
-import { ChartDataPoint, FuelLogData, Log, EditFormData, EditingLogState, ViewMode, Vehicle } from '../utils/types';
-import { formatCostPerMile, formatKmL, formatL100km, formatMPG, getNumericFuelPrice, getNumericMPG } from '../utils/calculations';
+import { FuelLogData, Log, EditFormData, EditingLogState, ViewMode, Vehicle } from '../utils/types';
+import { formatCostPerMile, formatKmL, formatL100km, formatMPG } from '../utils/calculations';
 import { useTheme } from '../context/ThemeContext';
 import { useRemoteConfig } from '../context/RemoteConfigContext'; // Import the hook
 import { exportLogsToPDF } from '../utils/pdfExport'; // Import PDF Export utility
@@ -30,14 +25,6 @@ import { sanitizeUrl } from '../utils/sanitize';
 import { formatDate } from '../utils/formatDate';
 import { fetchUserStations } from '../firebase/firestoreService';
 import { Station } from '../utils/types';
-
-interface VehicleComparisonDatum {
-    vehicleId: string;
-    name: string;
-    avgL100km: number;
-    avgCostPerLitre: number;
-    totalSpend: number;
-}
 
 // --- React Component ---
 function HistoryPage(): JSX.Element {
@@ -53,11 +40,9 @@ function HistoryPage(): JSX.Element {
     const { theme } = useTheme();
 
     // --- Feature Flags ---
-    const costPerLitreGraphEnabled = getBoolean("costPerLitreGraphEnabled");
     const totalSpentDisplayEnabled = getBoolean("totalSpentDisplayEnabled");
     const receiptDigitizationEnabled = getBoolean("receiptDigitizationEnabled");
     const odometerInputEnabled = getBoolean("odometerInputEnabled");
-    const vehicleComparisonEnabled = getBoolean("vehicleComparisonEnabled");
 
     const [logs, setLogs] = useState<Log[]>([]); // Holds the array of ALL fetched fuel logs for the user
     const [stations, setStations] = useState<Station[]>([]); // Holds station info
@@ -83,22 +68,6 @@ function HistoryPage(): JSX.Element {
     const [filterBrand, setFilterBrand] = useState<string>('');       // Selected brand or '' for all
     const [uniqueBrands, setUniqueBrands] = useState<string[]>([]);    // List of unique brands for the filter dropdown
 
-    // --- Lifetime Aggregation Stats ---
-    const [lifetimeStats, setLifetimeStats] = useState<LifetimeStats | null>(null);
-
-    // --- Main Chart Series Visibility (toggled via Legend click) ---
-    const [hiddenChartSeries, setHiddenChartSeries] = useState<Set<string>>(new Set());
-    const toggleChartSeries = (dataKey: string) => {
-        setHiddenChartSeries(prev => {
-            const next = new Set(prev);
-            if (next.has(dataKey)) next.delete(dataKey); else next.add(dataKey);
-            return next;
-        });
-    };
-
-    // --- Multi-Vehicle Comparison Stats ---
-    const [vehicleComparisonStats, setVehicleComparisonStats] = useState<VehicleComparisonDatum[]>([]);
-
     // --- Fetch Vehicles Effect ---
     useEffect(() => {
         if (!user) { setVehicles([]); return; }
@@ -118,44 +87,6 @@ function HistoryPage(): JSX.Element {
         };
         fetchVehicles();
     }, [user]);
-
-    // --- Fetch Lifetime Aggregation Stats ---
-    useEffect(() => {
-        if (!user) { setLifetimeStats(null); return; }
-        getLifetimeStats(user.uid, filterVehicleId || undefined)
-            .then(setLifetimeStats)
-            .catch(err => console.error('Error fetching lifetime stats:', err));
-    }, [user, filterVehicleId]);
-
-    // --- Fetch Per-Vehicle Comparison Stats ---
-    // One getLifetimeStats aggregation call per active vehicle (no raw document reads).
-    useEffect(() => {
-        if (!user || !vehicleComparisonEnabled) { setVehicleComparisonStats([]); return; }
-        const activeVehicles = vehicles.filter(v => !v.isArchived);
-        if (activeVehicles.length < 2) { setVehicleComparisonStats([]); return; }
-
-        let cancelled = false;
-        Promise.all(
-            activeVehicles.map(vehicle =>
-                getLifetimeStats(user.uid, vehicle.id).then(stats => ({ vehicle, stats }))
-            )
-        )
-            .then(results => {
-                if (cancelled) return;
-                const withLogs = results.filter(({ stats }) => stats.logCount > 0);
-                if (withLogs.length < 2) { setVehicleComparisonStats([]); return; }
-                setVehicleComparisonStats(withLogs.map(({ vehicle, stats }) => ({
-                    vehicleId: vehicle.id,
-                    name: vehicle.name,
-                    avgL100km: stats.totalDistanceKm > 0 ? (stats.totalLitres / stats.totalDistanceKm) * 100 : 0,
-                    avgCostPerLitre: stats.totalLitres > 0 ? stats.totalCost / stats.totalLitres : 0,
-                    totalSpend: stats.totalCost,
-                })));
-            })
-            .catch(err => console.error('Error fetching vehicle comparison stats:', err));
-
-        return () => { cancelled = true; };
-    }, [user, vehicles, vehicleComparisonEnabled]);
 
     // --- State for View Toggle ---
     const [viewMode, setViewMode] = useState<ViewMode>('table'); // Default to table view
@@ -270,21 +201,6 @@ function HistoryPage(): JSX.Element {
         vehicles.forEach(v => map[v.id] = v.name);
         return map;
     }, [vehicles]);
-
-    // --- Prepare Chart Data (Uses filteredLogs) ---
-    // Memoized calculation for chart data based on the *filtered* logs.
-    const chartData = useMemo((): ChartDataPoint[] => {
-        if (!filteredLogs || filteredLogs.length === 0) return [];
-        // Sort ascending by date for time-series charts
-        const sortedLogs = [...filteredLogs].sort((a, b) => a.timestamp.toMillis() - b.timestamp.toMillis());
-        return sortedLogs.map(log => ({
-            date: log.timestamp?.toDate() ? formatDate(log.timestamp.toDate()) : 'N/A',
-            timestampValue: log.timestamp?.toMillis(),
-            mpg: getNumericMPG(log.distanceKm, log.fuelAmountLiters),
-            cost: log.cost > 0 ? log.cost : null,
-            fuelPrice: getNumericFuelPrice(log.cost, log.fuelAmountLiters)
-        }));
-    }, [filteredLogs]); // Recalculate only when filteredLogs change
 
     // --- Calculate Summary Metrics (Uses filteredLogs) ---
     // Memoized calculation for the total cost, average MPG, and average cost based on the *filtered* logs.
@@ -521,150 +437,6 @@ function HistoryPage(): JSX.Element {
                         </p>
                     </div>
                 </div>
-            )}
-
-            {/* --- Lifetime Stats (Server-side aggregation, no full data download) --- */}
-            {lifetimeStats && !isLoading && !error && (
-                <div>
-                    <p className="text-xs font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider mb-3">
-                        {t('history.lifetimeStats.heading', { defaultValue: 'Lifetime Totals' })}
-                    </p>
-                    <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-                        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-4 flex flex-col items-center gap-2 hover:shadow-md transition-all duration-200">
-                            <div className="p-2 rounded-lg bg-brand-primary/10 text-brand-primary">
-                                <Banknote size={18} />
-                            </div>
-                            <p className="text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider text-center">{t('history.lifetimeStats.totalSpent', { defaultValue: 'Total Spent' })}</p>
-                            <p className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white font-mono tracking-tighter">{homeCurrencySymbol}{lifetimeStats.totalCost.toFixed(2)}</p>
-                        </div>
-                        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-4 flex flex-col items-center gap-2 hover:shadow-md transition-all duration-200">
-                            <div className="p-2 rounded-lg bg-brand-primary/10 text-brand-primary">
-                                <Droplets size={18} />
-                            </div>
-                            <p className="text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider text-center">{t('history.lifetimeStats.totalLitres', { defaultValue: 'Total Litres' })}</p>
-                            <p className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white font-mono tracking-tighter">{lifetimeStats.totalLitres.toFixed(1)}L</p>
-                        </div>
-                        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-4 flex flex-col items-center gap-2 hover:shadow-md transition-all duration-200">
-                            <div className="p-2 rounded-lg bg-brand-primary/10 text-brand-primary">
-                                <Route size={18} />
-                            </div>
-                            <p className="text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider text-center">{t('history.lifetimeStats.totalDistance', { defaultValue: 'Total Distance' })}</p>
-                            <p className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white font-mono tracking-tighter">{lifetimeStats.totalDistanceKm.toFixed(0)}km</p>
-                        </div>
-                        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-4 flex flex-col items-center gap-2 hover:shadow-md transition-all duration-200">
-                            <div className="p-2 rounded-lg bg-brand-primary/10 text-brand-primary">
-                                <Fuel size={18} />
-                            </div>
-                            <p className="text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider text-center">{t('history.lifetimeStats.logCount', { defaultValue: 'Fill-ups' })}</p>
-                            <p className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white font-mono tracking-tighter">{lifetimeStats.logCount}</p>
-                        </div>
-                    </div>
-                </div>
-            )}
-
-            {/* --- Charts Section (Uses filtered data via chartData) --- */}
-            {/* Render chart only if not loading, no error, and enough filtered data exists */}
-            {filteredLogs.length > 1 && !isLoading && !error ? (
-                <div className="bg-white dark:bg-gray-800 shadow-lg rounded-xl p-4 sm:p-6 border border-gray-200 dark:border-gray-700">
-                    <h3 className="text-lg font-medium text-gray-700 dark:text-gray-300 mb-4">{t('history.charts.mpgOverTime')}</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                        <LineChart data={chartData} margin={{ top: 5, right: 20, left: -10, bottom: 5 }}>
-                            <CartesianGrid strokeDasharray="3 3" stroke={theme === 'dark' ? '#4A5568' : '#e0e0e0'} />
-                            <XAxis dataKey="date" tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }} angle={-30} textAnchor="end" height={50} interval="preserveStartEnd" />
-                            <YAxis yAxisId="left" tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }} domain={['auto', 'auto']} label={{ value: 'MPG (UK)', angle: -90, position: 'insideLeft', offset: 10, style: { fontSize: '12px', fill: theme === 'dark' ? '#cbd5e0' : '#6b7280' } }} />
-                            <YAxis
-                                yAxisId="right"
-                                orientation="right"
-                                tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }}
-                                domain={['auto', 'auto']}
-                                tickFormatter={(value: number) => value.toFixed(3)}
-                                label={{ value: `${t('history.charts.pricePerLitre')} (${homeCurrencySymbol})`, angle: 90, position: 'insideRight', offset: 10, style: { fontSize: '12px', fill: theme === 'dark' ? '#cbd5e0' : '#6b7280' } }}
-                            />
-                            <Tooltip
-                                contentStyle={{
-                                    fontSize: '12px',
-                                    padding: '5px',
-                                    backgroundColor: theme === 'dark' ? '#2D3748' : 'white',
-                                    color: theme === 'dark' ? 'white' : 'black',
-                                    border: theme === 'dark' ? '1px solid #4A5568' : '1px solid #e0e0e0'
-                                }}
-                                formatter={(value: number, name: string) => name === t('history.charts.pricePerLitre')
-                                    ? `${homeCurrencySymbol}${value.toFixed(3)}`
-                                    : value?.toFixed(2)}
-                            />
-                            <Legend
-                                wrapperStyle={{ fontSize: '12px', paddingTop: '10px', color: theme === 'dark' ? 'white' : 'black', cursor: 'pointer' }}
-                                onClick={(e) => toggleChartSeries(e.dataKey as string)}
-                            />
-                            <Line yAxisId="left" type="monotone" dataKey="mpg" name="MPG (UK)" stroke="#8884d8" strokeWidth={2} activeDot={{ r: 6 }} connectNulls hide={hiddenChartSeries.has('mpg')} />
-                            <Line yAxisId="right" type="monotone" dataKey="fuelPrice" name={t('history.charts.pricePerLitre')} stroke="#F59E0B" strokeWidth={2} activeDot={{ r: 6 }} connectNulls hide={hiddenChartSeries.has('fuelPrice')} />
-                        </LineChart>
-                    </ResponsiveContainer>
-                </div>
-            ) : null}
-
-            {/* Conditionally render Cost Per Litre Graph if feature flag is enabled and data exists */}
-            {costPerLitreGraphEnabled && filteredLogs.length > 1 && !isLoading && !error && (
-                <div className="bg-white dark:bg-gray-800 shadow-lg rounded-xl p-4 sm:p-6 border border-gray-200 dark:border-gray-700 mt-8">
-                    <h3 className="text-lg font-medium text-gray-700 dark:text-gray-300 mb-4">{t('history.charts.costPerLitreOverTime')}</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                        <LineChart data={chartData} margin={{ top: 5, right: 20, left: -10, bottom: 5 }}>
-                            <CartesianGrid strokeDasharray="3 3" stroke={theme === 'dark' ? '#4A5568' : '#e0e0e0'} />
-                            <XAxis dataKey="date" tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }} angle={-30} textAnchor="end" height={50} interval="preserveStartEnd" />
-                            <YAxis
-                                tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }}
-                                domain={['auto', 'auto']}
-                                label={{ value: 'Cost Per Litre (€)', angle: -90, position: 'insideLeft', offset: 10, style: { fontSize: '12px', fill: theme === 'dark' ? '#cbd5e0' : '#6b7280' } }}
-                                tickFormatter={(value) => value.toFixed(3)} // Format Y-axis ticks to 3 decimal places
-                            />
-                            <Tooltip
-                                contentStyle={{ fontSize: '12px', padding: '5px', backgroundColor: theme === 'dark' ? '#2D3748' : 'white', color: theme === 'dark' ? 'white' : 'black', border: theme === 'dark' ? '1px solid #4A5568' : '1px solid #e0e0e0' }}
-                                formatter={(value: number) => `€${value.toFixed(3)}`} // Format tooltip value
-                            />
-                            <Legend wrapperStyle={{ fontSize: '12px', paddingTop: '10px', color: theme === 'dark' ? 'white' : 'black' }} />
-                            <Line type="monotone" dataKey="fuelPrice" name="Cost Per Litre" stroke="#82ca9d" strokeWidth={2} activeDot={{ r: 6 }} connectNulls />
-                        </LineChart>
-                    </ResponsiveContainer>
-                </div>
-            )}
-
-            {/* Multi-vehicle efficiency/cost comparison, behind vehicleComparisonEnabled flag */}
-            {vehicleComparisonEnabled && vehicleComparisonStats.length >= 2 && (
-                <div className="bg-white dark:bg-gray-800 shadow-lg rounded-xl p-4 sm:p-6 border border-gray-200 dark:border-gray-700 mt-8">
-                    <h3 className="text-lg font-medium text-gray-700 dark:text-gray-300 mb-4">{t('history.charts.vehicleComparison')}</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                        <BarChart data={vehicleComparisonStats} margin={{ top: 5, right: 20, left: -10, bottom: 5 }}>
-                            <CartesianGrid strokeDasharray="3 3" stroke={theme === 'dark' ? '#4A5568' : '#e0e0e0'} />
-                            <XAxis dataKey="name" tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }} />
-                            <YAxis
-                                yAxisId="left"
-                                tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }}
-                            />
-                            <YAxis
-                                yAxisId="right"
-                                orientation="right"
-                                tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }}
-                            />
-                            <Tooltip
-                                contentStyle={{ fontSize: '12px', padding: '5px', backgroundColor: theme === 'dark' ? '#2D3748' : 'white', color: theme === 'dark' ? 'white' : 'black', border: theme === 'dark' ? '1px solid #4A5568' : '1px solid #e0e0e0' }}
-                                formatter={(value: number, name: string) => name === t('history.charts.totalSpend')
-                                    ? `${homeCurrencySymbol}${value.toFixed(2)}`
-                                    : name === t('history.charts.avgCostPerLitre')
-                                        ? `${homeCurrencySymbol}${value.toFixed(3)}`
-                                        : value.toFixed(2)}
-                            />
-                            <Legend wrapperStyle={{ fontSize: '12px', paddingTop: '10px', color: theme === 'dark' ? 'white' : 'black' }} />
-                            <Bar yAxisId="left" dataKey="avgL100km" name={t('history.charts.avgL100km')} fill="#8884d8" />
-                            <Bar yAxisId="left" dataKey="avgCostPerLitre" name={t('history.charts.avgCostPerLitre')} fill="#82ca9d" />
-                            <Bar yAxisId="right" dataKey="totalSpend" name={t('history.charts.totalSpend')} fill="#fbbf24" />
-                        </BarChart>
-                    </ResponsiveContainer>
-                </div>
-            )}
-
-            {/* Message for insufficient data for ANY active graph */}
-            {filteredLogs.length <= 1 && !isLoading && !error && logs.length > 0 && (
-                 <div className="text-center text-gray-500 dark:text-gray-400 text-sm p-4">{t('history.charts.needMoreData')}</div>
             )}
 
             {/* --- Table / Cards Section --- */}


### PR DESCRIPTION
## Summary
- Implements stage 1 of #170: consolidates dashboard-style analytics into the Dashboard tab
- Moves the MPG/Price trend LineChart, the feature-flagged Cost-per-Litre LineChart, the feature-flagged multi-vehicle comparison BarChart, and the lifetime stat cards (Total Spent, Total Litres, Total Distance, Fill-ups) from History to Dashboard
- History keeps the filterable summary metric cards, the table/card log view, edit/delete, and PDF/copy export — i.e. it stays a pure log of entries plus the per-filter summary
- Dashboard's vehicle selector now drives the lifetime stats and comparison charts too

## Test plan
- [x] `npm run lint` — no new warnings/errors
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run build` — succeeds
- [x] `npx vitest run` — all 196 tests pass (updated `DashboardPage.test.tsx` mocks for `useRemoteConfig` and `aggregationService`)
- [ ] Manual check in browser: Dashboard shows trend chart + lifetime stats; History shows only filters/table/cards

Closes part of #170 (new dashboard widgets are a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)