### PR TITLE
Add Dashboard to mobile bottom navigation

### DIFF
--- a/src/components/BottomNav.test.tsx
+++ b/src/components/BottomNav.test.tsx
@@ -4,7 +4,7 @@ import { describe, it, expect } from 'vitest';
 import BottomNav from './BottomNav';
 
 describe('BottomNav', () => {
-  it('renders exactly 5 destinations to keep tap targets comfortable on mobile (#141)', () => {
+  it('renders all 6 navigation destinations including Dashboard (#183)', () => {
     render(
       <MemoryRouter>
         <BottomNav />
@@ -12,10 +12,10 @@ describe('BottomNav', () => {
     );
 
     const links = screen.getAllByRole('link');
-    expect(links).toHaveLength(5);
+    expect(links).toHaveLength(6);
   });
 
-  it('links to Log, History, Map, Stations, and Profile, but not Dashboard', () => {
+  it('links to Log, Dashboard, History, Map, Stations, and Profile', () => {
     render(
       <MemoryRouter>
         <BottomNav />
@@ -23,7 +23,6 @@ describe('BottomNav', () => {
     );
 
     const hrefs = screen.getAllByRole('link').map((link) => link.getAttribute('href'));
-    expect(hrefs).toEqual(['/', '/history', '/map', '/stations', '/profile']);
-    expect(hrefs).not.toContain('/dashboard');
+    expect(hrefs).toEqual(['/', '/dashboard', '/history', '/map', '/stations', '/profile']);
   });
 });

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,6 +1,6 @@
 import { JSX } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { History, Map as MapIcon, User, PlusCircle, Fuel } from 'lucide-react';
+import { History, Map as MapIcon, User, PlusCircle, Fuel, LayoutDashboard } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 /**
@@ -11,11 +11,9 @@ const BottomNav = (): JSX.Element => {
   const location = useLocation();
   const { t } = useTranslation();
 
-  // Dashboard is intentionally omitted from the mobile bottom nav to keep
-  // tap targets and labels comfortable at narrow widths (#141). It remains
-  // reachable on mobile via a link on the Log page, and via the desktop top nav.
   const navItems = [
     { path: '/', label: t('nav.log'), icon: PlusCircle },
+    { path: '/dashboard', label: t('nav.dashboard'), icon: LayoutDashboard },
     { path: '/history', label: t('nav.history'), icon: History },
     { path: '/map', label: t('nav.map'), icon: MapIcon },
     { path: '/stations', label: t('nav.stations'), icon: Fuel },

--- a/src/pages/QuickLogPage.tsx
+++ b/src/pages/QuickLogPage.tsx
@@ -7,7 +7,6 @@ import { useAuth } from '../context/AuthContext';
 import { fetchExchangeRate, COMMON_CURRENCIES } from '../utils/currencyApi';
 import { Vehicle, FuelLogData } from '../utils/types';
 import { Link } from 'react-router-dom';
-import { LayoutDashboard } from 'lucide-react';
 import { useRemoteConfig } from '../context/RemoteConfigContext';
 import { uploadReceipt } from '../firebase/storageService';
 import { getLastOdometerReading, getOrCreateStation, updateStationMetrics } from '../firebase/firestoreService';
@@ -412,13 +411,6 @@ function QuickLogPage(): JSX.Element {
         <div className="bg-white dark:bg-gray-800 shadow-lg rounded-xl p-6 sm:p-8 border border-gray-200 dark:border-gray-700">
             <div className="flex items-center justify-center gap-2 mb-6">
               <h2 className="text-2xl font-bold text-gray-800 dark:text-white text-center">{t('quickLog.title')}</h2>
-              <Link
-                to="/dashboard"
-                aria-label={t('nav.dashboard')}
-                className="sm:hidden p-2 -m-2 text-gray-400 dark:text-gray-500 hover:text-brand-primary transition-colors"
-              >
-                <LayoutDashboard size={20} />
-              </Link>
             </div>
 
             {isLoadingVehicles ? (


### PR DESCRIPTION
Adds Dashboard as the second item in the mobile bottom nav bar so it's
easily reachable on small screens.  Removes the now-redundant dashboard
icon link from the QuickLogPage header.

Closes #183

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RjxXwgTMnw5nTdh8rBepuy