### PR TITLE
perf: compress receipt images before uploading to storage

### DIFF
--- a/src/firebase/storageService.test.ts
+++ b/src/firebase/storageService.test.ts
@@ -15,13 +15,37 @@ vi.mock('firebase/storage', () => ({
   deleteObject: vi.fn(),
 }));
 
+const mockBlob = new Blob(['compressed'], { type: 'image/jpeg' });
+
+const mockCtx = {
+  drawImage: vi.fn(),
+};
+
+const mockCanvas = {
+  width: 0,
+  height: 0,
+  getContext: vi.fn(() => mockCtx),
+  toBlob: vi.fn((cb: BlobCallback) => cb(mockBlob)),
+};
+
+vi.stubGlobal('createImageBitmap', vi.fn().mockResolvedValue({
+  width: 4000,
+  height: 3000,
+  close: vi.fn(),
+}));
+
+vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+  if (tag === 'canvas') return mockCanvas as unknown as HTMLCanvasElement;
+  return document.createElement(tag);
+});
+
 describe('storageService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   describe('uploadReceipt', () => {
-    it('successfully uploads a file and returns the download URL', async () => {
+    it('successfully uploads a compressed file and returns the download URL', async () => {
       const mockFile = new File(['test'], 'test.jpg', { type: 'image/jpeg' });
       const mockUserId = 'user123';
       const mockDownloadUrl = 'https://firebase-storage.com/receipt.jpg';
@@ -36,7 +60,11 @@ describe('storageService', () => {
 
       expect(url).toBe(mockDownloadUrl);
       expect(storage.ref).toHaveBeenCalled();
-      expect(storage.uploadBytes).toHaveBeenCalled();
+      expect(storage.uploadBytes).toHaveBeenCalledWith(
+        expect.anything(),
+        mockBlob,
+        { contentType: 'image/jpeg' },
+      );
       expect(storage.getDownloadURL).toHaveBeenCalled();
     });
 

--- a/src/firebase/storageService.test.ts
+++ b/src/firebase/storageService.test.ts
@@ -34,9 +34,10 @@ vi.stubGlobal('createImageBitmap', vi.fn().mockResolvedValue({
   close: vi.fn(),
 }));
 
+const originalCreateElement = document.createElement.bind(document);
 vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
   if (tag === 'canvas') return mockCanvas as unknown as HTMLCanvasElement;
-  return document.createElement(tag);
+  return originalCreateElement(tag);
 });
 
 describe('storageService', () => {

--- a/src/firebase/storageService.ts
+++ b/src/firebase/storageService.ts
@@ -1,6 +1,31 @@
 import { ref, uploadBytes, getDownloadURL, deleteObject } from "firebase/storage";
 import { storage } from "./config";
 
+const STORAGE_MAX_DIMENSION = 1600;
+const STORAGE_JPEG_QUALITY = 0.8;
+
+async function compressImage(file: File): Promise<Blob> {
+  const bitmap = await createImageBitmap(file);
+  const { width, height } = bitmap;
+
+  const scale = Math.min(1, STORAGE_MAX_DIMENSION / Math.max(width, height));
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.round(width * scale);
+  canvas.height = Math.round(height * scale);
+
+  const ctx = canvas.getContext('2d')!;
+  ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+  bitmap.close();
+
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      blob => blob ? resolve(blob) : reject(new Error('Failed to compress image')),
+      'image/jpeg',
+      STORAGE_JPEG_QUALITY,
+    );
+  });
+}
+
 /**
  * Uploads a file to Firebase Storage and returns the download URL.
  * @param file The file to upload.
@@ -8,11 +33,13 @@ import { storage } from "./config";
  * @returns Promise resolving to the download URL string.
  */
 export const uploadReceipt = async (file: File, userId: string): Promise<string> => {
-  const fileName = `${Date.now()}_${file.name}`;
+  const baseName = file.name.replace(/\.[^.]+$/, '');
+  const fileName = `${Date.now()}_${baseName}.jpg`;
   const storageRef = ref(storage, `receipts/${userId}/${fileName}`);
-  
+
   try {
-    const snapshot = await uploadBytes(storageRef, file);
+    const compressed = await compressImage(file);
+    const snapshot = await uploadBytes(storageRef, compressed, { contentType: 'image/jpeg' });
     const downloadURL = await getDownloadURL(snapshot.ref);
     return downloadURL;
   } catch (error) {

--- a/src/firebase/storageService.ts
+++ b/src/firebase/storageService.ts
@@ -13,7 +13,11 @@ async function compressImage(file: File): Promise<Blob> {
   canvas.width = Math.round(width * scale);
   canvas.height = Math.round(height * scale);
 
-  const ctx = canvas.getContext('2d')!;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    bitmap.close();
+    throw new Error('Failed to get 2D canvas context');
+  }
   ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
   bitmap.close();
 
@@ -33,13 +37,26 @@ async function compressImage(file: File): Promise<Blob> {
  * @returns Promise resolving to the download URL string.
  */
 export const uploadReceipt = async (file: File, userId: string): Promise<string> => {
-  const baseName = file.name.replace(/\.[^.]+$/, '');
-  const fileName = `${Date.now()}_${baseName}.jpg`;
+  const isImage = file.type.startsWith('image/');
+  let uploadData: Blob | File = file;
+  let contentType = file.type;
+  let fileName = `${Date.now()}_${file.name}`;
+
+  if (isImage) {
+    try {
+      uploadData = await compressImage(file);
+      contentType = 'image/jpeg';
+      const baseName = file.name.replace(/\.[^.]+$/, '');
+      fileName = `${Date.now()}_${baseName}.jpg`;
+    } catch (error) {
+      console.warn('Image compression failed, falling back to original file:', error);
+    }
+  }
+
   const storageRef = ref(storage, `receipts/${userId}/${fileName}`);
 
   try {
-    const compressed = await compressImage(file);
-    const snapshot = await uploadBytes(storageRef, compressed, { contentType: 'image/jpeg' });
+    const snapshot = await uploadBytes(storageRef, uploadData, { contentType });
     const downloadURL = await getDownloadURL(snapshot.ref);
     return downloadURL;
   } catch (error) {


### PR DESCRIPTION
## Summary
- Receipt photos from phone cameras were uploaded at full resolution (often 4000x3000+), making them unnecessarily large and slow to load
- Now compresses images client-side before uploading: resized to max 1600px and converted to JPEG at 80% quality
- Receipts remain fully readable while being significantly smaller in storage

## Test plan
- [x] All 210 existing tests pass
- [ ] Upload a receipt photo from a phone camera and verify it uploads successfully
- [ ] Verify the stored image is readable and reasonably sized
- [ ] Verify AI receipt extraction still works correctly with the compressed image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rmrne3Xu4oey6FabJFucA

---
_Generated by [Claude Code](https://claude.ai/code/session_011rmrne3Xu4oey6FabJFucA)_