### PR TITLE
Default-sort Stations page by proximity to current location

### DIFF
--- a/src/components/StationTable.tsx
+++ b/src/components/StationTable.tsx
@@ -3,21 +3,25 @@ import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ArrowUpDown, ArrowUp, ArrowDown } from 'lucide-react';
 import { Station } from '../utils/types';
+import { Coordinates, haversineDistanceKm } from '../utils/locationService';
 
 interface StationTableProps {
   stations: Station[];
   onSelectStation: (stationId: string) => void;
   selectedStationId: string | null;
+  origin?: Coordinates | null;
 }
 
-type SortKey = 'name' | 'avgPrice' | 'logCount';
+type SortKey = 'name' | 'avgPrice' | 'logCount' | 'distance';
 type SortDirection = 'asc' | 'desc';
+type StationWithDistance = Station & { distance?: number };
 
-const SORT_OPTIONS: { key: SortKey; labelKey: string }[] = [
+const BASE_SORT_OPTIONS: { key: SortKey; labelKey: string }[] = [
   { key: 'name', labelKey: 'stationTable.name' },
   { key: 'avgPrice', labelKey: 'stationTable.avgPrice' },
   { key: 'logCount', labelKey: 'stationTable.logCount' },
 ];
+const DISTANCE_SORT_OPTION: { key: SortKey; labelKey: string } = { key: 'distance', labelKey: 'stationTable.distance' };
 
 // A station's price tier (relative to the other visible stations) is the signature
 // of this list: it lets a user spot the cheapest fill-up at a glance instead of
@@ -58,13 +62,28 @@ const usePriceTiers = (stations: Station[]): Map<string, PriceTier> => {
   }, [stations]);
 };
 
-const StationTable: React.FC<StationTableProps> = ({ stations, onSelectStation, selectedStationId }) => {
+const StationTable: React.FC<StationTableProps> = ({ stations, onSelectStation, selectedStationId, origin }) => {
   const { t } = useTranslation();
-  const [sortConfig, setSortConfig] = useState<{ key: SortKey; direction: SortDirection } | null>(null);
+  const [sortConfig, setSortConfig] = useState<{ key: SortKey; direction: SortDirection } | null>(
+    () => (origin ? { key: 'distance', direction: 'asc' } : null)
+  );
   const priceTiers = usePriceTiers(stations);
 
+  const SORT_OPTIONS = useMemo(
+    () => (origin ? [DISTANCE_SORT_OPTION, ...BASE_SORT_OPTIONS] : BASE_SORT_OPTIONS),
+    [origin]
+  );
+
+  const stationsWithDistance = useMemo((): StationWithDistance[] => {
+    if (!origin) return stations;
+    return stations.map((s) => ({
+      ...s,
+      distance: haversineDistanceKm(origin.latitude, origin.longitude, s.latitude, s.longitude),
+    }));
+  }, [stations, origin]);
+
   const sortedStations = useMemo(() => {
-    const sortable = [...stations];
+    const sortable = [...stationsWithDistance];
     if (sortConfig !== null) {
       sortable.sort((a, b) => {
         const aValue = a[sortConfig.key];
@@ -83,7 +102,7 @@ const StationTable: React.FC<StationTableProps> = ({ stations, onSelectStation, 
       });
     }
     return sortable;
-  }, [stations, sortConfig]);
+  }, [stationsWithDistance, sortConfig]);
 
   const requestSort = (key: SortKey) => {
     let direction: SortDirection = 'asc';
@@ -154,6 +173,7 @@ const StationTable: React.FC<StationTableProps> = ({ stations, onSelectStation, 
                   </span>
                   <span className="block text-xs text-gray-500 dark:text-gray-400 truncate">
                     {station.brand || t('stationTable.unknownBrand')} · {station.logCount} {t('stationTable.logCount')}
+                    {typeof station.distance === 'number' && ` · ${station.distance.toFixed(1)} km`}
                   </span>
                 </span>
                 <span className="text-sm font-mono font-semibold text-gray-900 dark:text-gray-100 shrink-0 whitespace-nowrap">

--- a/src/components/__tests__/StationTable.test.tsx
+++ b/src/components/__tests__/StationTable.test.tsx
@@ -16,6 +16,7 @@ vi.mock('react-i18next', () => ({
         'stationTable.logCount': 'Logs',
         'stationTable.unknownBrand': 'Unknown Brand',
         'stationTable.noData': 'N/A',
+        'stationTable.distance': 'Distance',
       };
       return translations[key] || key;
     },
@@ -137,5 +138,43 @@ describe('StationTable', () => {
 
     fireEvent.click(screen.getByTestId('sort-logCount'));
     expect(orderedNames()).toEqual(['NoBrand C', 'Shell A', 'Maxol B']); // 15, 10, 5
+  });
+
+  it('does not show a Distance sort option when no origin is provided', () => {
+    render(<StationTable stations={mockStations} onSelectStation={onSelectStation} selectedStationId={null} />);
+    expect(screen.queryByTestId('sort-distance')).not.toBeInTheDocument();
+  });
+
+  it('defaults to nearest-first distance sort when an origin is provided', () => {
+    // Origin near station2 (11, 21); station1 (10,20) and station3 (12,22) are
+    // roughly equidistant on either side, so station2 should sort first.
+    render(
+      <StationTable
+        stations={mockStations}
+        onSelectStation={onSelectStation}
+        selectedStationId={null}
+        origin={{ latitude: 11, longitude: 21 }}
+      />
+    );
+
+    expect(screen.getByTestId('sort-distance')).toBeInTheDocument();
+    expect(screen.getByTestId('sort-distance')).toHaveAttribute('aria-pressed', 'true');
+    expect(orderedNames()[0]).toEqual('Maxol B');
+  });
+
+  it('toggles distance sort direction on click', () => {
+    render(
+      <StationTable
+        stations={mockStations}
+        onSelectStation={onSelectStation}
+        selectedStationId={null}
+        origin={{ latitude: 11, longitude: 21 }}
+      />
+    );
+
+    const nearestFirst = orderedNames();
+    fireEvent.click(screen.getByTestId('sort-distance'));
+    const farthestFirst = orderedNames();
+    expect(farthestFirst).toEqual([...nearestFirst].reverse());
   });
 });

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -28,7 +28,8 @@
     "avgPrice": "Ø-Preis",
     "logCount": "Einträge",
     "unknownBrand": "Unbekannte Marke",
-    "noData": "k. A."
+    "noData": "k. A.",
+    "distance": "Distance"
   },
   "stationDetail": {
     "unknownBrand": "Unbekannte Marke",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -28,7 +28,8 @@
     "avgPrice": "Avg. Price",
     "logCount": "Logs",
     "unknownBrand": "Unknown Brand",
-    "noData": "N/A"
+    "noData": "N/A",
+    "distance": "Distance"
   },
   "stationDetail": {
     "unknownBrand": "Unknown Brand",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -28,7 +28,8 @@
     "avgPrice": "Precio medio",
     "logCount": "Registros",
     "unknownBrand": "Marca desconocida",
-    "noData": "N/D"
+    "noData": "N/D",
+    "distance": "Distance"
   },
   "stationDetail": {
     "unknownBrand": "Marca desconocida",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -28,7 +28,8 @@
     "avgPrice": "Keskihinta",
     "logCount": "Merkinnät",
     "unknownBrand": "Tuntematon merkki",
-    "noData": "Ei tietoa"
+    "noData": "Ei tietoa",
+    "distance": "Distance"
   },
   "stationDetail": {
     "unknownBrand": "Tuntematon merkki",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -28,7 +28,8 @@
     "avgPrice": "Prix moyen",
     "logCount": "Entrées",
     "unknownBrand": "Marque inconnue",
-    "noData": "N/D"
+    "noData": "N/D",
+    "distance": "Distance"
   },
   "stationDetail": {
     "unknownBrand": "Marque inconnue",

--- a/src/i18n/locales/ga.json
+++ b/src/i18n/locales/ga.json
@@ -28,7 +28,8 @@
     "avgPrice": "Meánphraghas",
     "logCount": "Logaí",
     "unknownBrand": "Branda Anaithnid",
-    "noData": "N/B"
+    "noData": "N/B",
+    "distance": "Distance"
   },
   "stationDetail": {
     "unknownBrand": "Branda Anaithnid",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -28,7 +28,8 @@
     "avgPrice": "平均価格",
     "logCount": "記録数",
     "unknownBrand": "不明なブランド",
-    "noData": "なし"
+    "noData": "なし",
+    "distance": "Distance"
   },
   "stationDetail": {
     "unknownBrand": "不明なブランド",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -28,7 +28,8 @@
     "avgPrice": "평균 가격",
     "logCount": "기록 수",
     "unknownBrand": "알 수 없는 브랜드",
-    "noData": "해당 없음"
+    "noData": "해당 없음",
+    "distance": "Distance"
   },
   "stationDetail": {
     "unknownBrand": "알 수 없는 브랜드",

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -28,7 +28,8 @@
     "avgPrice": "Gj.snitt. Pris",
     "logCount": "Logger",
     "unknownBrand": "Ukjent merke",
-    "noData": "I/T"
+    "noData": "I/T",
+    "distance": "Distance"
   },
   "stationDetail": {
     "unknownBrand": "Ukjent merke",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -28,7 +28,8 @@
     "avgPrice": "Genomsnittligt pris",
     "logCount": "Loggar",
     "unknownBrand": "Okänt märke",
-    "noData": "Ej tillgänglig"
+    "noData": "Ej tillgänglig",
+    "distance": "Distance"
   },
   "stationDetail": {
     "unknownBrand": "Okänt märke",

--- a/src/pages/StationsPage.tsx
+++ b/src/pages/StationsPage.tsx
@@ -1,10 +1,11 @@
 // src/pages/StationsPage.tsx
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Loader, AlertCircle } from 'lucide-react';
 
 import { fetchFuelLocations, fetchUserStations } from '../firebase/firestoreService';
 import { Station } from '../utils/types';
+import { Coordinates, getCurrentPosition } from '../utils/locationService';
 import StationTable from '../components/StationTable'; // Will create this component
 import StationDetail from '../components/StationDetail'; // Will create this component
 
@@ -14,6 +15,10 @@ const StationsPage: React.FC = () => {
     const [loading, setLoading] = useState<boolean>(true);
     const [error, setError] = useState<string | null>(null);
     const [selectedStationId, setSelectedStationId] = useState<string | null>(null);
+    const [origin, setOrigin] = useState<Coordinates | null>(null);
+    // Geolocation should always win over the fallback, regardless of which
+    // resolves first; this guards the fallback from clobbering a real fix.
+    const hasGeolocationFix = useRef(false);
 
     useEffect(() => {
         const loadStations = async () => {
@@ -23,6 +28,12 @@ const StationsPage: React.FC = () => {
                 const logs = await fetchFuelLocations();
                 const userStations = await fetchUserStations(logs);
                 setStations(userStations);
+                // Fallback origin: the most recent fill-up location (logs are
+                // ordered timestamp desc and pre-filtered to have coordinates).
+                const lastLog = logs[0];
+                if (!hasGeolocationFix.current && lastLog?.latitude !== undefined && lastLog?.longitude !== undefined) {
+                    setOrigin({ latitude: lastLog.latitude, longitude: lastLog.longitude });
+                }
             } catch (err) {
                 console.error("Failed to load stations:", err);
                 setError(t('stations.errorLoading'));
@@ -33,6 +44,17 @@ const StationsPage: React.FC = () => {
 
         loadStations();
     }, [t]);
+
+    useEffect(() => {
+        let cancelled = false;
+        getCurrentPosition().then((position) => {
+            if (!cancelled && position) {
+                hasGeolocationFix.current = true;
+                setOrigin(position);
+            }
+        });
+        return () => { cancelled = true; };
+    }, []);
 
     const handleSelectStation = (stationId: string) => {
         setSelectedStationId(stationId);
@@ -67,10 +89,11 @@ const StationsPage: React.FC = () => {
             ) : (
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                     <div className="md:col-span-1">
-                        <StationTable 
-                            stations={stations} 
-                            onSelectStation={handleSelectStation} 
-                            selectedStationId={selectedStationId} 
+                        <StationTable
+                            stations={stations}
+                            onSelectStation={handleSelectStation}
+                            selectedStationId={selectedStationId}
+                            origin={origin}
                         />
                     </div>
                     <div className="md:col-span-2">

--- a/src/pages/__tests__/StationsPage.test.tsx
+++ b/src/pages/__tests__/StationsPage.test.tsx
@@ -29,8 +29,8 @@ vi.mock('../../firebase/firestoreService', () => ({
 
 // Mock StationTable and StationDetail components
 vi.mock('../../components/StationTable', () => ({
-  default: vi.fn(({ stations, onSelectStation, selectedStationId }) => (
-    <div data-testid="station-table">
+  default: vi.fn(({ stations, onSelectStation, selectedStationId, origin }) => (
+    <div data-testid="station-table" data-origin={origin ? `${origin.latitude},${origin.longitude}` : ''}>
       {stations.map((station: Station) => (
         <div key={station.id} data-testid={`station-item-${station.id}`} onClick={() => onSelectStation(station.id)}>
           {station.name} {selectedStationId === station.id && '(Selected)'}
@@ -38,6 +38,11 @@ vi.mock('../../components/StationTable', () => ({
       ))}
     </div>
   )),
+}));
+
+const mockGetCurrentPosition = vi.fn();
+vi.mock('../../utils/locationService', () => ({
+  getCurrentPosition: () => mockGetCurrentPosition(),
 }));
 vi.mock('../../components/StationDetail', () => ({
   default: vi.fn(({ stationId }) => (
@@ -75,6 +80,7 @@ describe('StationsPage', () => {
     vi.clearAllMocks();
     vi.mocked(fetchFuelLocations).mockResolvedValue([]);
     vi.mocked(fetchUserStations).mockResolvedValue([]); // Default to no stations
+    mockGetCurrentPosition.mockResolvedValue(null); // Default: geolocation denied/unavailable
   });
 
   it('renders loading state initially', () => {
@@ -135,6 +141,32 @@ describe('StationsPage', () => {
       expect(screen.getByTestId('station-detail')).toBeInTheDocument();
       expect(screen.getByText('Station Detail for station1')).toBeInTheDocument();
       expect(screen.getByText('Shell A (Selected)')).toBeInTheDocument();
+    });
+  });
+
+  it('falls back to the most recent logged location as origin when geolocation is unavailable', async () => {
+    const mockLogs = [{ id: 'log1', latitude: 15, longitude: 25 }] as never;
+    vi.mocked(fetchFuelLocations).mockResolvedValue(mockLogs);
+    vi.mocked(fetchUserStations).mockResolvedValue(mockStations);
+    mockGetCurrentPosition.mockResolvedValue(null);
+
+    render(<StationsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('station-table')).toHaveAttribute('data-origin', '15,25');
+    });
+  });
+
+  it('uses the resolved geolocation position as origin once available', async () => {
+    const mockLogs = [{ id: 'log1', latitude: 15, longitude: 25 }] as never;
+    vi.mocked(fetchFuelLocations).mockResolvedValue(mockLogs);
+    vi.mocked(fetchUserStations).mockResolvedValue(mockStations);
+    mockGetCurrentPosition.mockResolvedValue({ latitude: 50, longitude: 60 });
+
+    render(<StationsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('station-table')).toHaveAttribute('data-origin', '50,60');
     });
   });
 });

--- a/src/utils/locationService.ts
+++ b/src/utils/locationService.ts
@@ -46,6 +46,52 @@ export function isAccurateEnoughForStationMatch(locationAccuracy: number): boole
     return locationAccuracy <= GPS_ACCURACY_THRESHOLD_METERS;
 }
 
+const EARTH_RADIUS_KM = 6371;
+
+/**
+ * Great-circle distance between two coordinates, in kilometres.
+ */
+export function haversineDistanceKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
+    const toRad = (deg: number) => (deg * Math.PI) / 180;
+    const dLat = toRad(lat2 - lat1);
+    const dLon = toRad(lon2 - lon1);
+    const a =
+        Math.sin(dLat / 2) ** 2 +
+        Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+    return EARTH_RADIUS_KM * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+export interface Coordinates {
+    latitude: number;
+    longitude: number;
+}
+
+/**
+ * Resolves the browser's current position for rough proximity sorting.
+ * Never rejects: resolves null if geolocation is unsupported, denied, or errors.
+ */
+export function getCurrentPosition(): Promise<Coordinates | null> {
+    return new Promise((resolve) => {
+        if (!navigator.geolocation) {
+            resolve(null);
+            return;
+        }
+        navigator.geolocation.getCurrentPosition(
+            (position) => {
+                resolve({
+                    latitude: position.coords.latitude,
+                    longitude: position.coords.longitude,
+                });
+            },
+            (error) => {
+                console.warn(`Geolocation error (${error.code}): ${error.message}`);
+                resolve(null);
+            },
+            { enableHighAccuracy: true, timeout: 10000, maximumAge: 60000 }
+        );
+    });
+}
+
 /**
  * Find the nearest petrol station within a radius (default 150m) of the given coordinates.
  */


### PR DESCRIPTION
## Summary
- Closes #173 — adopts the "measure first, don't over-engineer" conclusion from the issue discussion (no virtualization/web workers/geohash queries; the per-user station list is small).
- Adds `haversineDistanceKm` and a standalone `getCurrentPosition()` helper to `src/utils/locationService.ts`.
- `StationsPage.tsx` resolves a fallback origin synchronously from the user's most recent logged location (`fetchFuelLocations()` already returns logs ordered by timestamp desc and filtered to ones with coordinates — `logs[0]` is the fallback, no extra Firestore calls) and asynchronously requests geolocation in the background to refine it. Geolocation always wins over the fallback regardless of resolution order (guarded with a ref).
- `StationTable.tsx` gets a `distance` sort key that's pre-computed once via `useMemo` (keyed on `stations`/`origin`, not recomputed inside the sort comparator), defaults to ascending when an `origin` is available, and only shows the "Distance" sort button in that case. Rows now also show the computed distance.
- Added `stationTable.distance` i18n key across all locales.

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `npm run build` (`tsc -b && vite build`) — passes
- [x] `npx vitest run` — all 204 tests pass, including new cases:
  - `StationTable.test.tsx`: no distance option without an origin, default nearest-first sort with an origin, direction toggle
  - `StationsPage.test.tsx`: fallback-to-last-logged-location when geolocation is unavailable, geolocation result overriding the fallback once resolved
- [x] i18n key-parity check (matches CI's `i18n-check.yml`) — passes locally
- [ ] Manual check in browser: `/stations` with location permission granted vs denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)