### PR TITLE
fix: resolve 'L is not defined' in production

### DIFF
--- a/src/leaflet-setup.test.ts
+++ b/src/leaflet-setup.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+
+describe('Leaflet Setup', () => {
+  it('injects L into the global window object', async () => {
+    // Dynamically import the setup file to simulate the entrypoint behavior
+    await import('./leaflet-setup');
+
+    // Leaflet's L object should now be attached to the global window
+    expect(window.L).toBeDefined();
+    
+    // Verify it's actually the Leaflet object by checking for core methods
+    expect(window.L).toHaveProperty('map');
+    expect(window.L).toHaveProperty('marker');
+
+  });
+});

--- a/src/leaflet-setup.ts
+++ b/src/leaflet-setup.ts
@@ -1,0 +1,7 @@
+import L from 'leaflet';
+
+// Leaflet plugins like leaflet.heat and leaflet.markercluster expect L to be globally available on the window object.
+// In production bundles, tree-shaking and module scoping can hide L, causing "L is not defined" errors.
+// We explicitly attach it here before any map components are loaded.
+
+window.L = window.L || L;

--- a/src/leaflet-setup.ts
+++ b/src/leaflet-setup.ts
@@ -1,7 +1,15 @@
 import L from 'leaflet';
 
+declare global {
+  interface Window {
+    L: typeof L;
+  }
+}
+
 // Leaflet plugins like leaflet.heat and leaflet.markercluster expect L to be globally available on the window object.
 // In production bundles, tree-shaking and module scoping can hide L, causing "L is not defined" errors.
 // We explicitly attach it here before any map components are loaded.
 
-window.L = window.L || L;
+if (typeof window !== 'undefined') {
+  window.L = window.L || L;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,5 @@
 // src/main.tsx
+import './leaflet-setup';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import * as Sentry from '@sentry/react';


### PR DESCRIPTION
Resolves an issue where production builds crash because leaflet map plugins cannot find `window.L`. Fixes this by injecting Leaflet globally at the main app entrypoint before any map components mount.