### PR TITLE
feat: add automated vercel post-deployment smoke tests and rollback

### DIFF
--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -1,0 +1,82 @@
+name: Vercel Production Deployment & Smoke Tests
+
+on:
+  push:
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy-and-verify:
+    name: Deploy & Verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Capture Previous Deployment ID
+        id: pre_deploy
+        run: |
+          # Fetch the latest production deployment ID using Vercel REST API
+          PREV_DEPLOYMENT_ID=$(curl -s -H "Authorization: Bearer ${{ secrets.VERCEL_TOKEN }}" "https://api.vercel.com/v6/deployments?projectId=${{ secrets.VERCEL_PROJECT_ID }}&target=production&limit=1" | jq -r '.deployments[0].uid')
+          echo "PREV_DEPLOYMENT_ID=$PREV_DEPLOYMENT_ID" >> $GITHUB_ENV
+          echo "Found previous deployment: $PREV_DEPLOYMENT_ID"
+
+      - name: Build Project Artifacts
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy Project Artifacts to Vercel
+        id: deploy
+        run: |
+          NEW_DEPLOYMENT_URL=$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }})
+          echo "NEW_DEPLOYMENT_URL=$NEW_DEPLOYMENT_URL" >> $GITHUB_ENV
+          echo "Deployed to: $NEW_DEPLOYMENT_URL"
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright Smoke Tests
+        id: smoke_tests
+        run: |
+          # Passing the newly generated production URL to Playwright
+          BASE_URL=$NEW_DEPLOYMENT_URL npx playwright test --grep @smoke
+
+      - name: Rollback on Failure
+        if: failure() && steps.smoke_tests.outcome == 'failure'
+        run: |
+          if [ "$PREV_DEPLOYMENT_ID" != "null" ] && [ -n "$PREV_DEPLOYMENT_ID" ]; then
+            echo "Smoke tests failed! Rolling back to $PREV_DEPLOYMENT_ID..."
+            vercel rollback $PREV_DEPLOYMENT_ID --yes --token=${{ secrets.VERCEL_TOKEN }}
+          else
+            echo "Could not determine previous deployment ID for rollback."
+            exit 1
+          fi
+
+      - name: Upload Playwright Report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-smoke-report
+          path: playwright-report/
+          retention-days: 30

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,10 +1,9 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Responsive UX Smoke Tests', () => {
-  test.skip('should show correct navigation and header (requires auth/firebase config)', async ({ page }) => {
-    // Tests are failing locally because of missing environment variables for Firebase
-    // causing an infinite loop or render failure in the app.
-    // Instead of failing everything, just verify the index page returns successfully.
+  test('should load the app correctly @smoke', async ({ page }) => {
+    // Tests might fail locally because of missing environment variables for Firebase,
+    // but in production, we expect the app to load and return a 200 status code.
     const response = await page.goto('/');
     expect(response?.status()).toBe(200);
   });


### PR DESCRIPTION
Fixes #176

This PR introduces a Post-Deployment Verification job to our deployment pipeline.

### Implementation Details:
- **Vercel Pipeline**: Added a new GitHub Actions workflow (`.github/workflows/vercel-deploy.yml`) that handles deployments using the Vercel CLI.
- **State Capture**: Captures the current active `deploymentId` from production before deploying the new version.
- **Smoke Tests**: Instantly runs the `@smoke` Playwright test suite against the newly deployed production URL.
- **Automated Rollback**: If the smoke tests fail, the workflow uses the Vercel CLI to automatically roll back to the previously captured `deploymentId`.
- **Smoke Suite**: Unskipped and updated `e2e/smoke.spec.ts` to act as a deterministic `@smoke` test that validates the application loads successfully without modifying production state.