### PR TITLE
Add cursor-based pagination to HistoryPage

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -128,7 +128,8 @@
     "metrics": {
       "totalSpent": "Gesamtausgaben (Gefiltert)",
       "avgMpg": "Ø MPG (UK) (Gefiltert)",
-      "avgCostPerLitre": "Ø Kosten / Liter (Gefiltert)"
+      "avgCostPerLitre": "Ø Kosten / Liter (Gefiltert)",
+      "partialDisclaimer": "Based on loaded entries only"
     },
     "charts": {
       "mpgOverTime": "MPG (UK) im Zeitverlauf (Gefiltert)",
@@ -143,7 +144,8 @@
     "logDetails": {
       "heading": "Eintragsdetails",
       "filteredCount": "({{filtered}} von {{total}} angezeigt)",
-      "totalCount": "({{count}} gesamt)"
+      "totalCount": "({{count}} gesamt)",
+      "loadedCount": "({{count}} loaded)"
     },
     "copyStatus": {
       "idle": "Tabellendaten kopieren",
@@ -222,6 +224,10 @@
       "totalLitres": "Gesamtliter",
       "totalDistance": "Gesamtstrecke",
       "logCount": "Tankstopps"
+    },
+    "pagination": {
+      "loadMore": "Load More",
+      "loading": "Loading..."
     }
   },
   "imageUpload": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -128,7 +128,8 @@
     "metrics": {
       "totalSpent": "Total Spent (Filtered)",
       "avgMpg": "Average MPG (UK) (Filtered)",
-      "avgCostPerLitre": "Average Cost / Litre (Filtered)"
+      "avgCostPerLitre": "Average Cost / Litre (Filtered)",
+      "partialDisclaimer": "Based on loaded entries only"
     },
     "charts": {
       "mpgOverTime": "MPG (UK) Over Time (Filtered)",
@@ -143,7 +144,12 @@
     "logDetails": {
       "heading": "Log Details",
       "filteredCount": "({{filtered}} of {{total}} shown)",
-      "totalCount": "({{count}} total)"
+      "totalCount": "({{count}} total)",
+      "loadedCount": "({{count}} loaded)"
+    },
+    "pagination": {
+      "loadMore": "Load More",
+      "loading": "Loading..."
     },
     "copyStatus": {
       "idle": "Copy Table Data",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -128,7 +128,8 @@
     "metrics": {
       "totalSpent": "Total Gastado (Filtrado)",
       "avgMpg": "MPG Promedio (UK) (Filtrado)",
-      "avgCostPerLitre": "Coste Promedio / Litro (Filtrado)"
+      "avgCostPerLitre": "Coste Promedio / Litro (Filtrado)",
+      "partialDisclaimer": "Based on loaded entries only"
     },
     "charts": {
       "mpgOverTime": "MPG (UK) a lo Largo del Tiempo (Filtrado)",
@@ -143,7 +144,8 @@
     "logDetails": {
       "heading": "Detalles del Registro",
       "filteredCount": "({{filtered}} de {{total}} mostrados)",
-      "totalCount": "({{count}} total)"
+      "totalCount": "({{count}} total)",
+      "loadedCount": "({{count}} loaded)"
     },
     "copyStatus": {
       "idle": "Copiar Datos de Tabla",
@@ -222,6 +224,10 @@
       "totalLitres": "Total de litros",
       "totalDistance": "Distancia total",
       "logCount": "Repostajes"
+    },
+    "pagination": {
+      "loadMore": "Load More",
+      "loading": "Loading..."
     }
   },
   "imageUpload": {

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -128,7 +128,8 @@
     "metrics": {
       "totalSpent": "Yhteensä käytetty (suodatettu)",
       "avgMpg": "Keskimääräinen MPG (UK) (suodatettu)",
-      "avgCostPerLitre": "Keskimääräinen hinta / litra (suodatettu)"
+      "avgCostPerLitre": "Keskimääräinen hinta / litra (suodatettu)",
+      "partialDisclaimer": "Based on loaded entries only"
     },
     "charts": {
       "mpgOverTime": "MPG (UK) ajan myötä (suodatettu)",
@@ -143,7 +144,8 @@
     "logDetails": {
       "heading": "Login tiedot",
       "filteredCount": "({{filtered}} / {{total}} näytetään)",
-      "totalCount": "({{count}} yhteensä)"
+      "totalCount": "({{count}} yhteensä)",
+      "loadedCount": "({{count}} loaded)"
     },
     "copyStatus": {
       "idle": "Kopioi taulukon tiedot",
@@ -222,6 +224,10 @@
       "totalLitres": "Litroja yhteensä",
       "totalDistance": "Kokonaismatka",
       "logCount": "Tankkaukset"
+    },
+    "pagination": {
+      "loadMore": "Load More",
+      "loading": "Loading..."
     }
   },
   "imageUpload": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -128,7 +128,8 @@
     "metrics": {
       "totalSpent": "Total Dépensé (Filtré)",
       "avgMpg": "MPG Moyen (UK) (Filtré)",
-      "avgCostPerLitre": "Coût Moyen / Litre (Filtré)"
+      "avgCostPerLitre": "Coût Moyen / Litre (Filtré)",
+      "partialDisclaimer": "Based on loaded entries only"
     },
     "charts": {
       "mpgOverTime": "MPG (UK) dans le Temps (Filtré)",
@@ -143,7 +144,8 @@
     "logDetails": {
       "heading": "Détails des Saisies",
       "filteredCount": "({{filtered}} sur {{total}} affichés)",
-      "totalCount": "({{count}} total)"
+      "totalCount": "({{count}} total)",
+      "loadedCount": "({{count}} loaded)"
     },
     "copyStatus": {
       "idle": "Copier les Données",
@@ -222,6 +224,10 @@
       "totalLitres": "Total de litres",
       "totalDistance": "Distance totale",
       "logCount": "Pleins"
+    },
+    "pagination": {
+      "loadMore": "Load More",
+      "loading": "Loading..."
     }
   },
   "imageUpload": {

--- a/src/i18n/locales/ga.json
+++ b/src/i18n/locales/ga.json
@@ -128,7 +128,8 @@
     "metrics": {
       "totalSpent": "Caiteachas Iomlán (Scagtha)",
       "avgMpg": "Meán MPG (UK) (Scagtha)",
-      "avgCostPerLitre": "Meán Costas / Lítear (Scagtha)"
+      "avgCostPerLitre": "Meán Costas / Lítear (Scagtha)",
+      "partialDisclaimer": "Based on loaded entries only"
     },
     "charts": {
       "mpgOverTime": "MPG (UK) Thar Am (Scagtha)",
@@ -143,7 +144,8 @@
     "logDetails": {
       "heading": "Sonraí Iontrálacha",
       "filteredCount": "({{filtered}} as {{total}} á thaispeáint)",
-      "totalCount": "({{count}} iomlán)"
+      "totalCount": "({{count}} iomlán)",
+      "loadedCount": "({{count}} loaded)"
     },
     "copyStatus": {
       "idle": "Cóipeáil Sonraí Tábla",
@@ -222,6 +224,10 @@
       "totalLitres": "Líotair Iomlán",
       "totalDistance": "Fad Iomlán",
       "logCount": "Líonadh"
+    },
+    "pagination": {
+      "loadMore": "Load More",
+      "loading": "Loading..."
     }
   },
   "imageUpload": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -128,7 +128,8 @@
     "metrics": {
       "totalSpent": "合計支出（フィルター済み）",
       "avgMpg": "平均MPG (UK)（フィルター済み）",
-      "avgCostPerLitre": "平均コスト／リットル（フィルター済み）"
+      "avgCostPerLitre": "平均コスト／リットル（フィルター済み）",
+      "partialDisclaimer": "Based on loaded entries only"
     },
     "charts": {
       "mpgOverTime": "MPG (UK) の推移（フィルター済み）",
@@ -143,7 +144,8 @@
     "logDetails": {
       "heading": "記録詳細",
       "filteredCount": "({{total}}件中{{filtered}}件表示)",
-      "totalCount": "(合計{{count}}件)"
+      "totalCount": "(合計{{count}}件)",
+      "loadedCount": "({{count}} loaded)"
     },
     "copyStatus": {
       "idle": "テーブルデータをコピー",
@@ -222,6 +224,10 @@
       "totalLitres": "合計リットル",
       "totalDistance": "合計走行距離",
       "logCount": "給油回数"
+    },
+    "pagination": {
+      "loadMore": "Load More",
+      "loading": "Loading..."
     }
   },
   "imageUpload": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -128,7 +128,8 @@
     "metrics": {
       "totalSpent": "총 지출 (필터됨)",
       "avgMpg": "평균 MPG (UK) (필터됨)",
-      "avgCostPerLitre": "평균 비용 / 리터 (필터됨)"
+      "avgCostPerLitre": "평균 비용 / 리터 (필터됨)",
+      "partialDisclaimer": "Based on loaded entries only"
     },
     "charts": {
       "mpgOverTime": "MPG (UK) 시간 추이 (필터됨)",
@@ -143,7 +144,8 @@
     "logDetails": {
       "heading": "기록 세부정보",
       "filteredCount": "({{total}}개 중 {{filtered}}개 표시)",
-      "totalCount": "(총 {{count}}개)"
+      "totalCount": "(총 {{count}}개)",
+      "loadedCount": "({{count}} loaded)"
     },
     "copyStatus": {
       "idle": "테이블 데이터 복사",
@@ -222,6 +224,10 @@
       "totalLitres": "총 리터",
       "totalDistance": "총 거리",
       "logCount": "주유 횟수"
+    },
+    "pagination": {
+      "loadMore": "Load More",
+      "loading": "Loading..."
     }
   },
   "imageUpload": {

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -128,7 +128,8 @@
     "metrics": {
       "totalSpent": "Totalt brukt (filtrert)",
       "avgMpg": "Gjennomsnittlig MPG (UK) (filtrert)",
-      "avgCostPerLitre": "Gjennomsnittlig kostnad / liter (filtrert)"
+      "avgCostPerLitre": "Gjennomsnittlig kostnad / liter (filtrert)",
+      "partialDisclaimer": "Based on loaded entries only"
     },
     "charts": {
       "mpgOverTime": "MPG (UK) over tid (filtrert)",
@@ -143,7 +144,8 @@
     "logDetails": {
       "heading": "Loggdetaljer",
       "filteredCount": "({{filtered}} av {{total}} vises)",
-      "totalCount": "({{count}} totalt)"
+      "totalCount": "({{count}} totalt)",
+      "loadedCount": "({{count}} loaded)"
     },
     "copyStatus": {
       "idle": "Kopier tabelldata",
@@ -222,6 +224,10 @@
       "totalLitres": "Totalt liter",
       "totalDistance": "Total distanse",
       "logCount": "Tankstopp"
+    },
+    "pagination": {
+      "loadMore": "Load More",
+      "loading": "Loading..."
     }
   },
   "imageUpload": {

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -128,7 +128,8 @@
     "metrics": {
       "totalSpent": "Totalt spenderat (filtrerat)",
       "avgMpg": "Genomsnittlig MPG (UK) (filtrerat)",
-      "avgCostPerLitre": "Genomsnittlig kostnad / liter (filtrerat)"
+      "avgCostPerLitre": "Genomsnittlig kostnad / liter (filtrerat)",
+      "partialDisclaimer": "Based on loaded entries only"
     },
     "charts": {
       "mpgOverTime": "MPG (UK) över tid (filtrerat)",
@@ -143,7 +144,8 @@
     "logDetails": {
       "heading": "Loggdetaljer",
       "filteredCount": "({{filtered}} av {{total}} visas)",
-      "totalCount": "({{count}} totalt)"
+      "totalCount": "({{count}} totalt)",
+      "loadedCount": "({{count}} loaded)"
     },
     "copyStatus": {
       "idle": "Kopiera tabelldata",
@@ -222,6 +224,10 @@
       "totalLitres": "Totalt liter",
       "totalDistance": "Total distans",
       "logCount": "Tankningar"
+    },
+    "pagination": {
+      "loadMore": "Load More",
+      "loading": "Loading..."
     }
   },
   "imageUpload": {

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -112,7 +112,7 @@ function HistoryPage(): JSX.Element {
     // --- Paginated Fetch Function ---
     const fetchLogs = useCallback(async (loadMore = false) => {
         if (!user) return;
-        loadMore ? setIsLoadingMore(true) : setIsLoading(true);
+        if (loadMore) { setIsLoadingMore(true); } else { setIsLoading(true); }
         setError(null);
 
         try {

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -1,10 +1,11 @@
 // src/pages/HistoryPage.tsx
-import { JSX, useState, useEffect, useMemo, ChangeEvent, FormEvent } from 'react';
+import { JSX, useState, useEffect, useMemo, useCallback, ChangeEvent, FormEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 // Import Firestore functions for reading, updating, and deleting documents
 import {
-    collection, query, where, orderBy, onSnapshot, getDocs,
-    doc, deleteDoc, updateDoc, DocumentData, QuerySnapshot
+    collection, query, where, orderBy, getDocs, limit, startAfter,
+    doc, deleteDoc, updateDoc, DocumentData, QueryDocumentSnapshot,
+    QueryConstraint, Timestamp
 } from "firebase/firestore";
 // Import Firebase config and Auth hook
 import { db } from '../firebase/config';
@@ -68,6 +69,12 @@ function HistoryPage(): JSX.Element {
     const [filterBrand, setFilterBrand] = useState<string>('');       // Selected brand or '' for all
     const [uniqueBrands, setUniqueBrands] = useState<string[]>([]);    // List of unique brands for the filter dropdown
 
+    // --- Pagination State ---
+    const PAGE_SIZE = 25;
+    const [lastDoc, setLastDoc] = useState<QueryDocumentSnapshot<DocumentData> | null>(null);
+    const [hasMore, setHasMore] = useState<boolean>(true);
+    const [isLoadingMore, setIsLoadingMore] = useState<boolean>(false);
+
     // --- Fetch Vehicles Effect ---
     useEffect(() => {
         if (!user) { setVehicles([]); return; }
@@ -102,46 +109,89 @@ function HistoryPage(): JSX.Element {
         // but initial load should be correct.
     }, []);
 
-    // --- Firestore Listener Effect ---
-    // Fetches all logs for the user and listens for real-time updates.
-    // Also extracts unique brands for the filter dropdown.
-    useEffect(() => {
-        if (!user) { setIsLoading(false); setLogs([]); setUniqueBrands([]); return; }; // Reset if user logs out
-        setIsLoading(true); setError(null);
+    // --- Paginated Fetch Function ---
+    const fetchLogs = useCallback(async (loadMore = false) => {
+        if (!user) return;
+        loadMore ? setIsLoadingMore(true) : setIsLoading(true);
+        setError(null);
 
-        const q = query(collection(db, "fuelLogs"), where("userId", "==", user.uid), orderBy("timestamp", "desc"));
+        try {
+            const constraints: QueryConstraint[] = [
+                where("userId", "==", user.uid),
+                orderBy("timestamp", "desc"),
+            ];
 
-        const unsubscribe = onSnapshot(q, (querySnapshot: QuerySnapshot<DocumentData>) => {
-            const logsData: Log[] = [];
-            const brands = new Set<string>(); // Use Set for efficient uniqueness check
+            if (filterVehicleId) {
+                constraints.push(where("vehicleId", "==", filterVehicleId));
+            }
+            if (filterStartDate) {
+                const start = new Date(filterStartDate);
+                start.setHours(0, 0, 0, 0);
+                constraints.push(where("timestamp", ">=", Timestamp.fromDate(start)));
+            }
+            if (filterEndDate) {
+                const end = new Date(filterEndDate);
+                end.setHours(23, 59, 59, 999);
+                constraints.push(where("timestamp", "<=", Timestamp.fromDate(end)));
+            }
 
-            querySnapshot.forEach((doc) => {
-                const data = doc.data() as FuelLogData;
-                logsData.push({ id: doc.id, ...data });
-                // Add brand to set if it exists and is not 'Unknown'
+            if (loadMore && lastDoc) {
+                constraints.push(startAfter(lastDoc));
+            }
+            constraints.push(limit(PAGE_SIZE));
+
+            const q = query(collection(db, "fuelLogs"), ...constraints);
+            const snapshot = await getDocs(q);
+
+            const newLogs: Log[] = [];
+            const brands = new Set<string>();
+            snapshot.forEach((docSnap) => {
+                const data = docSnap.data() as FuelLogData;
+                newLogs.push({ id: docSnap.id, ...data });
                 if (data.brand && data.brand.toLowerCase() !== 'unknown') {
                     brands.add(data.brand.trim());
                 }
             });
 
-            setLogs(logsData); // Update the main logs state
-            // Update the unique brands list for the filter dropdown
-            setUniqueBrands(Array.from(brands).sort((a, b) => a.localeCompare(b)));
-            setIsLoading(false); // Loading complete
-        }, (err) => {
-            // Handle Firestore errors
+            if (loadMore) {
+                setLogs(prev => [...prev, ...newLogs]);
+            } else {
+                setLogs(newLogs);
+            }
+
+            setLastDoc(snapshot.docs[snapshot.docs.length - 1] || null);
+            setHasMore(snapshot.docs.length === PAGE_SIZE);
+            setUniqueBrands(prev => {
+                const merged = new Set([...prev, ...brands]);
+                return Array.from(merged).sort((a, b) => a.localeCompare(b));
+            });
+        } catch (err) {
             console.error("Error fetching fuel logs:", err);
             setError(
                 !navigator.onLine
                     ? t('history.offlineError', { defaultValue: 'You are offline. Please check your connection and try again.' })
                     : t('history.loadError', { defaultValue: 'Failed to load fuel history. Please check your connection and try again.' })
             );
+        } finally {
             setIsLoading(false);
-        });
+            setIsLoadingMore(false);
+        }
+    }, [user, filterVehicleId, filterStartDate, filterEndDate, lastDoc, t]);
 
-        // Cleanup listener on unmount or user change
-        return () => unsubscribe();
-    }, [user, t]); // Dependency array ensures effect runs when user changes
+    // Reset and re-fetch when user or filters change
+    const [fetchKey, setFetchKey] = useState(0);
+    useEffect(() => {
+        setLastDoc(null);
+        setHasMore(true);
+        setLogs([]);
+        setUniqueBrands([]);
+        setFetchKey(k => k + 1);
+    }, [user, filterVehicleId, filterStartDate, filterEndDate]);
+
+    useEffect(() => {
+        if (user) fetchLogs(false);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [fetchKey]);
 
     // --- Fetch Stations Effect ---
     useEffect(() => {
@@ -163,38 +213,9 @@ function HistoryPage(): JSX.Element {
     // Creates a memoized array of logs based on the current filter state.
     // This avoids re-filtering on every render unless logs or filters change.
     const filteredLogs = useMemo(() => {
-        let tempLogs = [...logs]; // Start with a copy of all fetched logs
-
-        // Filter by Vehicle
-        if (filterVehicleId) {
-            tempLogs = tempLogs.filter(log => log.vehicleId === filterVehicleId);
-        }
-
-        // Filter by Start Date
-        if (filterStartDate) {
-            try {
-                const startDate = new Date(filterStartDate);
-                startDate.setHours(0, 0, 0, 0); // Compare from the beginning of the day
-                tempLogs = tempLogs.filter(log => log.timestamp.toDate() >= startDate);
-            } catch (e) { console.error("Error parsing start date for filtering:", e); }
-        }
-
-        // Filter by End Date
-        if (filterEndDate) {
-            try {
-                const endDate = new Date(filterEndDate);
-                endDate.setHours(23, 59, 59, 999); // Compare until the end of the day
-                tempLogs = tempLogs.filter(log => log.timestamp.toDate() <= endDate);
-            } catch (e) { console.error("Error parsing end date for filtering:", e); }
-        }
-
-        // Filter by Brand
-        if (filterBrand) { // Only filter if a brand is selected (not '')
-            tempLogs = tempLogs.filter(log => log.brand === filterBrand);
-        }
-
-        return tempLogs; // Return the filtered array
-    }, [logs, filterStartDate, filterEndDate, filterBrand, filterVehicleId]); // Dependencies for recalculation
+        if (!filterBrand) return logs;
+        return logs.filter(log => log.brand === filterBrand);
+    }, [logs, filterBrand]);
 
     const vehicleMap = useMemo(() => {
         const map: Record<string, string> = {};
@@ -271,8 +292,7 @@ function HistoryPage(): JSX.Element {
             try {
                 const logRef = doc(db, "fuelLogs", logId);
                 await deleteDoc(logRef);
-                console.log(`Log ${logId} deleted successfully.`);
-                // UI updates via onSnapshot listener
+                setLogs(prev => prev.filter(l => l.id !== logId));
             } catch (error) {
                 console.error("Error deleting document: ", error);
                 alert(t('history.deleteError', { defaultValue: 'Failed to delete log entry.' }));
@@ -353,8 +373,8 @@ function HistoryPage(): JSX.Element {
                 updatedData.longitude = parsedLon;
             }
             await updateDoc(logRef, updatedData);
-            console.log(`Log ${editingLog.id} updated successfully.`);
-            handleCloseModal(); // Close modal on success
+            setLogs(prev => prev.map(l => l.id === editingLog.id ? { ...l, ...updatedData } : l));
+            handleCloseModal();
         } catch (error) { console.error("Error updating document: ", error); setModalError(t('history.updateError', { defaultValue: 'Failed to update log. Please try again.' })); }
         finally { setIsUpdating(false); }
     };
@@ -449,13 +469,18 @@ function HistoryPage(): JSX.Element {
                     </div>
                 </div>
             )}
+            {filteredLogs.length > 0 && hasMore && !isLoading && !error && (
+                <p className="text-xs text-gray-400 dark:text-gray-500 text-center mt-1">
+                    {t('history.metrics.partialDisclaimer', { defaultValue: 'Based on loaded entries only' })}
+                </p>
+            )}
 
             {/* --- Table / Cards Section --- */}
             <div className="bg-white dark:bg-gray-800 shadow-lg rounded-xl p-4 sm:p-6 border border-gray-200 dark:border-gray-700">
                 {/* Section Header with Title (showing filtered count) and Copy Button */}
                 <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-4 sm:mb-6">
                     <h3 className="text-lg font-medium text-gray-700 dark:text-gray-300 mb-2 sm:mb-0">
-                        {t('history.logDetails.heading')} {filteredLogs.length !== logs.length ? t('history.logDetails.filteredCount', { filtered: filteredLogs.length, total: logs.length }) : t('history.logDetails.totalCount', { count: logs.length })}
+                        {t('history.logDetails.heading')} {filteredLogs.length !== logs.length ? t('history.logDetails.filteredCount', { filtered: filteredLogs.length, total: logs.length }) : hasMore ? t('history.logDetails.loadedCount', { count: logs.length, defaultValue: '({{count}} loaded)' }) : t('history.logDetails.totalCount', { count: logs.length })}
                     </h3>
                     <div className="flex space-x-2">
                         <button 
@@ -570,6 +595,21 @@ function HistoryPage(): JSX.Element {
                             ))}
                         </div>
                     )
+                )}
+
+                {/* Load More Button */}
+                {!isLoading && !error && hasMore && filteredLogs.length > 0 && (
+                    <div className="text-center mt-6">
+                        <button
+                            onClick={() => fetchLogs(true)}
+                            disabled={isLoadingMore}
+                            className="px-6 py-2 text-sm font-medium rounded-md shadow-sm bg-indigo-100 dark:bg-indigo-700 text-indigo-700 dark:text-indigo-300 hover:bg-indigo-200 dark:hover:bg-indigo-600 disabled:opacity-50 transition duration-150"
+                        >
+                            {isLoadingMore
+                                ? t('history.pagination.loading', { defaultValue: 'Loading...' })
+                                : t('history.pagination.loadMore', { defaultValue: 'Load More' })}
+                        </button>
+                    </div>
                 )}
             </div>
 

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -1,5 +1,5 @@
 // src/pages/HistoryPage.tsx
-import { JSX, useState, useEffect, useMemo, useCallback, ChangeEvent, FormEvent } from 'react';
+import { JSX, useState, useEffect, useMemo, useCallback, useRef, ChangeEvent, FormEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 // Import Firestore functions for reading, updating, and deleting documents
 import {
@@ -74,6 +74,7 @@ function HistoryPage(): JSX.Element {
     const [lastDoc, setLastDoc] = useState<QueryDocumentSnapshot<DocumentData> | null>(null);
     const [hasMore, setHasMore] = useState<boolean>(true);
     const [isLoadingMore, setIsLoadingMore] = useState<boolean>(false);
+    const requestSeq = useRef(0);
 
     // --- Fetch Vehicles Effect ---
     useEffect(() => {
@@ -112,6 +113,7 @@ function HistoryPage(): JSX.Element {
     // --- Paginated Fetch Function ---
     const fetchLogs = useCallback(async (loadMore = false) => {
         if (!user) return;
+        const currentSeq = ++requestSeq.current;
         if (loadMore) { setIsLoadingMore(true); } else { setIsLoading(true); }
         setError(null);
 
@@ -125,13 +127,13 @@ function HistoryPage(): JSX.Element {
                 constraints.push(where("vehicleId", "==", filterVehicleId));
             }
             if (filterStartDate) {
-                const start = new Date(filterStartDate);
-                start.setHours(0, 0, 0, 0);
+                const [y, m, d] = filterStartDate.split('-').map(Number);
+                const start = new Date(y, m - 1, d, 0, 0, 0, 0);
                 constraints.push(where("timestamp", ">=", Timestamp.fromDate(start)));
             }
             if (filterEndDate) {
-                const end = new Date(filterEndDate);
-                end.setHours(23, 59, 59, 999);
+                const [y, m, d] = filterEndDate.split('-').map(Number);
+                const end = new Date(y, m - 1, d, 23, 59, 59, 999);
                 constraints.push(where("timestamp", "<=", Timestamp.fromDate(end)));
             }
 
@@ -142,6 +144,8 @@ function HistoryPage(): JSX.Element {
 
             const q = query(collection(db, "fuelLogs"), ...constraints);
             const snapshot = await getDocs(q);
+
+            if (currentSeq !== requestSeq.current) return;
 
             const newLogs: Log[] = [];
             const brands = new Set<string>();
@@ -166,6 +170,7 @@ function HistoryPage(): JSX.Element {
                 return Array.from(merged).sort((a, b) => a.localeCompare(b));
             });
         } catch (err) {
+            if (currentSeq !== requestSeq.current) return;
             console.error("Error fetching fuel logs:", err);
             setError(
                 !navigator.onLine
@@ -173,8 +178,10 @@ function HistoryPage(): JSX.Element {
                     : t('history.loadError', { defaultValue: 'Failed to load fuel history. Please check your connection and try again.' })
             );
         } finally {
-            setIsLoading(false);
-            setIsLoadingMore(false);
+            if (currentSeq === requestSeq.current) {
+                setIsLoading(false);
+                setIsLoadingMore(false);
+            }
         }
     }, [user, filterVehicleId, filterStartDate, filterEndDate, lastDoc, t]);
 
@@ -373,7 +380,9 @@ function HistoryPage(): JSX.Element {
                 updatedData.longitude = parsedLon;
             }
             await updateDoc(logRef, updatedData);
-            setLogs(prev => prev.map(l => l.id === editingLog.id ? { ...l, ...updatedData } : l));
+            setLogs(prev => prev.map(l => l.id === editingLog.id ? { ...l, ...updatedData } : l)
+                .filter(l => !filterVehicleId || l.vehicleId === filterVehicleId)
+            );
             handleCloseModal();
         } catch (error) { console.error("Error updating document: ", error); setModalError(t('history.updateError', { defaultValue: 'Failed to update log. Please try again.' })); }
         finally { setIsUpdating(false); }


### PR DESCRIPTION
## Summary
- Replace unbounded `onSnapshot` listener with paginated `getDocs` using Firestore's `limit`/`startAfter` (25 logs per page)
- Move vehicle and date filters server-side to Firestore query constraints, reducing unnecessary reads
- Add "Load More" button for cursor-based pagination
- Update delete/edit handlers to modify local state instead of relying on real-time listener

## Test plan
- [ ] Verify initial load shows max 25 logs
- [ ] Click "Load More" and confirm next 25 logs append correctly
- [ ] Test vehicle filter resets and re-fetches from server
- [ ] Test date range filters work server-side
- [ ] Test brand filter still works client-side on loaded data
- [ ] Verify edit/delete update the UI without full re-fetch
- [ ] Check metrics disclaimer appears when more data is available
- [ ] Test card view and table view both work with pagination

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JB2HHMkdCrVSs8PyRfYT9L

---
_Generated by [Claude Code](https://claude.ai/code/session_01JB2HHMkdCrVSs8PyRfYT9L)_