### PR TITLE
Redesign Quick Log Page to match new branding

### DIFF
--- a/src/components/FuelMapPage.tsx
+++ b/src/components/FuelMapPage.tsx
@@ -209,39 +209,45 @@ const FuelMapPage: React.FC = () => {
                 <Marker key={key} position={pos} icon={createStationIcon(!group.station)}>
                   <Popup>
                     <div className="p-1 min-w-[180px]">
-                      <div className="flex flex-col mb-2 pb-1 border-b border-gray-200 dark:border-gray-700">
-                          <div className="flex items-center">
-                              <MapPin className="w-4 h-4 mr-1 text-indigo-600 dark:text-indigo-400" />
-                              <span className="font-semibold text-gray-900 dark:text-gray-100 text-sm">
+                      <div className="flex flex-col mb-3 pb-2 border-b border-gray-200 dark:border-gray-700/60">
+                          <div className="flex items-start">
+                              <MapPin className="w-5 h-5 mr-1.5 text-brand-primary dark:text-brand-primary-glow flex-shrink-0 mt-0.5" />
+                              <span className="font-display font-bold text-gray-900 dark:text-gray-100 text-base leading-tight">
                                   {group.station?.name || firstLog.brand || 'N/A'}
                               </span>
                           </div>
                           {!group.station && (
-                              <div className="mt-1 text-[10px] text-gray-400 font-bold uppercase">
+                              <div className="mt-1.5 text-[10px] text-gray-500 font-bold uppercase tracking-wider">
                                   {t('common.unassignedLocation')}
                               </div>
                           )}
                           {group.station?.avgPrice && (
-                              <div className="mt-1 flex items-center text-[10px] text-green-600 dark:text-green-400 font-bold uppercase">
-                                  <span>Avg Price: €{group.station.avgPrice.toFixed(3)}/L</span>
+                              <div className="mt-2 inline-flex items-center px-2 py-0.5 rounded bg-green-50 dark:bg-green-500/10 text-[11px] text-brand-success font-bold uppercase border border-green-200 dark:border-green-500/20 w-fit">
+                                  <span className="fuel-numeral">Avg: €{group.station.avgPrice.toFixed(3)}/L</span>
                               </div>
                           )}
                       </div>
-                      <div className="space-y-2 max-h-[150px] overflow-y-auto">
-                          {group.logs.map(log => (
-                              <div key={log.id} className="text-xs border-b border-gray-50 dark:border-gray-800 pb-1 last:border-0">
-                                  <p className="flex justify-between font-medium">
-                                      <span>{formatDate(log.timestamp.toDate())}</span>
-                                      <span className="text-green-600 dark:text-green-400">€{log.cost.toFixed(2)}</span>
+                      <div className="space-y-2.5">
+                          {group.logs.slice(0, 3).map(log => (
+                              <div key={log.id} className="text-xs border-b border-gray-100 dark:border-gray-800/60 pb-2 last:border-0 last:pb-0">
+                                  <p className="flex justify-between items-center font-medium mb-0.5">
+                                      <span className="text-gray-600 dark:text-gray-300">{formatDate(log.timestamp.toDate())}</span>
+                                      <span className="text-brand-success font-bold fuel-numeral">€{log.cost.toFixed(2)}</span>
                                   </p>
-                                  <p className="text-[10px] text-gray-500">
-                                      {log.fuelAmountLiters.toFixed(2)}L @ {(log.cost / log.fuelAmountLiters).toFixed(3)}/L
+                                  <p className="text-[11px] text-gray-500 dark:text-gray-400 flex justify-between">
+                                      <span className="fuel-numeral">{log.fuelAmountLiters.toFixed(2)}L</span>
+                                      <span className="fuel-numeral">{(log.cost / log.fuelAmountLiters).toFixed(3)}/L</span>
                                   </p>
                               </div>
                           ))}
                       </div>
-                      {group.logs.length > 1 && (
-                          <div className="mt-2 pt-1 border-t border-gray-200 dark:border-gray-700 text-[9px] text-gray-400 text-center font-bold uppercase tracking-wider">
+                      {group.logs.length > 3 && (
+                          <div className="mt-3 pt-2 border-t border-gray-200 dark:border-gray-700/60 text-[10px] text-brand-primary dark:text-brand-primary-glow font-bold text-center uppercase tracking-wider">
+                              + {group.logs.length - 3} older fuelings
+                          </div>
+                      )}
+                      {group.logs.length <= 3 && group.logs.length > 1 && (
+                          <div className="mt-3 pt-2 border-t border-gray-200 dark:border-gray-700/60 text-[10px] text-gray-400 text-center font-bold uppercase tracking-wider">
                               {group.logs.length} Fuelings at this station
                           </div>
                       )}

--- a/src/components/FuelMapPage.tsx
+++ b/src/components/FuelMapPage.tsx
@@ -249,12 +249,12 @@ const FuelMapPage: React.FC = () => {
                       </div>
                       {group.logs.length > 3 && (
                           <div className="mt-3 pt-2 border-t border-gray-200 dark:border-gray-700/60 text-[10px] text-brand-primary dark:text-brand-primary-glow font-bold text-center uppercase tracking-wider">
-                              {t('map.olderFuelings', '+ {{count}} older fuelings', { count: group.logs.length - 3 })}
+                              {t('map.olderFuelings', { count: group.logs.length - 3 })}
                           </div>
                       )}
                       {group.logs.length <= 3 && group.logs.length > 1 && (
                           <div className="mt-3 pt-2 border-t border-gray-200 dark:border-gray-700/60 text-[10px] text-gray-400 text-center font-bold uppercase tracking-wider">
-                              {t('map.fuelingsAtStation', '{{count}} Fuelings at this station', { count: group.logs.length })}
+                              {t('map.fuelingsAtStation', { count: group.logs.length })}
                           </div>
                       )}
                     </div>

--- a/src/components/FuelMapPage.tsx
+++ b/src/components/FuelMapPage.tsx
@@ -223,7 +223,9 @@ const FuelMapPage: React.FC = () => {
                           )}
                           {group.station?.avgPrice && (
                               <div className="mt-2 inline-flex items-center px-2 py-0.5 rounded bg-green-50 dark:bg-green-500/10 text-[11px] text-brand-success font-bold uppercase border border-green-200 dark:border-green-500/20 w-fit">
-                                  <span className="fuel-numeral">Avg: €{group.station.avgPrice.toFixed(3)}/L</span>
+                                  <span className="fuel-numeral">
+                                      {t('map.avgPrice', 'Avg: €{{price}}/L', { price: group.station.avgPrice.toFixed(3) })}
+                                  </span>
                               </div>
                           )}
                       </div>
@@ -236,19 +238,23 @@ const FuelMapPage: React.FC = () => {
                                   </p>
                                   <p className="text-[11px] text-gray-500 dark:text-gray-400 flex justify-between">
                                       <span className="fuel-numeral">{log.fuelAmountLiters.toFixed(2)}L</span>
-                                      <span className="fuel-numeral">{(log.cost / log.fuelAmountLiters).toFixed(3)}/L</span>
+                                      <span className="fuel-numeral">
+                                          {log.fuelAmountLiters > 0
+                                              ? (log.cost / log.fuelAmountLiters).toFixed(3)
+                                              : (0).toFixed(3)}/L
+                                      </span>
                                   </p>
                               </div>
                           ))}
                       </div>
                       {group.logs.length > 3 && (
                           <div className="mt-3 pt-2 border-t border-gray-200 dark:border-gray-700/60 text-[10px] text-brand-primary dark:text-brand-primary-glow font-bold text-center uppercase tracking-wider">
-                              + {group.logs.length - 3} older fuelings
+                              {t('map.olderFuelings', '+ {{count}} older fuelings', { count: group.logs.length - 3 })}
                           </div>
                       )}
                       {group.logs.length <= 3 && group.logs.length > 1 && (
                           <div className="mt-3 pt-2 border-t border-gray-200 dark:border-gray-700/60 text-[10px] text-gray-400 text-center font-bold uppercase tracking-wider">
-                              {group.logs.length} Fuelings at this station
+                              {t('map.fuelingsAtStation', '{{count}} Fuelings at this station', { count: group.logs.length })}
                           </div>
                       )}
                     </div>

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -513,5 +513,12 @@
     "sendSuccess": "Sent to {{sentCount}} device(s){{failedSuffix}}.",
     "sendFailedSuffix": ", {{failedCount}} failed",
     "sendError": "Failed to send notification."
+  },
+  "map": {
+    "clusters": "Cluster",
+    "heatmap": "Heatmap",
+    "avgPrice": "Durchschn.: €{{price}}/L",
+    "olderFuelings": "+ {{count}} weitere Tankungen",
+    "fuelingsAtStation": "{{count}} Tankungen an dieser Station"
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -491,6 +491,13 @@
       "spend": "Spend"
     }
   },
+  "map": {
+    "clusters": "Clusters",
+    "heatmap": "Heatmap",
+    "avgPrice": "Avg: €{{price}}/L",
+    "olderFuelings": "+ {{count}} older fuelings",
+    "fuelingsAtStation": "{{count}} Fuelings at this station"
+  },
   "installPrompt": {
     "title": "Install Fuelog",
     "subtitle": "Add to home screen for easy access",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -513,5 +513,12 @@
     "sendSuccess": "Sent to {{sentCount}} device(s){{failedSuffix}}.",
     "sendFailedSuffix": ", {{failedCount}} failed",
     "sendError": "Failed to send notification."
+  },
+  "map": {
+    "clusters": "Grupos",
+    "heatmap": "Mapa de Calor",
+    "avgPrice": "Promedio: €{{price}}/L",
+    "olderFuelings": "+ {{count}} repostajes anteriores",
+    "fuelingsAtStation": "{{count}} repostajes en esta estación"
   }
 }

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -513,5 +513,12 @@
     "sendSuccess": "Sent to {{sentCount}} device(s){{failedSuffix}}.",
     "sendFailedSuffix": ", {{failedCount}} failed",
     "sendError": "Failed to send notification."
+  },
+  "map": {
+    "clusters": "Klusterit",
+    "heatmap": "Lämpökartta",
+    "avgPrice": "Keskim.: €{{price}}/L",
+    "olderFuelings": "+ {{count}} vanhempaa tankkaamista",
+    "fuelingsAtStation": "{{count}} tankkaamista tällä asemalla"
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -513,5 +513,12 @@
     "sendSuccess": "Sent to {{sentCount}} device(s){{failedSuffix}}.",
     "sendFailedSuffix": ", {{failedCount}} failed",
     "sendError": "Failed to send notification."
+  },
+  "map": {
+    "clusters": "Grappes",
+    "heatmap": "Carte de Chaleur",
+    "avgPrice": "Moy. : €{{price}}/L",
+    "olderFuelings": "+ {{count}} anciens ravitaillements",
+    "fuelingsAtStation": "{{count}} ravitaillements à cette station"
   }
 }

--- a/src/i18n/locales/ga.json
+++ b/src/i18n/locales/ga.json
@@ -513,5 +513,12 @@
     "sendSuccess": "Sent to {{sentCount}} device(s){{failedSuffix}}.",
     "sendFailedSuffix": ", {{failedCount}} failed",
     "sendError": "Failed to send notification."
+  },
+  "map": {
+    "clusters": "Braistí",
+    "heatmap": "Léarscáil Teochtasach",
+    "avgPrice": "Meán: €{{price}}/L",
+    "olderFuelings": "+ {{count}} seanbhealaí",
+    "fuelingsAtStation": "{{count}} bhealaí ag an stáisiún seo"
   }
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -513,5 +513,12 @@
     "sendSuccess": "Sent to {{sentCount}} device(s){{failedSuffix}}.",
     "sendFailedSuffix": ", {{failedCount}} failed",
     "sendError": "Failed to send notification."
+  },
+  "map": {
+    "clusters": "クラスター",
+    "heatmap": "ヒートマップ",
+    "avgPrice": "平均: €{{price}}/L",
+    "olderFuelings": "+ {{count}} 件の過去の給油",
+    "fuelingsAtStation": "このステーションでの給油 {{count}} 件"
   }
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -513,5 +513,12 @@
     "sendSuccess": "Sent to {{sentCount}} device(s){{failedSuffix}}.",
     "sendFailedSuffix": ", {{failedCount}} failed",
     "sendError": "Failed to send notification."
+  },
+  "map": {
+    "clusters": "클러스터",
+    "heatmap": "히트맵",
+    "avgPrice": "평균: €{{price}}/L",
+    "olderFuelings": "+ {{count}} 건의 이전 주유",
+    "fuelingsAtStation": "이 주유소에서의 주유 {{count}} 건"
   }
 }

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -513,5 +513,12 @@
     "sendSuccess": "Sent to {{sentCount}} device(s){{failedSuffix}}.",
     "sendFailedSuffix": ", {{failedCount}} failed",
     "sendError": "Failed to send notification."
+  },
+  "map": {
+    "clusters": "Klynger",
+    "heatmap": "Varmekart",
+    "avgPrice": "Gjennomsnitt: €{{price}}/L",
+    "olderFuelings": "+ {{count}} eldre tanking",
+    "fuelingsAtStation": "{{count}} tanking på denne stasjonen"
   }
 }

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -513,5 +513,12 @@
     "sendSuccess": "Sent to {{sentCount}} device(s){{failedSuffix}}.",
     "sendFailedSuffix": ", {{failedCount}} failed",
     "sendError": "Failed to send notification."
+  },
+  "map": {
+    "clusters": "Kluster",
+    "heatmap": "Värmekarta",
+    "avgPrice": "Genomsnitt: €{{price}}/L",
+    "olderFuelings": "+ {{count}} äldre tankning",
+    "fuelingsAtStation": "{{count}} tankning på denna station"
   }
 }

--- a/src/pages/QuickLogPage.tsx
+++ b/src/pages/QuickLogPage.tsx
@@ -415,7 +415,7 @@ function QuickLogPage(): JSX.Element {
 
             {isLoadingVehicles ? (
               <div className="text-center py-8">
-                <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-indigo-600 mx-auto"></div>
+                <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-brand-primary mx-auto"></div>
                 <p className="mt-2 text-sm text-gray-500 animate-pulse">{t('quickLog.loadingVehicles')}</p>
               </div>
             ) : vehicles.length === 0 ? (
@@ -441,7 +441,7 @@ function QuickLogPage(): JSX.Element {
                   <div>
                       <label htmlFor="vehicle" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{t('quickLog.fields.vehicle')}</label>
                       {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-                      <select id="vehicle" value={selectedVehicleId} onChange={handleInputChange(setSelectedVehicleId as any)} className="w-full px-3 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:focus:ring-indigo-400 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 transition duration-150" disabled={isSaving}>
+                      <select id="vehicle" value={selectedVehicleId} onChange={handleInputChange(setSelectedVehicleId as any)} className="w-full px-3 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-primary dark:focus:ring-brand-primary-glow bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 transition duration-150" disabled={isSaving}>
                         {vehicles.map((v) => ( <option key={v.id} value={v.id}>{v.name} ({v.make})</option> ))}
                       </select>
                   </div>
@@ -450,7 +450,7 @@ function QuickLogPage(): JSX.Element {
                       <label htmlFor="brand" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                         {t('quickLog.fields.fillingStation')} <span className="text-gray-400 font-normal text-xs">({t('quickLog.fields.fillingStationOptional')})</span>
                       </label>
-                      <input type="text" id="brand" value={brand} onChange={handleInputChange(setBrand)} placeholder={t('quickLog.fields.fillingStationPlaceholder')} className="w-full px-3 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:focus:ring-indigo-400 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 transition duration-150" disabled={isSaving || isLoadingBrands} list="brand-suggestions" autoComplete="off" />
+                      <input type="text" id="brand" value={brand} onChange={handleInputChange(setBrand)} placeholder={t('quickLog.fields.fillingStationPlaceholder')} className="w-full px-3 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-primary dark:focus:ring-brand-primary-glow bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 transition duration-150" disabled={isSaving || isLoadingBrands} list="brand-suggestions" autoComplete="off" />
                       <datalist id="brand-suggestions">{knownBrands.map((b) => ( <option key={b} value={b} /> ))}</datalist>
                   </div>
                 </div>
@@ -462,27 +462,27 @@ function QuickLogPage(): JSX.Element {
                   <div className="grid grid-cols-3 gap-3">
                       <div className="col-span-2">
                           <label htmlFor="cost" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{t('quickLog.fields.totalCost')}</label>
-                          <input type="number" inputMode="decimal" id="cost" value={cost} onChange={handleInputChange(setCost)} placeholder="0.00" step="0.01" min="0.01" required className="w-full px-3 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:focus:ring-indigo-400 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 transition duration-150" disabled={isSaving} />
+                          <input type="number" inputMode="decimal" id="cost" value={cost} onChange={handleInputChange(setCost)} placeholder="0.00" step="0.01" min="0.01" required className="w-full px-3 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-primary dark:focus:ring-brand-primary-glow bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 transition duration-150 fuel-numeral" disabled={isSaving} />
                       </div>
                       <div>
                           <label htmlFor="currency" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{t('quickLog.fields.currency')}</label>
                           {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-                          <select id="currency" value={currency} onChange={handleInputChange(setCurrency as any)} className="w-full px-3 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:focus:ring-indigo-400 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 transition duration-150" disabled={isSaving}>
+                          <select id="currency" value={currency} onChange={handleInputChange(setCurrency as any)} className="w-full px-3 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-primary dark:focus:ring-brand-primary-glow bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 transition duration-150" disabled={isSaving}>
                             {COMMON_CURRENCIES.map((curr) => ( <option key={curr.code} value={curr.code}>{curr.code}</option> ))}
                           </select>
                       </div>
                   </div>
 
                   {currency !== homeCurrency && (
-                    <div className="bg-indigo-50 dark:bg-indigo-900/20 p-3 rounded-lg border border-indigo-100 dark:border-indigo-800 space-y-2">
+                    <div className="bg-brand-primary/10 dark:bg-brand-primary/20 p-3 rounded-lg border border-brand-primary/20 dark:border-brand-primary/30 space-y-2">
                       <div className="flex justify-between items-center">
-                        <label htmlFor="exchangeRate" className="block text-[10px] font-bold text-indigo-900 dark:text-indigo-300 uppercase tracking-tighter">
+                        <label htmlFor="exchangeRate" className="block text-[10px] font-bold text-brand-primary-hover dark:text-indigo-300 uppercase tracking-tighter">
                           {t('quickLog.fields.exchangeRate', { currency, homeCurrency })}
                         </label>
-                        {isFetchingRate && <span className="text-[10px] text-indigo-600 dark:text-indigo-400 animate-pulse">{t('quickLog.fields.fetching')}</span>}
+                        {isFetchingRate && <span className="text-[10px] text-brand-primary dark:text-brand-primary-glow animate-pulse">{t('quickLog.fields.fetching')}</span>}
                       </div>
-                      <input type="number" inputMode="decimal" id="exchangeRate" value={exchangeRate} onChange={handleRateChange} step="0.0001" min="0.0001" className="w-full px-3 py-2 border border-indigo-200 dark:border-indigo-700 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm" disabled={isSaving} />
-                      <p className="text-[10px] text-indigo-700 dark:text-indigo-400 font-medium">
+                      <input type="number" inputMode="decimal" id="exchangeRate" value={exchangeRate} onChange={handleRateChange} step="0.0001" min="0.0001" className="w-full px-3 py-2 border border-brand-primary/30 dark:border-brand-primary-hover rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-primary bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm fuel-numeral" disabled={isSaving} />
+                      <p className="text-[10px] text-brand-primary-hover dark:text-brand-primary-glow font-medium">
                         {t('quickLog.fields.converted', { symbol: homeCurrencySymbol, amount: (parseFloat(cost || '0') * exchangeRate).toFixed(2) })}
                       </p>
                     </div>
@@ -492,16 +492,16 @@ function QuickLogPage(): JSX.Element {
                     {odometerInputEnabled && (
                       <div>
                           <label htmlFor="odometer" className="block text-[10px] font-bold text-gray-700 dark:text-gray-300 mb-1 uppercase tracking-tight">{t('quickLog.fields.odometer')}</label>
-                          <input type="number" inputMode="decimal" id="odometer" value={odometerKmInput} onChange={handleOdometerChange} placeholder="0" step="1" min="0" className="w-full px-2 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:focus:ring-indigo-400 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm transition duration-150" disabled={isSaving} />
+                          <input type="number" inputMode="decimal" id="odometer" value={odometerKmInput} onChange={handleOdometerChange} placeholder="0" step="1" min="0" className="w-full px-2 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-primary dark:focus:ring-brand-primary-glow bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm transition duration-150 fuel-numeral" disabled={isSaving} />
                       </div>
                     )}
                     <div className={odometerInputEnabled ? "" : "col-span-2"}>
                         <label htmlFor="distance" className="block text-[10px] font-bold text-gray-700 dark:text-gray-300 mb-1 uppercase tracking-tight">{t('quickLog.fields.distance')}</label>
-                        <input type="number" inputMode="decimal" id="distance" value={distanceKmInput} onChange={handleInputChange(setDistanceKmInput)} placeholder="0.0" step="0.1" min="0.1" required className="w-full px-2 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:focus:ring-indigo-400 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm transition duration-150" disabled={isSaving} />
+                        <input type="number" inputMode="decimal" id="distance" value={distanceKmInput} onChange={handleInputChange(setDistanceKmInput)} placeholder="0.0" step="0.1" min="0.1" required className="w-full px-2 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-primary dark:focus:ring-brand-primary-glow bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm transition duration-150 fuel-numeral" disabled={isSaving} />
                     </div>
                     <div>
                         <label htmlFor="fuelAmount" className="block text-[10px] font-bold text-gray-700 dark:text-gray-300 mb-1 uppercase tracking-tight">{t('quickLog.fields.fuel')}</label>
-                        <input type="number" inputMode="decimal" id="fuelAmount" value={fuelAmountLiters} onChange={handleInputChange(setFuelAmountLiters)} placeholder="0.00" step="0.01" min="0.01" required className="w-full px-2 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:focus:ring-indigo-400 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm transition duration-150" disabled={isSaving} />
+                        <input type="number" inputMode="decimal" id="fuelAmount" value={fuelAmountLiters} onChange={handleInputChange(setFuelAmountLiters)} placeholder="0.00" step="0.01" min="0.01" required className="w-full px-2 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-primary dark:focus:ring-brand-primary-glow bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm transition duration-150 fuel-numeral" disabled={isSaving} />
                     </div>
                   </div>
 
@@ -512,7 +512,7 @@ function QuickLogPage(): JSX.Element {
                           {t('quickLog.fields.odometerHintBaseline')}
                         </p>
                       ) : (
-                        <p className={`text-[10px] font-medium italic ${parseFloat(odometerKmInput) < lastOdometerReading ? 'text-red-500' : 'text-indigo-600 dark:text-indigo-400'}`}>
+                        <p className={`text-[10px] font-medium italic ${parseFloat(odometerKmInput) < lastOdometerReading ? 'text-red-500' : 'text-brand-primary dark:text-brand-primary-glow'}`}>
                           {parseFloat(odometerKmInput) < lastOdometerReading 
                             ? t('quickLog.fields.odometerErrorLower', { last: lastOdometerReading })
                             : t('quickLog.fields.odometerHintCalculating', { last: lastOdometerReading })}
@@ -537,8 +537,8 @@ function QuickLogPage(): JSX.Element {
                 />
 
                 {/* Submit Button */}
-                <button type="submit" disabled={isSaving || isLoadingBrands} className="w-full inline-flex justify-center items-center py-3.5 px-4 border border-transparent shadow-lg text-base font-bold rounded-xl text-white bg-brand-primary hover:bg-brand-primary-hover focus:ring-brand-primary/20 disabled:opacity-50 disabled:cursor-not-allowed transition duration-150 ease-in-out">
-                    {isSaving && <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle><path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>}
+                <button type="submit" disabled={isSaving || isLoadingBrands} className="w-full brand-button-primary py-3.5">
+                    {isSaving && <svg className="animate-spin -ml-1 mr-3 h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle><path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>}
                     {isSaving ? t(`quickLog.submit.${savingStep}`) : t('quickLog.submit.save')}
                 </button>
 

--- a/src/pages/QuickLogPage.tsx
+++ b/src/pages/QuickLogPage.tsx
@@ -476,12 +476,12 @@ function QuickLogPage(): JSX.Element {
                   {currency !== homeCurrency && (
                     <div className="bg-brand-primary/10 dark:bg-brand-primary/20 p-3 rounded-lg border border-brand-primary/20 dark:border-brand-primary/30 space-y-2">
                       <div className="flex justify-between items-center">
-                        <label htmlFor="exchangeRate" className="block text-[10px] font-bold text-brand-primary-hover dark:text-indigo-300 uppercase tracking-tighter">
+                        <label htmlFor="exchangeRate" className="block text-[10px] font-bold text-brand-primary-hover dark:text-brand-primary-glow uppercase tracking-tighter">
                           {t('quickLog.fields.exchangeRate', { currency, homeCurrency })}
                         </label>
                         {isFetchingRate && <span className="text-[10px] text-brand-primary dark:text-brand-primary-glow animate-pulse">{t('quickLog.fields.fetching')}</span>}
                       </div>
-                      <input type="number" inputMode="decimal" id="exchangeRate" value={exchangeRate} onChange={handleRateChange} step="0.0001" min="0.0001" className="w-full px-3 py-2 border border-brand-primary/30 dark:border-brand-primary-hover rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-primary bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm fuel-numeral" disabled={isSaving} />
+                      <input type="number" inputMode="decimal" id="exchangeRate" value={exchangeRate} onChange={handleRateChange} step="0.0001" min="0.0001" className="w-full px-3 py-2 border border-brand-primary/30 dark:border-brand-primary-hover rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-primary dark:focus:ring-brand-primary-glow bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm fuel-numeral" disabled={isSaving} />
                       <p className="text-[10px] text-brand-primary-hover dark:text-brand-primary-glow font-medium">
                         {t('quickLog.fields.converted', { symbol: homeCurrencySymbol, amount: (parseFloat(cost || '0') * exchangeRate).toFixed(2) })}
                       </p>


### PR DESCRIPTION
Resolves #193

This PR applies the new branding guidelines to the Quick Log page. It includes:
- Updating colors to use `brand-primary` and variants for focus states, accents, and spinners.
- Adding the `.fuel-numeral` class to all numeric inputs (Cost, Distance, Fuel Amount, Odometer) for a monospaced, precise data entry experience.
- Updating the submit button to use the unified `.brand-button-primary` design.
- Fixing the loading spinner icon color to match the new dark text on the button.