### PR TITLE
Show UID on Admin Console access-denied screen

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -499,6 +499,7 @@
   },
   "admin": {
     "accessDenied": "You don't have access to this page.",
+    "yourUid": "Your UID: {{uid}}",
     "title": "Admin Console",
     "subtitle": "Send a test push notification via FCM.",
     "fields": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -499,6 +499,7 @@
   },
   "admin": {
     "accessDenied": "You don't have access to this page.",
+    "yourUid": "Your UID: {{uid}}",
     "title": "Admin Console",
     "subtitle": "Send a test push notification via FCM.",
     "fields": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -499,6 +499,7 @@
   },
   "admin": {
     "accessDenied": "You don't have access to this page.",
+    "yourUid": "Your UID: {{uid}}",
     "title": "Admin Console",
     "subtitle": "Send a test push notification via FCM.",
     "fields": {

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -499,6 +499,7 @@
   },
   "admin": {
     "accessDenied": "You don't have access to this page.",
+    "yourUid": "Your UID: {{uid}}",
     "title": "Admin Console",
     "subtitle": "Send a test push notification via FCM.",
     "fields": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -499,6 +499,7 @@
   },
   "admin": {
     "accessDenied": "You don't have access to this page.",
+    "yourUid": "Your UID: {{uid}}",
     "title": "Admin Console",
     "subtitle": "Send a test push notification via FCM.",
     "fields": {

--- a/src/i18n/locales/ga.json
+++ b/src/i18n/locales/ga.json
@@ -499,6 +499,7 @@
   },
   "admin": {
     "accessDenied": "You don't have access to this page.",
+    "yourUid": "Your UID: {{uid}}",
     "title": "Admin Console",
     "subtitle": "Send a test push notification via FCM.",
     "fields": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -499,6 +499,7 @@
   },
   "admin": {
     "accessDenied": "You don't have access to this page.",
+    "yourUid": "Your UID: {{uid}}",
     "title": "Admin Console",
     "subtitle": "Send a test push notification via FCM.",
     "fields": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -499,6 +499,7 @@
   },
   "admin": {
     "accessDenied": "You don't have access to this page.",
+    "yourUid": "Your UID: {{uid}}",
     "title": "Admin Console",
     "subtitle": "Send a test push notification via FCM.",
     "fields": {

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -499,6 +499,7 @@
   },
   "admin": {
     "accessDenied": "You don't have access to this page.",
+    "yourUid": "Your UID: {{uid}}",
     "title": "Admin Console",
     "subtitle": "Send a test push notification via FCM.",
     "fields": {

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -499,6 +499,7 @@
   },
   "admin": {
     "accessDenied": "You don't have access to this page.",
+    "yourUid": "Your UID: {{uid}}",
     "title": "Admin Console",
     "subtitle": "Send a test push notification via FCM.",
     "fields": {

--- a/src/pages/AdminConsolePage.tsx
+++ b/src/pages/AdminConsolePage.tsx
@@ -82,6 +82,11 @@ function AdminConsolePage(): JSX.Element {
       <div className="flex flex-col items-center justify-center min-h-[40vh] text-center space-y-3">
         <ShieldAlert className="w-10 h-10 text-red-500" />
         <p className="text-gray-600 dark:text-gray-400">{t('admin.accessDenied')}</p>
+        {user && (
+          <p className="text-xs text-gray-400 dark:text-gray-500 font-mono">
+            {t('admin.yourUid', { uid: user.uid })}
+          </p>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- The Admin Console (`/admin`, `AdminConsolePage.tsx`) gates access via the `checkDeveloperAccess` callable, which checks the signed-in UID against the server-side `DEV_NOTIFICATION_UIDS` allowlist param. There was previously no way to see your own UID from the denied screen if you weren't on that list.
- Adds the current user's UID to the access-denied message so it can be copied and added to the allowlist.
- Added `admin.yourUid` i18n key across all locales.

## Test plan
- [x] `npm run build` (`tsc -b && vite build`) — passes
- [x] `npm run lint` — 0 errors
- [x] `npx vitest run` — all 204 tests pass