### PR TITLE
Migrate receipt analysis to Gemini Interactions API

### DIFF
--- a/api/extract-receipt.ts
+++ b/api/extract-receipt.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage, ServerResponse } from 'http';
 import { getAdminApp } from '../src/mcp/firebase-admin.js';
 import { getAuth } from 'firebase-admin/auth';
-import { GoogleGenerativeAI } from '@google/generative-ai';
+import { GoogleGenAI } from '@google/genai';
 import { log } from './_logger.js';
 
 function handleCors(req: IncomingMessage, res: ServerResponse): boolean {
@@ -79,12 +79,7 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
   const thinkingBudget = parseInt(process.env.GEMINI_THINKING_BUDGET ?? '512', 10);
 
   try {
-    const genAI = new GoogleGenerativeAI(apiKey);
-    const model = genAI.getGenerativeModel({
-      model: geminiModel,
-      // thinkingConfig is not yet in SDK types (v0.24.1) but is supported at runtime
-      ...({ generationConfig: { thinkingConfig: { thinkingBudget } } } as object),
-    });
+    const client = new GoogleGenAI({ apiKey });
 
     const prompt = `
       Analyze this receipt image and extract the following information for a fuel purchase:
@@ -97,12 +92,18 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
       Do not use markdown formatting like \`\`\`json.
     `;
 
-    const result = await model.generateContent([
-      prompt,
-      { inlineData: { data: base64Data, mimeType } },
-    ]);
+    const interaction = await client.interactions.create({
+      model: geminiModel,
+      config: {
+        thinkingConfig: { thinkingBudget },
+      },
+      input: [
+        { type: 'text', text: prompt },
+        { type: 'image', data: base64Data, mime_type: mimeType },
+      ],
+    });
 
-    const text = result.response.text();
+    const text = interaction.output_text ?? '';
     let jsonText = text.trim();
     const jsonMatch = jsonText.match(/```(?:json)?\n([\s\S]*?)\n```/s);
     if (jsonMatch?.[1]) jsonText = jsonMatch[1];

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "fuelog",
       "version": "2.3.0",
       "dependencies": {
-        "@google/generative-ai": "^0.24.1",
+        "@google/genai": "^2.9.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@sentry/node": "^10.42.0",
         "@sentry/react": "^10.42.0",
@@ -3324,13 +3324,28 @@
         "node": ">=14"
       }
     },
-    "node_modules/@google/generative-ai": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
-      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+    "node_modules/@google/genai": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.9.0.tgz",
+      "integrity": "sha512-3DRdSJ0LaKFig3FNGeRDn9BQxtjZm2qr0hNH2d771LKcG0HvUYddlN0LPdSp8XU7Ekb04i9q3+tt64uYqavUdw==",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -6005,6 +6020,12 @@
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "license": "MIT"
     },
     "node_modules/@types/send": {
@@ -13632,6 +13653,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -14795,7 +14829,6 @@
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 4"
       }
@@ -17904,6 +17937,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@google/generative-ai": "^0.24.1",
+    "@google/genai": "^2.9.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@sentry/node": "^10.42.0",
     "@sentry/react": "^10.42.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -169,7 +169,7 @@ export default defineConfig({
             if (id.includes('jspdf') || id.includes('jspdf-autotable')) return 'vendor-pdf';
             if (id.includes('html2canvas')) return 'vendor-canvas';
             if (id.includes('dompurify')) return 'vendor-sanitize';
-            if (id.includes('@google/generative-ai')) return 'vendor-ai';
+            if (id.includes('@google/genai')) return 'vendor-ai';
             if (id.includes('leaflet.markercluster') || id.includes('react-leaflet-markercluster') || id.includes('leaflet.heat')) {
               return null;
             }


### PR DESCRIPTION
## Summary

- Replaced deprecated `@google/generative-ai` SDK with `@google/genai` (Interactions API)
- Migrated `api/extract-receipt.ts` from `generateContent` to `client.interactions.create()`
- Removed `thinkingConfig` type cast hack — now first-class in the new SDK
- Updated Vite chunk splitting config for the new package name

## Why

Google has made the [Interactions API the default for Gemini](https://blog.google/innovation-and-ai/technology/developers-tools/interactions-api-general-availability/). The legacy SDK is deprecated and frontier features will only land on the new API.

## Test plan

- [x] `npm run build` passes
- [x] All 206 tests pass
- [ ] Manual test: upload a receipt and verify cost/liters/brand extraction works

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rn4Ge7mAVZ8LcWTneyMnX7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rn4Ge7mAVZ8LcWTneyMnX7)_