### PR TITLE
fix: prevent undefined Firestore fields and clarify save errors

### DIFF
--- a/src/firebase/__tests__/firestoreService.test.ts
+++ b/src/firebase/__tests__/firestoreService.test.ts
@@ -1,9 +1,9 @@
 // src/firebase/__tests__/firestoreService.test.ts
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { CollectionReference, Query, QueryConstraint, QuerySnapshot, QueryFieldFilterConstraint, QueryOrderByConstraint, QueryLimitConstraint } from 'firebase/firestore';
-import { collection, query, where, getDocs, orderBy, limit, doc, getDoc, Timestamp } from 'firebase/firestore';
+import { collection, query, where, getDocs, orderBy, limit, doc, getDoc, Timestamp, runTransaction, increment } from 'firebase/firestore';
 import { auth, db } from '../config'; // Mocked config for auth and db
-import { fetchFuelLogsByStationId, fetchStationById } from '../firestoreService';
+import { fetchFuelLogsByStationId, fetchStationById, updateStationMetrics } from '../firestoreService';
 import { Log } from '../../utils/types';
 
 // Mock Firebase
@@ -19,6 +19,8 @@ vi.mock('firebase/firestore', async (importOriginal) => {
         limit: vi.fn(),
         doc: vi.fn(),
         getDoc: vi.fn(),
+        runTransaction: vi.fn(),
+        increment: vi.fn((n: number) => ({ __increment: n })),
         Timestamp: {
             fromDate: vi.fn((date: Date) => ({
                 toDate: () => date,
@@ -166,6 +168,57 @@ describe('firestoreService', () => {
             const result = await fetchStationById(mockStationId);
 
             expect(result).toBeNull();
+        });
+    });
+
+    describe('updateStationMetrics', () => {
+        it('updates the running average, count and last price for an existing station', async () => {
+            vi.mocked(doc).mockReturnValue({} as never);
+            const update = vi.fn();
+            const transaction = {
+                get: vi.fn().mockResolvedValue({
+                    exists: () => true,
+                    data: () => ({ logCount: 1, avgPrice: 2 }),
+                }),
+                update,
+            };
+            vi.mocked(runTransaction).mockImplementation(
+                async (_db, cb) => cb(transaction as never)
+            );
+
+            await updateStationMetrics(mockStationId, 4);
+
+            expect(doc).toHaveBeenCalledWith(db, 'stations', mockStationId);
+            // New average for [2, 4] is 3; count increments by 1; last price is 4.
+            expect(update).toHaveBeenCalledWith({}, {
+                logCount: { __increment: 1 },
+                avgPrice: 3,
+                lastPrice: 4,
+            });
+            expect(increment).toHaveBeenCalledWith(1);
+        });
+
+        it('does not update when the station document does not exist', async () => {
+            vi.mocked(doc).mockReturnValue({} as never);
+            const update = vi.fn();
+            const transaction = {
+                get: vi.fn().mockResolvedValue({ exists: () => false }),
+                update,
+            };
+            vi.mocked(runTransaction).mockImplementation(
+                async (_db, cb) => cb(transaction as never)
+            );
+
+            await updateStationMetrics(mockStationId, 4);
+
+            expect(update).not.toHaveBeenCalled();
+        });
+
+        it('propagates transaction failures to the caller', async () => {
+            vi.mocked(doc).mockReturnValue({} as never);
+            vi.mocked(runTransaction).mockRejectedValue(new Error('permission-denied'));
+
+            await expect(updateStationMetrics(mockStationId, 4)).rejects.toThrow('permission-denied');
         });
     });
 });

--- a/src/firebase/firestoreService.ts
+++ b/src/firebase/firestoreService.ts
@@ -119,27 +119,25 @@ export const getOrCreateStation = async (osmStation: OSMStation): Promise<string
 export const updateStationMetrics = async (stationId: string, pricePerLitre: number) => {
     const stationRef = doc(db, 'stations', stationId);
 
-    try {
-        await runTransaction(db, async (transaction) => {
-            const stationSnap = await transaction.get(stationRef);
-            if (!stationSnap.exists()) return;
+    // Let transaction failures propagate so callers can surface a warning to the
+    // user; callers (QuickLogPage, migrationService) handle this non-fatally.
+    await runTransaction(db, async (transaction) => {
+        const stationSnap = await transaction.get(stationRef);
+        if (!stationSnap.exists()) return;
 
-            const data = stationSnap.data() as Station;
-            const currentCount = data.logCount || 0;
-            const currentAvg = data.avgPrice || 0;
+        const data = stationSnap.data() as Station;
+        const currentCount = data.logCount || 0;
+        const currentAvg = data.avgPrice || 0;
 
-            // Calculate new average
-            const newAvg = ((currentAvg * currentCount) + pricePerLitre) / (currentCount + 1);
+        // Calculate new average
+        const newAvg = ((currentAvg * currentCount) + pricePerLitre) / (currentCount + 1);
 
-            transaction.update(stationRef, {
-                logCount: increment(1),
-                avgPrice: newAvg,
-                lastPrice: pricePerLitre
-            });
+        transaction.update(stationRef, {
+            logCount: increment(1),
+            avgPrice: newAvg,
+            lastPrice: pricePerLitre
         });
-    } catch (error) {
-        console.error("Transaction failed: ", error);
-    }
+    });
 };
 
 /**

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -97,9 +97,12 @@
       "uploadingReceipt": "Quittungsfoto wird hochgeladen...",
       "savedSuccess": "Eintrag erfolgreich gespeichert!",
       "savedNoLocation": "Eintrag erfolgreich gespeichert! (Standort nicht erfasst)",
-      "saveError": "Fehler beim Speichern. Bitte versuchen Sie es erneut.",
+      "saveError": "Dein Eintrag konnte nicht gespeichert werden: {{detail}}. Bitte versuche es erneut.",
       "fetchRateError": "Fehler beim Abrufen des {{currency}}-Kurses. Bitte manuell einstellen.",
-      "locationCapturedAt": "Located at {{station}}."
+      "locationCapturedAt": "Located at {{station}}.",
+      "receiptUploadWarning": "Dein Belegfoto konnte nicht hochgeladen werden, daher wurde der Eintrag ohne es gespeichert.",
+      "stationLookupWarning": "In der Nähe konnte keine Tankstelle gefunden werden, daher wurde dieser Eintrag keiner zugeordnet.",
+      "stationMetricsWarning": "Dein Eintrag wurde gespeichert, aber die Preisstatistik der Tankstelle konnte nicht aktualisiert werden."
     }
   },
   "history": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -98,7 +98,10 @@
       "uploadingReceipt": "Uploading receipt photo...",
       "savedSuccess": "Log saved successfully!",
       "savedNoLocation": "Log saved successfully! (Location not captured)",
-      "saveError": "Error saving log. Please try again.",
+      "saveError": "Couldn't save your log: {{detail}}. Please try again.",
+      "receiptUploadWarning": "Your receipt photo couldn't be uploaded, so the log was saved without it.",
+      "stationLookupWarning": "Couldn't look up a nearby station, so this log wasn't linked to one.",
+      "stationMetricsWarning": "Your log was saved, but the station's price stats couldn't be updated.",
       "fetchRateError": "Failed to fetch {{currency}} rate. Please set manually."
     }
   },

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -97,9 +97,12 @@
       "uploadingReceipt": "Subiendo foto del recibo...",
       "savedSuccess": "¡Registro guardado exitosamente!",
       "savedNoLocation": "¡Registro guardado exitosamente! (Ubicación no capturada)",
-      "saveError": "Error al guardar el registro. Por favor, inténtalo de nuevo.",
+      "saveError": "No se pudo guardar tu registro: {{detail}}. Inténtalo de nuevo.",
       "fetchRateError": "Error al obtener la tasa de {{currency}}. Por favor, configúrala manualmente.",
-      "locationCapturedAt": "Located at {{station}}."
+      "locationCapturedAt": "Located at {{station}}.",
+      "receiptUploadWarning": "No se pudo subir la foto del recibo, así que el registro se guardó sin ella.",
+      "stationLookupWarning": "No se pudo buscar una gasolinera cercana, así que este registro no se vinculó a ninguna.",
+      "stationMetricsWarning": "Tu registro se guardó, pero no se pudieron actualizar las estadísticas de precios de la gasolinera."
     }
   },
   "history": {

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -97,9 +97,12 @@
       "uploadingReceipt": "Ladataan kuittikuvaa...",
       "savedSuccess": "Loki tallennettu onnistuneesti!",
       "savedNoLocation": "Loki tallennettu onnistuneesti! (Sijaintia ei saatu)",
-      "saveError": "Virhe tallennettaessa lokia. Yritä uudelleen.",
+      "saveError": "Lokin tallentaminen epäonnistui: {{detail}}. Yritä uudelleen.",
       "fetchRateError": "Valuuttakurssin {{currency}} haku epäonnistui. Aseta manuaalisesti.",
-      "locationCapturedAt": "Located at {{station}}."
+      "locationCapturedAt": "Located at {{station}}.",
+      "receiptUploadWarning": "Kuittikuvaa ei voitu ladata, joten loki tallennettiin ilman sitä.",
+      "stationLookupWarning": "Lähistöltä ei löytynyt asemaa, joten tätä lokia ei yhdistetty mihinkään.",
+      "stationMetricsWarning": "Lokisi tallennettiin, mutta aseman hintatietoja ei voitu päivittää."
     }
   },
   "history": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -97,9 +97,12 @@
       "uploadingReceipt": "Téléversement de la photo du reçu...",
       "savedSuccess": "Saisie enregistrée avec succès !",
       "savedNoLocation": "Saisie enregistrée avec succès ! (Localisation non capturée)",
-      "saveError": "Erreur lors de l'enregistrement. Veuillez réessayer.",
+      "saveError": "Impossible d'enregistrer votre entrée : {{detail}}. Veuillez réessayer.",
       "fetchRateError": "Échec de la récupération du taux {{currency}}. Veuillez le définir manuellement.",
-      "locationCapturedAt": "Located at {{station}}."
+      "locationCapturedAt": "Located at {{station}}.",
+      "receiptUploadWarning": "La photo de votre reçu n'a pas pu être téléchargée, l'entrée a donc été enregistrée sans elle.",
+      "stationLookupWarning": "Impossible de trouver une station à proximité, cette entrée n'a donc été liée à aucune.",
+      "stationMetricsWarning": "Votre entrée a été enregistrée, mais les statistiques de prix de la station n'ont pas pu être mises à jour."
     }
   },
   "history": {

--- a/src/i18n/locales/ga.json
+++ b/src/i18n/locales/ga.json
@@ -97,9 +97,12 @@
       "uploadingReceipt": "Ag uaslódáil grianghraf admhála...",
       "savedSuccess": "Iontráil sábháilte go rathúil!",
       "savedNoLocation": "Iontráil sábháilte go rathúil! (Suíomh gan gabhail)",
-      "saveError": "Earráid agus iontráil á sábháil. Déan iarracht arís le do thoil.",
+      "saveError": "Níorbh fhéidir do logáil a shábháil: {{detail}}. Bain triail eile as le do thoil.",
       "fetchRateError": "Theip ar an ráta {{currency}} a fháil. Socraigh de láimh le do thoil.",
-      "locationCapturedAt": "Located at {{station}}."
+      "locationCapturedAt": "Located at {{station}}.",
+      "receiptUploadWarning": "Níorbh fhéidir grianghraf an admhála a uaslódáil, mar sin sábháladh an logáil gan é.",
+      "stationLookupWarning": "Níorbh fhéidir stáisiún in aice láimhe a aimsiú, mar sin níor nascadh an logáil seo le ceann ar bith.",
+      "stationMetricsWarning": "Sábháladh do logáil, ach níorbh fhéidir staitisticí praghais an stáisiúin a nuashonrú."
     }
   },
   "history": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -97,9 +97,12 @@
       "uploadingReceipt": "レシート写真をアップロード中...",
       "savedSuccess": "記録が正常に保存されました！",
       "savedNoLocation": "記録が正常に保存されました！（位置情報なし）",
-      "saveError": "記録の保存中にエラーが発生しました。もう一度お試しください。",
+      "saveError": "記録を保存できませんでした: {{detail}}。もう一度お試しください。",
       "fetchRateError": "{{currency}}のレートの取得に失敗しました。手動で設定してください。",
-      "locationCapturedAt": "Located at {{station}}."
+      "locationCapturedAt": "Located at {{station}}.",
+      "receiptUploadWarning": "レシート写真をアップロードできなかったため、記録はそれなしで保存されました。",
+      "stationLookupWarning": "近くのガソリンスタンドを検索できなかったため、この記録はどのスタンドにも関連付けられませんでした。",
+      "stationMetricsWarning": "記録は保存されましたが、スタンドの価格統計を更新できませんでした。"
     }
   },
   "history": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -97,9 +97,12 @@
       "uploadingReceipt": "영수증 사진 업로드 중...",
       "savedSuccess": "기록이 성공적으로 저장되었습니다!",
       "savedNoLocation": "기록이 성공적으로 저장되었습니다! (위치 정보 없음)",
-      "saveError": "기록 저장 중 오류가 발생했습니다. 다시 시도해 주세요.",
+      "saveError": "기록을 저장할 수 없습니다: {{detail}}. 다시 시도해 주세요.",
       "fetchRateError": "{{currency}} 환율을 가져오는 데 실패했습니다. 수동으로 설정해 주세요.",
-      "locationCapturedAt": "Located at {{station}}."
+      "locationCapturedAt": "Located at {{station}}.",
+      "receiptUploadWarning": "영수증 사진을 업로드할 수 없어 기록이 사진 없이 저장되었습니다.",
+      "stationLookupWarning": "근처 주유소를 찾을 수 없어 이 기록이 주유소와 연결되지 않았습니다.",
+      "stationMetricsWarning": "기록은 저장되었지만 주유소의 가격 통계를 업데이트할 수 없습니다."
     }
   },
   "history": {

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -97,9 +97,12 @@
       "uploadingReceipt": "Laster opp kvitteringsbilde...",
       "savedSuccess": "Loggen ble lagret!",
       "savedNoLocation": "Loggen ble lagret! (Posisjon ikke hentet)",
-      "saveError": "Feil ved lagring av logg. Prøv igjen.",
+      "saveError": "Kunne ikke lagre loggen din: {{detail}}. Prøv igjen.",
       "fetchRateError": "Kunne ikke hente kurs for {{currency}}. Vennligst sett manuelt.",
-      "locationCapturedAt": "Located at {{station}}."
+      "locationCapturedAt": "Located at {{station}}.",
+      "receiptUploadWarning": "Kvitteringsbildet kunne ikke lastes opp, så loggen ble lagret uten det.",
+      "stationLookupWarning": "Kunne ikke finne en stasjon i nærheten, så denne loggen ble ikke koblet til noen.",
+      "stationMetricsWarning": "Loggen din ble lagret, men stasjonens prisstatistikk kunne ikke oppdateres."
     }
   },
   "history": {

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -97,9 +97,12 @@
       "uploadingReceipt": "Laddar upp kvittofoto...",
       "savedSuccess": "Loggen sparades framgångsrikt!",
       "savedNoLocation": "Loggen sparades framgångsrikt! (Plats hämtades inte)",
-      "saveError": "Fel vid sparande av logg. Försök igen.",
+      "saveError": "Det gick inte att spara din logg: {{detail}}. Försök igen.",
       "fetchRateError": "Misslyckades med att hämta kurs för {{currency}}. Ställ in manuellt.",
-      "locationCapturedAt": "Located at {{station}}."
+      "locationCapturedAt": "Located at {{station}}.",
+      "receiptUploadWarning": "Kvittofotot kunde inte laddas upp, så loggen sparades utan det.",
+      "stationLookupWarning": "Det gick inte att hitta en station i närheten, så den här loggen kopplades inte till någon.",
+      "stationMetricsWarning": "Din logg sparades, men stationens prisstatistik kunde inte uppdateras."
     }
   },
   "history": {

--- a/src/pages/QuickLogPage.test.tsx
+++ b/src/pages/QuickLogPage.test.tsx
@@ -338,4 +338,89 @@ describe('QuickLogPage', () => {
 
     expect(updateStationMetrics).toHaveBeenCalledWith('station-123', 50 / 30);
   });
+
+  it('omits stationId from the payload when no station is linked (no undefined fields)', async () => {
+    // Geolocation is denied in the default beforeEach, so no station is linked.
+    render(<MemoryRouter><QuickLogPage /></MemoryRouter>);
+
+    await waitFor(() => expect(screen.getByLabelText('quickLog.fields.totalCost')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText(/quickLog\.fields\.fillingStation/), { target: { value: 'Shell' } });
+    fireEvent.change(screen.getByLabelText('quickLog.fields.totalCost'), { target: { value: '50' } });
+    fireEvent.change(screen.getByLabelText('quickLog.fields.distance'), { target: { value: '400' } });
+    fireEvent.change(screen.getByLabelText('quickLog.fields.fuel'), { target: { value: '30' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /quickLog.submit.save/ }));
+
+    await waitFor(() => expect(addDoc).toHaveBeenCalledTimes(1));
+
+    const [, payload] = vi.mocked(addDoc).mock.calls[0];
+    // Firestore's addDoc() rejects fields whose value is undefined, so optional
+    // fields must be absent rather than set to undefined.
+    expect(payload).not.toHaveProperty('stationId');
+    expect(payload).not.toHaveProperty('receiptUrl');
+    expect(Object.values(payload as Record<string, unknown>)).not.toContain(undefined);
+  });
+
+  it('still saves the log and warns the user when updating station metrics fails', async () => {
+    const mockStation = {
+      id: 'station-123',
+      osmId: 'node/123',
+      name: 'Shell Berlin',
+      brand: 'Shell',
+      latitude: 52.52,
+      longitude: 13.405,
+    };
+
+    vi.mocked(findNearestStation).mockResolvedValue(mockStation);
+    vi.mocked(getOrCreateStation).mockResolvedValue('station-123');
+    vi.mocked(updateStationMetrics).mockRejectedValue(new Error('permission-denied'));
+
+    mockGetCurrentPosition.mockImplementation((success) =>
+      success({ coords: { latitude: 52.52, longitude: 13.405, accuracy: 15 } })
+    );
+
+    render(<MemoryRouter><QuickLogPage /></MemoryRouter>);
+
+    await waitFor(() => expect(screen.getByLabelText('quickLog.fields.totalCost')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText('quickLog.fields.totalCost'), { target: { value: '50' } });
+    fireEvent.change(screen.getByLabelText('quickLog.fields.distance'), { target: { value: '400' } });
+    fireEvent.change(screen.getByLabelText('quickLog.fields.fuel'), { target: { value: '30' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /quickLog.submit.save/ }));
+
+    // The log itself is still persisted...
+    await waitFor(() => expect(addDoc).toHaveBeenCalledTimes(1));
+    // ...and the user is warned about the metrics update without checking the console.
+    await waitFor(() =>
+      expect(screen.getByText(/quickLog\.messages\.stationMetricsWarning/)).toBeInTheDocument()
+    );
+  });
+
+  it('still saves the log and warns the user when station lookup fails', async () => {
+    vi.mocked(findNearestStation).mockRejectedValue(new Error('network'));
+
+    mockGetCurrentPosition.mockImplementation((success) =>
+      success({ coords: { latitude: 52.52, longitude: 13.405, accuracy: 15 } })
+    );
+
+    render(<MemoryRouter><QuickLogPage /></MemoryRouter>);
+
+    await waitFor(() => expect(screen.getByLabelText('quickLog.fields.totalCost')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText('quickLog.fields.totalCost'), { target: { value: '50' } });
+    fireEvent.change(screen.getByLabelText('quickLog.fields.distance'), { target: { value: '400' } });
+    fireEvent.change(screen.getByLabelText('quickLog.fields.fuel'), { target: { value: '30' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /quickLog.submit.save/ }));
+
+    await waitFor(() => expect(addDoc).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(screen.getByText(/quickLog\.messages\.stationLookupWarning/)).toBeInTheDocument()
+    );
+
+    const [, payload] = vi.mocked(addDoc).mock.calls[0];
+    expect(payload).not.toHaveProperty('stationId');
+  });
 });

--- a/src/pages/QuickLogPage.test.tsx
+++ b/src/pages/QuickLogPage.test.tsx
@@ -398,6 +398,28 @@ describe('QuickLogPage', () => {
     );
   });
 
+  it('shows a clear error with the failure detail when the Firestore write fails', async () => {
+    vi.mocked(addDoc).mockRejectedValue(new Error('permission-denied'));
+
+    render(<MemoryRouter><QuickLogPage /></MemoryRouter>);
+
+    await waitFor(() => expect(screen.getByLabelText('quickLog.fields.totalCost')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText('quickLog.fields.totalCost'), { target: { value: '50' } });
+    fireEvent.change(screen.getByLabelText('quickLog.fields.distance'), { target: { value: '400' } });
+    fireEvent.change(screen.getByLabelText('quickLog.fields.fuel'), { target: { value: '30' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /quickLog.submit.save/ }));
+
+    await waitFor(() => expect(addDoc).toHaveBeenCalledTimes(1));
+    // The save error is surfaced to the user instead of only being logged.
+    // (The mock t() returns the key; the real en.json string interpolates the
+    // {{detail}} placeholder with the underlying error message.)
+    await waitFor(() =>
+      expect(screen.getByText(/quickLog\.messages\.saveError/)).toBeInTheDocument()
+    );
+  });
+
   it('still saves the log and warns the user when station lookup fails', async () => {
     vi.mocked(findNearestStation).mockRejectedValue(new Error('network'));
 

--- a/src/pages/QuickLogPage.tsx
+++ b/src/pages/QuickLogPage.tsx
@@ -309,6 +309,7 @@ function QuickLogPage(): JSX.Element {
                 }
             } catch (err) {
                 console.error("Station lookup failed:", err);
+                setStationWarning(t('quickLog.messages.stationLookupWarning'));
             }
         }
     }
@@ -328,12 +329,23 @@ function QuickLogPage(): JSX.Element {
 
     setMessage({ type: 'info', text: t('quickLog.messages.savingLog', { locationMsg: locationMessage }) });
 
+    // Non-fatal problems collected during save (e.g. receipt upload or station
+    // linking failed). These don't block saving the log itself; we surface them
+    // to the user so they know something needs attention without the console.
+    const saveWarnings: string[] = [];
+
     try {
-      // --- Handle Receipt Upload ---
+      // --- Handle Receipt Upload (non-fatal) ---
       let receiptUrl = "";
       if (receiptFile && user) {
         setMessage({ type: 'info', text: t('quickLog.messages.uploadingReceipt') });
-        receiptUrl = await uploadReceipt(receiptFile, user.uid);
+        try {
+          receiptUrl = await uploadReceipt(receiptFile, user.uid);
+        } catch (uploadError) {
+          console.error("Receipt upload failed: ", uploadError);
+          analytics.then(a => { if (a) logEvent(a, 'fuel_log_failed', { error_type: 'receipt_upload' }); });
+          saveWarnings.push(t('quickLog.messages.receiptUploadWarning'));
+        }
       }
 
       // Calculate cost in home currency
@@ -352,9 +364,13 @@ function QuickLogPage(): JSX.Element {
         currency: currency,
         originalCost: parsedCost,
         exchangeRate: exchangeRate,
-        receiptUrl: receiptUrl || undefined,
-        stationId: linkedStationId
       };
+      if (receiptUrl) {
+        logData.receiptUrl = receiptUrl;
+      }
+      if (linkedStationId) {
+        logData.stationId = linkedStationId;
+      }
       if (!isNaN(parsedOdometer)) {
         logData.odometerKm = parsedOdometer;
       }
@@ -364,12 +380,18 @@ function QuickLogPage(): JSX.Element {
         logData.locationAccuracy = locationData.locationAccuracy;
       }
 
-      // Save to Firestore
+      // Save to Firestore — this is the only fatal step; if it throws the log
+      // wasn't recorded and we report a clear error below.
       await addDoc(collection(db, "fuelLogs"), logData);
-      
-      // Update station metrics if linked
+
+      // Update station metrics if linked (non-fatal — the log is already saved)
       if (linkedStationId) {
-        await updateStationMetrics(linkedStationId, pricePerLitre);
+        try {
+          await updateStationMetrics(linkedStationId, pricePerLitre);
+        } catch (metricsError) {
+          console.error("Updating station metrics failed: ", metricsError);
+          saveWarnings.push(t('quickLog.messages.stationMetricsWarning'));
+        }
       }
 
       analytics.then(a => { if (a) logEvent(a, 'fuel_log_submitted', { vehicle_id: selectedVehicleId, has_receipt: !!receiptFile, currency, used_ai_autofill: extractedData !== null, has_station: !!linkedStationId }); });
@@ -378,7 +400,13 @@ function QuickLogPage(): JSX.Element {
       setBrand(''); setCost(''); setDistanceKmInput(''); setFuelAmountLiters('');
       setOdometerKmInput('');
       setReceiptFile(null);
-      setMessage({ type: 'success', text: locationData ? t('quickLog.messages.savedSuccess') : t('quickLog.messages.savedNoLocation') });
+      if (saveWarnings.length > 0) {
+        // Saved, but something non-critical needs the user's attention.
+        const base = locationData ? t('quickLog.messages.savedSuccess') : t('quickLog.messages.savedNoLocation');
+        setMessage({ type: 'warning', text: `${base} ${saveWarnings.join(' ')}` });
+      } else {
+        setMessage({ type: 'success', text: locationData ? t('quickLog.messages.savedSuccess') : t('quickLog.messages.savedNoLocation') });
+      }
 
       // Haptic feedback for mobile
       if ('vibrate' in navigator) {
@@ -388,7 +416,12 @@ function QuickLogPage(): JSX.Element {
     } catch (error) {
       console.error("Error adding document: ", error);
       analytics.then(a => { if (a) logEvent(a, 'fuel_log_failed', { error_type: 'firestore_write' }); });
-      setMessage({ type: 'error', text: t('quickLog.messages.saveError') });
+      setMessage({
+        type: 'error',
+        text: t('quickLog.messages.saveError', {
+          detail: error instanceof Error ? error.message : String(error),
+        }),
+      });
     } finally {
       setIsSaving(false);
       setTimeout(() => setMessage({ type: '', text: '' }), 5000);

--- a/src/pages/QuickLogPage.tsx
+++ b/src/pages/QuickLogPage.tsx
@@ -424,7 +424,10 @@ function QuickLogPage(): JSX.Element {
       });
     } finally {
       setIsSaving(false);
-      setTimeout(() => setMessage({ type: '', text: '' }), 5000);
+      setTimeout(() => {
+        setMessage({ type: '', text: '' });
+        setStationWarning('');
+      }, 5000);
     }
   };
 

--- a/src/utils/locationService.test.ts
+++ b/src/utils/locationService.test.ts
@@ -105,14 +105,15 @@ describe('locationService', () => {
         expect(result?.osmId).toBe('way/999');
     });
 
-    it('returns null on API error', async () => {
+    it('throws on API error so callers can surface a warning', async () => {
         vi.mocked(global.fetch).mockResolvedValue({
             ok: false,
             status: 500
         } as Response);
 
-        const result = await findNearestStation(53.3, -6.2);
-        expect(result).toBeNull();
+        await expect(findNearestStation(53.3, -6.2)).rejects.toThrow(
+            'Overpass API responded with status 500'
+        );
     });
 
     it('retries on 429 error and eventually succeeds', async () => {

--- a/src/utils/locationService.ts
+++ b/src/utils/locationService.ts
@@ -182,11 +182,14 @@ export async function findNearestStation(lat: number, lon: number, radiusMeters:
                 address: best.tags?.['addr:street'] ? `${best.tags['addr:street']} ${best.tags['addr:housenumber'] || ''}`.trim() : undefined
             };
         } catch (error) {
+            // Propagate genuine lookup failures so callers can distinguish them
+            // from the "no station nearby" case (which returns null above) and
+            // surface a warning to the user.
             console.error('Error querying Overpass API:', error);
-            return null;
+            throw error;
         }
     }
 
     console.error('Max retries reached for Overpass API.');
-    return null;
+    throw new Error('Overpass API unavailable after maximum retries.');
 }


### PR DESCRIPTION
## 📋 Description

Fixes the runtime error `FirebaseError: Function addDoc() called with invalid data. Unsupported field value: undefined (found in field stationId ...)` when saving a fuel log.

Firestore's `addDoc()` rejects any field whose value is `undefined`. In `QuickLogPage`, `stationId` was assigned `linkedStationId` directly (which is `undefined` when no nearby station is found), and `receiptUrl` could likewise resolve to `undefined`. Either case made the whole save fail.

This PR omits those optional fields when they have no value, and also improves the error/warning messaging so failures are visible in the UI rather than only in the console.

## 🚀 Proposed Changes
- Build `stationId` and `receiptUrl` conditionally in the `fuelLogs` payload so they are omitted (not set to `undefined`), matching the existing pattern used for `odometerKm` and location fields.
- Treat receipt upload, nearby-station lookup, and station-metrics update as **non-fatal**: the log still saves, and the user sees a clear warning instead of a silent console error.
- Include the underlying error detail in the fatal save-error message.
- Add user-facing strings to `en.json`: `receiptUploadWarning`, `stationLookupWarning`, `stationMetricsWarning`, and an updated `saveError` with a `{{detail}}` placeholder.
- Add tests covering the omitted-field fix and the non-fatal warning paths.

## 🛡️ Checklist
- [x] I have verified that all unit tests pass locally (`npm run test`).
- [ ] I have verified that the build succeeds locally (`npm run build`).
- [x] I have added/updated unit tests for my changes.
- [x] I have followed the project's coding standards and naming conventions.
- [ ] I have updated the documentation (`docs/`) if necessary.
- [ ] New features are gated behind a Remote Config flag (refer to FEATURE_RELEASING.md).

## 📸 Screenshots (if applicable)
N/A — error-handling and data-validation change.

## 🔗 Related Issues/PRs
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015pG1UEyVnTWndJqDD93Cpf)_