### PR TITLE
feat: log fuel-ups at a later time and location

### DIFF
--- a/api/extract-receipt.test.ts
+++ b/api/extract-receipt.test.ts
@@ -16,7 +16,7 @@ vi.mock('firebase-admin/auth', () => ({
 class MockGoogleGenAI {
   interactions = {
     create: vi.fn().mockResolvedValue({
-      output_text: '{"cost": 42.5, "fuelAmountLiters": 28, "brand": "Esso"}',
+      output_text: '{"cost": 42.5, "fuelAmountLiters": 28, "brand": "Esso", "purchaseDate": "2026-06-20", "purchaseTime": "14:30", "address": "Main St, Dublin"}',
     }),
   };
 }
@@ -86,6 +86,13 @@ describe('api/extract-receipt handler', () => {
     await handler(req, res);
     expect(res._statusCode).toBe(200);
     const body = JSON.parse(res._body);
-    expect(body).toEqual({ cost: 42.5, fuelAmountLiters: 28, brand: 'Esso' });
+    expect(body).toEqual({
+      cost: 42.5,
+      fuelAmountLiters: 28,
+      brand: 'Esso',
+      purchaseDate: '2026-06-20',
+      purchaseTime: '14:30',
+      address: 'Main St, Dublin',
+    });
   });
 });

--- a/api/extract-receipt.ts
+++ b/api/extract-receipt.ts
@@ -86,8 +86,11 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
       1. Total Cost (as a number)
       2. Fuel Amount in Liters (as a number)
       3. Filling Station Brand Name (as a string)
+      4. Purchase Date (as a string in ISO format "YYYY-MM-DD")
+      5. Purchase Time (as a string in 24-hour format "HH:MM")
+      6. Station Address (the full street address or location of the station, as a string)
 
-      Return ONLY a raw JSON object with exactly these keys: "cost", "fuelAmountLiters", "brand".
+      Return ONLY a raw JSON object with exactly these keys: "cost", "fuelAmountLiters", "brand", "purchaseDate", "purchaseTime", "address".
       If a value cannot be found, use null.
       Do not use markdown formatting like \`\`\`json.
     `;
@@ -114,6 +117,9 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
       cost: typeof parsed.cost === 'number' ? parsed.cost : null,
       fuelAmountLiters: typeof parsed.fuelAmountLiters === 'number' ? parsed.fuelAmountLiters : null,
       brand: typeof parsed.brand === 'string' ? parsed.brand : null,
+      purchaseDate: typeof parsed.purchaseDate === 'string' ? parsed.purchaseDate : null,
+      purchaseTime: typeof parsed.purchaseTime === 'string' ? parsed.purchaseTime : null,
+      address: typeof parsed.address === 'string' ? parsed.address : null,
     });
   } catch (err) {
     log('error', 'extract-receipt', 'Gemini extraction failed', { message: (err as Error).message, durationMs: Date.now() - startMs });

--- a/src/components/LocationPicker.test.tsx
+++ b/src/components/LocationPicker.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Capture the map click handler registered via useMapEvents so tests can
+// simulate tapping the map to drop a pin.
+let capturedClick: ((e: { latlng: { lat: number; lng: number } }) => void) | undefined;
+const setView = vi.fn();
+
+vi.mock('react-leaflet', () => ({
+  MapContainer: ({ children }: { children: React.ReactNode }) => <div data-testid="map">{children}</div>,
+  TileLayer: () => <div data-testid="tile" />,
+  Marker: ({ position, eventHandlers }: { position: [number, number]; eventHandlers?: { dragend?: (e: unknown) => void } }) => (
+    <div
+      data-testid="marker"
+      data-pos={JSON.stringify(position)}
+      onClick={() => eventHandlers?.dragend?.({ target: { getLatLng: () => ({ lat: 9, lng: 8 }) } })}
+    />
+  ),
+  useMap: () => ({ setView, getZoom: () => 13 }),
+  useMapEvents: (handlers: { click: (e: { latlng: { lat: number; lng: number } }) => void }) => {
+    capturedClick = handlers.click;
+    return null;
+  },
+}));
+
+vi.mock('../context/ThemeContext', () => ({
+  useTheme: () => ({ theme: 'light' }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    // Supports t(key), t(key, opts), t(key, 'default'), and t(key, 'default', opts).
+    t: (key: string, defOrOpts?: string | Record<string, unknown>, maybeOpts?: Record<string, unknown>) => {
+      let template = key;
+      let opts: Record<string, unknown> | undefined;
+      if (typeof defOrOpts === 'string') {
+        template = defOrOpts;
+        opts = maybeOpts;
+      } else if (defOrOpts) {
+        opts = defOrOpts;
+        if ('defaultValue' in defOrOpts) template = String(defOrOpts.defaultValue);
+      }
+      return opts ? template.replace(/\{\{(\w+)\}\}/g, (_m, n) => String(opts![n] ?? '')) : template;
+    },
+  }),
+}));
+
+const getCurrentPosition = vi.fn();
+vi.mock('../utils/locationService', () => ({
+  getCurrentPosition: () => getCurrentPosition(),
+}));
+
+import LocationPicker from './LocationPicker';
+
+describe('LocationPicker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedClick = undefined;
+  });
+
+  it('renders a marker at the provided value and shows its coordinates', () => {
+    render(<LocationPicker value={{ latitude: 53.34, longitude: -6.26 }} onChange={vi.fn()} />);
+    const marker = screen.getByTestId('marker');
+    expect(JSON.parse(marker.getAttribute('data-pos')!)).toEqual([53.34, -6.26]);
+    const hint = screen.getByText(/tap or drag the pin to adjust/);
+    expect(hint).toHaveTextContent('53.34000');
+    expect(hint).toHaveTextContent('-6.26000');
+  });
+
+  it('shows the tap-to-place hint and no marker when there is no value', () => {
+    render(<LocationPicker value={null} onChange={vi.fn()} />);
+    expect(screen.queryByTestId('marker')).not.toBeInTheDocument();
+    expect(screen.getByText(/Tap the map to drop a pin/)).toBeInTheDocument();
+  });
+
+  it('drops a pin when the map is clicked', () => {
+    const onChange = vi.fn();
+    render(<LocationPicker value={null} onChange={onChange} />);
+    expect(capturedClick).toBeDefined();
+    capturedClick!({ latlng: { lat: 1.23, lng: 4.56 } });
+    expect(onChange).toHaveBeenCalledWith({ latitude: 1.23, longitude: 4.56 });
+  });
+
+  it('updates coordinates when the marker is dragged', () => {
+    const onChange = vi.fn();
+    render(<LocationPicker value={{ latitude: 1, longitude: 2 }} onChange={onChange} />);
+    fireEvent.click(screen.getByTestId('marker')); // mock maps click -> dragend
+    expect(onChange).toHaveBeenCalledWith({ latitude: 9, longitude: 8 });
+  });
+
+  it('uses the current location when the button resolves a position', async () => {
+    getCurrentPosition.mockResolvedValue({ latitude: 40, longitude: -70 });
+    const onChange = vi.fn();
+    render(<LocationPicker value={null} onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Use my location/ }));
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith({ latitude: 40, longitude: -70 }));
+  });
+
+  it('does not change anything when current location is unavailable', async () => {
+    getCurrentPosition.mockResolvedValue(null);
+    const onChange = vi.fn();
+    render(<LocationPicker value={null} onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Use my location/ }));
+    await waitFor(() => expect(getCurrentPosition).toHaveBeenCalled());
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/LocationPicker.tsx
+++ b/src/components/LocationPicker.tsx
@@ -1,0 +1,134 @@
+// src/components/LocationPicker.tsx
+import React, { useEffect, useState } from 'react';
+import { MapContainer, TileLayer, Marker, useMap, useMapEvents } from 'react-leaflet';
+import L from 'leaflet';
+import { Navigation, Loader } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import 'leaflet/dist/leaflet.css';
+
+import { MAP_TILES } from '../utils/mapConstants';
+import { getCurrentPosition } from '../utils/locationService';
+import { useTheme } from '../context/ThemeContext';
+
+// --- Default marker icon fix (points to public assets) ---
+// Mirrors the fix in FuelMapPage so the marker renders when this component is
+// mounted independently of the map page.
+const iconRetinaUrl = '/marker-icon-2x.png';
+const iconUrl = '/marker-icon.png';
+const shadowUrl = '/marker-shadow.png';
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+delete (L.Icon.Default.prototype as any)._getIconUrl;
+L.Icon.Default.mergeOptions({ iconRetinaUrl, iconUrl, shadowUrl });
+// --- End Icon Fix ---
+
+export interface PickerCoords {
+  latitude: number;
+  longitude: number;
+}
+
+interface LocationPickerProps {
+  value: PickerCoords | null;
+  onChange: (coords: PickerCoords) => void;
+  /** Where to centre the map when there's no value yet. Defaults to Dublin. */
+  defaultCenter?: PickerCoords;
+  className?: string;
+}
+
+const DUBLIN: PickerCoords = { latitude: 53.3498, longitude: -6.2603 };
+
+// Recentres the map whenever the selected coordinates change from outside
+// (e.g. a receipt-geocoded address or "use my current location").
+const RecenterOnChange: React.FC<{ coords: PickerCoords | null }> = ({ coords }) => {
+  const map = useMap();
+  useEffect(() => {
+    if (coords) {
+      map.setView([coords.latitude, coords.longitude], Math.max(map.getZoom(), 15));
+    }
+  }, [coords, map]);
+  return null;
+};
+
+// Places/moves the pin on map click.
+const ClickToPlace: React.FC<{ onChange: (coords: PickerCoords) => void }> = ({ onChange }) => {
+  useMapEvents({
+    click(e) {
+      onChange({ latitude: e.latlng.lat, longitude: e.latlng.lng });
+    },
+  });
+  return null;
+};
+
+const LocationPicker: React.FC<LocationPickerProps> = ({ value, onChange, defaultCenter, className }) => {
+  const { theme } = useTheme();
+  const { t } = useTranslation();
+  const [locating, setLocating] = useState(false);
+
+  const center = value ?? defaultCenter ?? DUBLIN;
+
+  const handleUseCurrentLocation = async () => {
+    setLocating(true);
+    try {
+      const pos = await getCurrentPosition();
+      if (pos) {
+        onChange({ latitude: pos.latitude, longitude: pos.longitude });
+      }
+    } finally {
+      setLocating(false);
+    }
+  };
+
+  return (
+    <div className={className}>
+      <div className="relative h-56 w-full rounded-xl overflow-hidden border border-gray-200 dark:border-gray-700 shadow-inner">
+        <MapContainer
+          center={[center.latitude, center.longitude]}
+          zoom={value ? 15 : 11}
+          scrollWheelZoom={true}
+          style={{ height: '100%', width: '100%' }}
+        >
+          <TileLayer
+            attribution={MAP_TILES.attribution}
+            url={theme === 'dark' ? MAP_TILES.dark : MAP_TILES.light}
+          />
+          <ClickToPlace onChange={onChange} />
+          <RecenterOnChange coords={value} />
+          {value && (
+            <Marker
+              position={[value.latitude, value.longitude]}
+              draggable={true}
+              eventHandlers={{
+                dragend: (e) => {
+                  const m = e.target as L.Marker;
+                  const { lat, lng } = m.getLatLng();
+                  onChange({ latitude: lat, longitude: lng });
+                },
+              }}
+            />
+          )}
+        </MapContainer>
+
+        <button
+          type="button"
+          onClick={handleUseCurrentLocation}
+          disabled={locating}
+          className="absolute z-[1000] bottom-2 right-2 flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-lg bg-white/90 dark:bg-gray-800/90 backdrop-blur border border-gray-300 dark:border-gray-600 shadow-md text-gray-700 dark:text-gray-200 hover:bg-white dark:hover:bg-gray-700 transition-colors disabled:opacity-60"
+        >
+          {locating
+            ? <Loader className="w-3.5 h-3.5 animate-spin" />
+            : <Navigation className="w-3.5 h-3.5" />}
+          {t('locationPicker.useCurrentLocation', 'Use my location')}
+        </button>
+      </div>
+      <p className="mt-1.5 text-[11px] text-gray-500 dark:text-gray-400">
+        {value
+          ? t('locationPicker.coords', '{{lat}}, {{lng}} — tap or drag the pin to adjust', {
+              lat: value.latitude.toFixed(5),
+              lng: value.longitude.toFixed(5),
+            })
+          : t('locationPicker.tapToPlace', 'Tap the map to drop a pin where you fuelled.')}
+      </p>
+    </div>
+  );
+};
+
+export default LocationPicker;

--- a/src/components/LocationPicker.tsx
+++ b/src/components/LocationPicker.tsx
@@ -44,7 +44,11 @@ const RecenterOnChange: React.FC<{ coords: PickerCoords | null }> = ({ coords })
     if (coords) {
       map.setView([coords.latitude, coords.longitude], Math.max(map.getZoom(), 15));
     }
-  }, [coords, map]);
+    // Depend on primitive lat/lng, not the object reference: parents recreate the
+    // coords object on every render, which would otherwise re-centre (snap back)
+    // the map whenever any other form field changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [coords?.latitude, coords?.longitude, map]);
   return null;
 };
 

--- a/src/components/ReceiptAISection.tsx
+++ b/src/components/ReceiptAISection.tsx
@@ -74,6 +74,8 @@ const ReceiptAISection: React.FC<ReceiptAISectionProps> = ({
                 <li><span className="font-medium">{t('receipt.cost')}:</span> {extractedData.cost !== null ? extractedData.cost : t('receipt.notFound')}</li>
                 <li><span className="font-medium">{t('receipt.litres')}:</span> {extractedData.fuelAmountLiters !== null ? extractedData.fuelAmountLiters : t('receipt.notFound')}</li>
                 <li><span className="font-medium">{t('receipt.brand')}:</span> {extractedData.brand !== null ? extractedData.brand : t('receipt.notFound')}</li>
+                <li><span className="font-medium">{t('receipt.date', { defaultValue: 'Date' })}:</span> {extractedData.purchaseDate !== null ? `${extractedData.purchaseDate}${extractedData.purchaseTime ? ` ${extractedData.purchaseTime}` : ''}` : t('receipt.notFound')}</li>
+                <li><span className="font-medium">{t('receipt.location', { defaultValue: 'Location' })}:</span> {extractedData.address !== null ? extractedData.address : t('receipt.notFound')}</li>
               </ul>
               <div className="flex gap-2">
                 <button

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -60,7 +60,8 @@
     "sections": {
       "vehicleStation": "Fahrzeug & Tankstelle",
       "fuelCost": "Kraftstoff & Kosten",
-      "receipt": "Quittung"
+      "receipt": "Quittung",
+      "location": "Standort"
     },
     "fields": {
       "vehicle": "Fahrzeug",
@@ -77,7 +78,8 @@
       "converted": "Umgerechnet: {{symbol}}{{amount}}",
       "odometerHintBaseline": "First odometer entry for this vehicle. Enter distance manually to establish a baseline.",
       "odometerHintCalculating": "Calculated from last log (Odo: {{last}} Km).",
-      "odometerErrorLower": "Odometer must be greater than previous ({{last}} Km)."
+      "odometerErrorLower": "Odometer must be greater than previous ({{last}} Km).",
+      "dateTime": "Datum & Uhrzeit des Tankens"
     },
     "submit": {
       "save": "Eintrag speichern",
@@ -102,7 +104,19 @@
       "locationCapturedAt": "Located at {{station}}.",
       "receiptUploadWarning": "Dein Belegfoto konnte nicht hochgeladen werden, daher wurde der Eintrag ohne es gespeichert.",
       "stationLookupWarning": "In der Nähe konnte keine Tankstelle gefunden werden, daher wurde dieser Eintrag keiner zugeordnet.",
-      "stationMetricsWarning": "Dein Eintrag wurde gespeichert, aber die Preisstatistik der Tankstelle konnte nicht aktualisiert werden."
+      "stationMetricsWarning": "Dein Eintrag wurde gespeichert, aber die Preisstatistik der Tankstelle konnte nicht aktualisiert werden.",
+      "invalidDate": "Bitte ein gültiges Datum und eine gültige Uhrzeit eingeben.",
+      "futureDate": "Datum/Uhrzeit des Tankens darf nicht in der Zukunft liegen.",
+      "locationSet": "Standort festgelegt."
+    },
+    "location": {
+      "adjustOnMap": "Auf Karte anpassen",
+      "hideMap": "Karte ausblenden",
+      "resolving": "Nächste Tankstelle wird gesucht…",
+      "coords": "{{lat}}, {{lng}}",
+      "manualBadge": "Markiert",
+      "gpsBadge": "GPS",
+      "none": "Noch kein Standort – auf der Karte festlegen."
     }
   },
   "history": {
@@ -213,7 +227,11 @@
       "cancel": "Abbrechen",
       "receipt": "Quittungsfoto",
       "updateReceipt": "Quittungsfoto aktualisieren",
-      "receiptKept": "Die aktuelle Quittung wird beibehalten, sofern sie nicht ersetzt wird."
+      "receiptKept": "Die aktuelle Quittung wird beibehalten, sofern sie nicht ersetzt wird.",
+      "dateTime": "Datum & Uhrzeit",
+      "location": "Standort",
+      "invalidDate": "Bitte ein gültiges Datum und eine gültige Uhrzeit eingeben.",
+      "futureDate": "Datum/Uhrzeit darf nicht in der Zukunft liegen."
     },
     "delete": {
       "confirm": "Diesen Eintrag löschen? Diese Aktion kann nicht rückgängig gemacht werden."
@@ -338,7 +356,9 @@
     "useValues": "Werte übernehmen",
     "discard": "Verwerfen",
     "extractionFailed": "Fehler beim Extrahieren der Daten aus der Quittung.",
-    "autoFilled": "Felder automatisch aus der Quittung ausgefüllt!"
+    "autoFilled": "Felder automatisch aus der Quittung ausgefüllt!",
+    "date": "Datum",
+    "location": "Standort"
   },
   "import": {
     "title": "Kraftstoffeinträge importieren",
@@ -529,5 +549,10 @@
     "avgPrice": "Durchschn.: €{{price}}/L",
     "olderFuelings": "+ {{count}} weitere Tankungen",
     "fuelingsAtStation": "{{count}} Tankungen an dieser Station"
+  },
+  "locationPicker": {
+    "useCurrentLocation": "Meinen Standort verwenden",
+    "coords": "{{lat}}, {{lng}} – tippen oder Pin ziehen zum Anpassen",
+    "tapToPlace": "Tippe auf die Karte, um einen Pin zu setzen, wo du getankt hast."
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -60,7 +60,8 @@
     "sections": {
       "vehicleStation": "Vehicle & Station",
       "fuelCost": "Fuel & Cost",
-      "receipt": "Receipt"
+      "receipt": "Receipt",
+      "location": "Location"
     },
     "fields": {
       "vehicle": "Vehicle",
@@ -77,7 +78,8 @@
       "converted": "Converted: {{symbol}}{{amount}}",
       "odometerHintBaseline": "First odometer entry for this vehicle. Enter distance manually to establish a baseline.",
       "odometerHintCalculating": "Calculated from last log (Odo: {{last}} Km).",
-      "odometerErrorLower": "Odometer must be greater than previous ({{last}} Km)."
+      "odometerErrorLower": "Odometer must be greater than previous ({{last}} Km).",
+      "dateTime": "Date & time of fuelling"
     },
     "submit": {
       "save": "Save Fuel Log",
@@ -102,7 +104,19 @@
       "receiptUploadWarning": "Your receipt photo couldn't be uploaded, so the log was saved without it.",
       "stationLookupWarning": "Couldn't look up a nearby station, so this log wasn't linked to one.",
       "stationMetricsWarning": "Your log was saved, but the station's price stats couldn't be updated.",
-      "fetchRateError": "Failed to fetch {{currency}} rate. Please set manually."
+      "fetchRateError": "Failed to fetch {{currency}} rate. Please set manually.",
+      "invalidDate": "Please enter a valid date and time.",
+      "futureDate": "The fuelling date/time cannot be in the future.",
+      "locationSet": "Location set."
+    },
+    "location": {
+      "adjustOnMap": "Adjust on map",
+      "hideMap": "Hide map",
+      "resolving": "Finding nearest station…",
+      "coords": "{{lat}}, {{lng}}",
+      "manualBadge": "Pinned",
+      "gpsBadge": "GPS",
+      "none": "No location yet — adjust on map to set one."
     }
   },
   "history": {
@@ -217,7 +231,11 @@
       "cancel": "Cancel",
       "receipt": "Receipt Photo",
       "updateReceipt": "Update Receipt Photo",
-      "receiptKept": "Current receipt will be kept unless replaced."
+      "receiptKept": "Current receipt will be kept unless replaced.",
+      "dateTime": "Date & time",
+      "location": "Location",
+      "invalidDate": "Please enter a valid date and time.",
+      "futureDate": "The date/time cannot be in the future."
     },
     "delete": {
       "confirm": "Delete this log entry? This action cannot be undone."
@@ -338,7 +356,9 @@
     "useValues": "Use Values",
     "discard": "Discard",
     "extractionFailed": "Failed to extract data from receipt.",
-    "autoFilled": "Fields auto-filled from receipt!"
+    "autoFilled": "Fields auto-filled from receipt!",
+    "date": "Date",
+    "location": "Location"
   },
   "import": {
     "title": "Import Fuel Logs",
@@ -529,5 +549,10 @@
     "sendSuccess": "Sent to {{sentCount}} device(s){{failedSuffix}}.",
     "sendFailedSuffix": ", {{failedCount}} failed",
     "sendError": "Failed to send notification."
+  },
+  "locationPicker": {
+    "useCurrentLocation": "Use my location",
+    "coords": "{{lat}}, {{lng}} — tap or drag the pin to adjust",
+    "tapToPlace": "Tap the map to drop a pin where you fuelled."
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -60,7 +60,8 @@
     "sections": {
       "vehicleStation": "Vehículo y Estación",
       "fuelCost": "Combustible y Coste",
-      "receipt": "Recibo"
+      "receipt": "Recibo",
+      "location": "Ubicación"
     },
     "fields": {
       "vehicle": "Vehículo",
@@ -77,7 +78,8 @@
       "converted": "Convertido: {{symbol}}{{amount}}",
       "odometerHintBaseline": "First odometer entry for this vehicle. Enter distance manually to establish a baseline.",
       "odometerHintCalculating": "Calculated from last log (Odo: {{last}} Km).",
-      "odometerErrorLower": "Odometer must be greater than previous ({{last}} Km)."
+      "odometerErrorLower": "Odometer must be greater than previous ({{last}} Km).",
+      "dateTime": "Fecha y hora del repostaje"
     },
     "submit": {
       "save": "Guardar Registro",
@@ -102,7 +104,19 @@
       "locationCapturedAt": "Located at {{station}}.",
       "receiptUploadWarning": "No se pudo subir la foto del recibo, así que el registro se guardó sin ella.",
       "stationLookupWarning": "No se pudo buscar una gasolinera cercana, así que este registro no se vinculó a ninguna.",
-      "stationMetricsWarning": "Tu registro se guardó, pero no se pudieron actualizar las estadísticas de precios de la gasolinera."
+      "stationMetricsWarning": "Tu registro se guardó, pero no se pudieron actualizar las estadísticas de precios de la gasolinera.",
+      "invalidDate": "Introduce una fecha y hora válidas.",
+      "futureDate": "La fecha/hora del repostaje no puede estar en el futuro.",
+      "locationSet": "Ubicación establecida."
+    },
+    "location": {
+      "adjustOnMap": "Ajustar en el mapa",
+      "hideMap": "Ocultar mapa",
+      "resolving": "Buscando la estación más cercana…",
+      "coords": "{{lat}}, {{lng}}",
+      "manualBadge": "Fijado",
+      "gpsBadge": "GPS",
+      "none": "Aún sin ubicación: ajústala en el mapa."
     }
   },
   "history": {
@@ -213,7 +227,11 @@
       "cancel": "Cancelar",
       "receipt": "Foto del Recibo",
       "updateReceipt": "Actualizar Foto del Recibo",
-      "receiptKept": "El recibo actual se conservará a menos que se reemplace."
+      "receiptKept": "El recibo actual se conservará a menos que se reemplace.",
+      "dateTime": "Fecha y hora",
+      "location": "Ubicación",
+      "invalidDate": "Introduce una fecha y hora válidas.",
+      "futureDate": "La fecha/hora no puede estar en el futuro."
     },
     "delete": {
       "confirm": "¿Eliminar esta entrada? Esta acción no se puede deshacer."
@@ -338,7 +356,9 @@
     "useValues": "Usar Valores",
     "discard": "Descartar",
     "extractionFailed": "Error al extraer datos del recibo.",
-    "autoFilled": "¡Campos autocompletados desde el recibo!"
+    "autoFilled": "¡Campos autocompletados desde el recibo!",
+    "date": "Fecha",
+    "location": "Ubicación"
   },
   "import": {
     "title": "Importar Registros de Combustible",
@@ -529,5 +549,10 @@
     "avgPrice": "Promedio: €{{price}}/L",
     "olderFuelings": "+ {{count}} repostajes anteriores",
     "fuelingsAtStation": "{{count}} repostajes en esta estación"
+  },
+  "locationPicker": {
+    "useCurrentLocation": "Usar mi ubicación",
+    "coords": "{{lat}}, {{lng}}: toca o arrastra el pin para ajustar",
+    "tapToPlace": "Toca el mapa para colocar un pin donde repostaste."
   }
 }

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -60,7 +60,8 @@
     "sections": {
       "vehicleStation": "Ajoneuvo & Asema",
       "fuelCost": "Polttoaine & Kustannus",
-      "receipt": "Kuitti"
+      "receipt": "Kuitti",
+      "location": "Sijainti"
     },
     "fields": {
       "vehicle": "Ajoneuvo",
@@ -77,7 +78,8 @@
       "converted": "Muunnettu: {{symbol}}{{amount}}",
       "odometerHintBaseline": "First odometer entry for this vehicle. Enter distance manually to establish a baseline.",
       "odometerHintCalculating": "Calculated from last log (Odo: {{last}} Km).",
-      "odometerErrorLower": "Odometer must be greater than previous ({{last}} Km)."
+      "odometerErrorLower": "Odometer must be greater than previous ({{last}} Km).",
+      "dateTime": "Tankkauksen päivä ja aika"
     },
     "submit": {
       "save": "Tallenna loki",
@@ -102,7 +104,19 @@
       "locationCapturedAt": "Located at {{station}}.",
       "receiptUploadWarning": "Kuittikuvaa ei voitu ladata, joten loki tallennettiin ilman sitä.",
       "stationLookupWarning": "Lähistöltä ei löytynyt asemaa, joten tätä lokia ei yhdistetty mihinkään.",
-      "stationMetricsWarning": "Lokisi tallennettiin, mutta aseman hintatietoja ei voitu päivittää."
+      "stationMetricsWarning": "Lokisi tallennettiin, mutta aseman hintatietoja ei voitu päivittää.",
+      "invalidDate": "Anna kelvollinen päivämäärä ja aika.",
+      "futureDate": "Tankkauksen aika ei voi olla tulevaisuudessa.",
+      "locationSet": "Sijainti asetettu."
+    },
+    "location": {
+      "adjustOnMap": "Säädä kartalla",
+      "hideMap": "Piilota kartta",
+      "resolving": "Etsitään lähintä asemaa…",
+      "coords": "{{lat}}, {{lng}}",
+      "manualBadge": "Merkitty",
+      "gpsBadge": "GPS",
+      "none": "Ei sijaintia vielä – aseta se kartalla."
     }
   },
   "history": {
@@ -213,7 +227,11 @@
       "cancel": "Peruuta",
       "receipt": "Kuittikuva",
       "updateReceipt": "Päivitä kuittikuva",
-      "receiptKept": "Nykyinen kuitti säilytetään, ellei sitä korvata."
+      "receiptKept": "Nykyinen kuitti säilytetään, ellei sitä korvata.",
+      "dateTime": "Päivä ja aika",
+      "location": "Sijainti",
+      "invalidDate": "Anna kelvollinen päivämäärä ja aika.",
+      "futureDate": "Päivä/aika ei voi olla tulevaisuudessa."
     },
     "delete": {
       "confirm": "Poistetaanko tämä merkintä? Toimintoa ei voi peruuttaa."
@@ -338,7 +356,9 @@
     "useValues": "Käytä arvoja",
     "discard": "Hylkää",
     "extractionFailed": "Tietojen haku kuitista epäonnistui.",
-    "autoFilled": "Kentät täytetty kuitista!"
+    "autoFilled": "Kentät täytetty kuitista!",
+    "date": "Päivämäärä",
+    "location": "Sijainti"
   },
   "import": {
     "title": "Tuo tankkauslokeja",
@@ -529,5 +549,10 @@
     "avgPrice": "Keskim.: €{{price}}/L",
     "olderFuelings": "+ {{count}} vanhempaa tankkaamista",
     "fuelingsAtStation": "{{count}} tankkaamista tällä asemalla"
+  },
+  "locationPicker": {
+    "useCurrentLocation": "Käytä sijaintiani",
+    "coords": "{{lat}}, {{lng}} – napauta tai vedä nastaa säätääksesi",
+    "tapToPlace": "Napauta karttaa asettaaksesi nastan tankkauspaikkaan."
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -60,7 +60,8 @@
     "sections": {
       "vehicleStation": "Véhicule et Station",
       "fuelCost": "Carburant et Coût",
-      "receipt": "Reçu"
+      "receipt": "Reçu",
+      "location": "Emplacement"
     },
     "fields": {
       "vehicle": "Véhicule",
@@ -77,7 +78,8 @@
       "converted": "Converti : {{symbol}}{{amount}}",
       "odometerHintBaseline": "First odometer entry for this vehicle. Enter distance manually to establish a baseline.",
       "odometerHintCalculating": "Calculated from last log (Odo: {{last}} Km).",
-      "odometerErrorLower": "Odometer must be greater than previous ({{last}} Km)."
+      "odometerErrorLower": "Odometer must be greater than previous ({{last}} Km).",
+      "dateTime": "Date et heure du plein"
     },
     "submit": {
       "save": "Enregistrer la Saisie",
@@ -102,7 +104,19 @@
       "locationCapturedAt": "Located at {{station}}.",
       "receiptUploadWarning": "La photo de votre reçu n'a pas pu être téléchargée, l'entrée a donc été enregistrée sans elle.",
       "stationLookupWarning": "Impossible de trouver une station à proximité, cette entrée n'a donc été liée à aucune.",
-      "stationMetricsWarning": "Votre entrée a été enregistrée, mais les statistiques de prix de la station n'ont pas pu être mises à jour."
+      "stationMetricsWarning": "Votre entrée a été enregistrée, mais les statistiques de prix de la station n'ont pas pu être mises à jour.",
+      "invalidDate": "Veuillez saisir une date et une heure valides.",
+      "futureDate": "La date/heure du plein ne peut pas être dans le futur.",
+      "locationSet": "Emplacement défini."
+    },
+    "location": {
+      "adjustOnMap": "Ajuster sur la carte",
+      "hideMap": "Masquer la carte",
+      "resolving": "Recherche de la station la plus proche…",
+      "coords": "{{lat}}, {{lng}}",
+      "manualBadge": "Épinglé",
+      "gpsBadge": "GPS",
+      "none": "Aucun emplacement pour l’instant — définissez-le sur la carte."
     }
   },
   "history": {
@@ -213,7 +227,11 @@
       "cancel": "Annuler",
       "receipt": "Photo du Reçu",
       "updateReceipt": "Mettre à Jour la Photo du Reçu",
-      "receiptKept": "Le reçu actuel sera conservé sauf remplacement."
+      "receiptKept": "Le reçu actuel sera conservé sauf remplacement.",
+      "dateTime": "Date et heure",
+      "location": "Emplacement",
+      "invalidDate": "Veuillez saisir une date et une heure valides.",
+      "futureDate": "La date/heure ne peut pas être dans le futur."
     },
     "delete": {
       "confirm": "Supprimer cette saisie ? Cette action est irréversible."
@@ -338,7 +356,9 @@
     "useValues": "Utiliser les Valeurs",
     "discard": "Ignorer",
     "extractionFailed": "Échec de l'extraction des données du reçu.",
-    "autoFilled": "Champs remplis automatiquement depuis le reçu !"
+    "autoFilled": "Champs remplis automatiquement depuis le reçu !",
+    "date": "Date",
+    "location": "Emplacement"
   },
   "import": {
     "title": "Importer des Saisies de Carburant",
@@ -529,5 +549,10 @@
     "avgPrice": "Moy. : €{{price}}/L",
     "olderFuelings": "+ {{count}} anciens ravitaillements",
     "fuelingsAtStation": "{{count}} ravitaillements à cette station"
+  },
+  "locationPicker": {
+    "useCurrentLocation": "Utiliser ma position",
+    "coords": "{{lat}}, {{lng}} — touchez ou faites glisser le repère pour ajuster",
+    "tapToPlace": "Touchez la carte pour placer un repère là où vous avez fait le plein."
   }
 }

--- a/src/i18n/locales/ga.json
+++ b/src/i18n/locales/ga.json
@@ -60,7 +60,8 @@
     "sections": {
       "vehicleStation": "Feithicil & Stáisiún",
       "fuelCost": "Breosla & Costas",
-      "receipt": "Admháil"
+      "receipt": "Admháil",
+      "location": "Suíomh"
     },
     "fields": {
       "vehicle": "Feithicil",
@@ -77,7 +78,8 @@
       "converted": "Tiontaithe: {{symbol}}{{amount}}",
       "odometerHintBaseline": "First odometer entry for this vehicle. Enter distance manually to establish a baseline.",
       "odometerHintCalculating": "Calculated from last log (Odo: {{last}} Km).",
-      "odometerErrorLower": "Odometer must be greater than previous ({{last}} Km)."
+      "odometerErrorLower": "Odometer must be greater than previous ({{last}} Km).",
+      "dateTime": "Dáta & am an bhreoslaithe"
     },
     "submit": {
       "save": "Sábháil Iontráil Breosla",
@@ -102,7 +104,19 @@
       "locationCapturedAt": "Located at {{station}}.",
       "receiptUploadWarning": "Níorbh fhéidir grianghraf an admhála a uaslódáil, mar sin sábháladh an logáil gan é.",
       "stationLookupWarning": "Níorbh fhéidir stáisiún in aice láimhe a aimsiú, mar sin níor nascadh an logáil seo le ceann ar bith.",
-      "stationMetricsWarning": "Sábháladh do logáil, ach níorbh fhéidir staitisticí praghais an stáisiúin a nuashonrú."
+      "stationMetricsWarning": "Sábháladh do logáil, ach níorbh fhéidir staitisticí praghais an stáisiúin a nuashonrú.",
+      "invalidDate": "Cuir isteach dáta agus am bailí.",
+      "futureDate": "Ní féidir le dáta/am an bhreoslaithe a bheith sa todhchaí.",
+      "locationSet": "Suíomh socraithe."
+    },
+    "location": {
+      "adjustOnMap": "Coigeartaigh ar an léarscáil",
+      "hideMap": "Folaigh an léarscáil",
+      "resolving": "Ag aimsiú an stáisiúin is gaire…",
+      "coords": "{{lat}}, {{lng}}",
+      "manualBadge": "Greamaithe",
+      "gpsBadge": "GPS",
+      "none": "Gan suíomh fós – socraigh ar an léarscáil é."
     }
   },
   "history": {
@@ -213,7 +227,11 @@
       "cancel": "Cealaigh",
       "receipt": "Grianghraf Admhála",
       "updateReceipt": "Nuashonraigh Grianghraf Admhála",
-      "receiptKept": "Coimeádfar an admháil reatha mura gcuirtear ceann eile ina áit."
+      "receiptKept": "Coimeádfar an admháil reatha mura gcuirtear ceann eile ina áit.",
+      "dateTime": "Dáta & am",
+      "location": "Suíomh",
+      "invalidDate": "Cuir isteach dáta agus am bailí.",
+      "futureDate": "Ní féidir leis an dáta/am a bheith sa todhchaí."
     },
     "delete": {
       "confirm": "An iontráil logála seo a scriosadh? Ní féidir an gníomh seo a chealú."
@@ -338,7 +356,9 @@
     "useValues": "Úsáid Luachanna",
     "discard": "Caith Uait",
     "extractionFailed": "Theip ar shonraí a eastóscadh ón admháil.",
-    "autoFilled": "Réimsí uathlíonta ón admháil!"
+    "autoFilled": "Réimsí uathlíonta ón admháil!",
+    "date": "Dáta",
+    "location": "Suíomh"
   },
   "import": {
     "title": "Iompórtáil Logaí Breosla",
@@ -529,5 +549,10 @@
     "avgPrice": "Meán: €{{price}}/L",
     "olderFuelings": "+ {{count}} seanbhealaí",
     "fuelingsAtStation": "{{count}} bhealaí ag an stáisiún seo"
+  },
+  "locationPicker": {
+    "useCurrentLocation": "Úsáid mo shuíomh",
+    "coords": "{{lat}}, {{lng}} – tapáil nó tarraing an biorán chun é a choigeartú",
+    "tapToPlace": "Tapáil an léarscáil chun biorán a chur san áit ar bhreoslaigh tú."
   }
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -60,7 +60,8 @@
     "sections": {
       "vehicleStation": "車両・ガソリンスタンド",
       "fuelCost": "燃料・費用",
-      "receipt": "レシート"
+      "receipt": "レシート",
+      "location": "場所"
     },
     "fields": {
       "vehicle": "車両",
@@ -77,7 +78,8 @@
       "converted": "換算後：{{symbol}}{{amount}}",
       "odometerHintBaseline": "First odometer entry for this vehicle. Enter distance manually to establish a baseline.",
       "odometerHintCalculating": "Calculated from last log (Odo: {{last}} Km).",
-      "odometerErrorLower": "Odometer must be greater than previous ({{last}} Km)."
+      "odometerErrorLower": "Odometer must be greater than previous ({{last}} Km).",
+      "dateTime": "給油の日時"
     },
     "submit": {
       "save": "記録を保存",
@@ -102,7 +104,19 @@
       "locationCapturedAt": "Located at {{station}}.",
       "receiptUploadWarning": "レシート写真をアップロードできなかったため、記録はそれなしで保存されました。",
       "stationLookupWarning": "近くのガソリンスタンドを検索できなかったため、この記録はどのスタンドにも関連付けられませんでした。",
-      "stationMetricsWarning": "記録は保存されましたが、スタンドの価格統計を更新できませんでした。"
+      "stationMetricsWarning": "記録は保存されましたが、スタンドの価格統計を更新できませんでした。",
+      "invalidDate": "有効な日付と時刻を入力してください。",
+      "futureDate": "給油の日時を未来に設定することはできません。",
+      "locationSet": "場所を設定しました。"
+    },
+    "location": {
+      "adjustOnMap": "地図で調整",
+      "hideMap": "地図を隠す",
+      "resolving": "最寄りのスタンドを検索中…",
+      "coords": "{{lat}}, {{lng}}",
+      "manualBadge": "ピン留め",
+      "gpsBadge": "GPS",
+      "none": "場所が未設定です。地図で設定してください。"
     }
   },
   "history": {
@@ -213,7 +227,11 @@
       "cancel": "キャンセル",
       "receipt": "レシート写真",
       "updateReceipt": "レシート写真を更新",
-      "receiptKept": "現在のレシートは置き換えない限り保持されます。"
+      "receiptKept": "現在のレシートは置き換えない限り保持されます。",
+      "dateTime": "日時",
+      "location": "場所",
+      "invalidDate": "有効な日付と時刻を入力してください。",
+      "futureDate": "日時を未来に設定することはできません。"
     },
     "delete": {
       "confirm": "この記録を削除しますか？この操作は元に戻せません。"
@@ -338,7 +356,9 @@
     "useValues": "値を使用",
     "discard": "破棄",
     "extractionFailed": "レシートからのデータ抽出に失敗しました。",
-    "autoFilled": "レシートからフィールドが自動入力されました！"
+    "autoFilled": "レシートからフィールドが自動入力されました！",
+    "date": "日付",
+    "location": "場所"
   },
   "import": {
     "title": "燃料記録をインポート",
@@ -529,5 +549,10 @@
     "avgPrice": "平均: €{{price}}/L",
     "olderFuelings": "+ {{count}} 件の過去の給油",
     "fuelingsAtStation": "このステーションでの給油 {{count}} 件"
+  },
+  "locationPicker": {
+    "useCurrentLocation": "現在地を使用",
+    "coords": "{{lat}}, {{lng}} — タップまたはピンをドラッグして調整",
+    "tapToPlace": "給油した場所を地図をタップしてピンを置いてください。"
   }
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -60,7 +60,8 @@
     "sections": {
       "vehicleStation": "차량 및 주유소",
       "fuelCost": "연료 및 비용",
-      "receipt": "영수증"
+      "receipt": "영수증",
+      "location": "위치"
     },
     "fields": {
       "vehicle": "차량",
@@ -77,7 +78,8 @@
       "converted": "환산: {{symbol}}{{amount}}",
       "odometerHintBaseline": "First odometer entry for this vehicle. Enter distance manually to establish a baseline.",
       "odometerHintCalculating": "Calculated from last log (Odo: {{last}} Km).",
-      "odometerErrorLower": "Odometer must be greater than previous ({{last}} Km)."
+      "odometerErrorLower": "Odometer must be greater than previous ({{last}} Km).",
+      "dateTime": "주유 날짜 및 시간"
     },
     "submit": {
       "save": "기록 저장",
@@ -102,7 +104,19 @@
       "locationCapturedAt": "Located at {{station}}.",
       "receiptUploadWarning": "영수증 사진을 업로드할 수 없어 기록이 사진 없이 저장되었습니다.",
       "stationLookupWarning": "근처 주유소를 찾을 수 없어 이 기록이 주유소와 연결되지 않았습니다.",
-      "stationMetricsWarning": "기록은 저장되었지만 주유소의 가격 통계를 업데이트할 수 없습니다."
+      "stationMetricsWarning": "기록은 저장되었지만 주유소의 가격 통계를 업데이트할 수 없습니다.",
+      "invalidDate": "유효한 날짜와 시간을 입력하세요.",
+      "futureDate": "주유 날짜/시간은 미래일 수 없습니다.",
+      "locationSet": "위치가 설정되었습니다."
+    },
+    "location": {
+      "adjustOnMap": "지도에서 조정",
+      "hideMap": "지도 숨기기",
+      "resolving": "가장 가까운 주유소 검색 중…",
+      "coords": "{{lat}}, {{lng}}",
+      "manualBadge": "고정됨",
+      "gpsBadge": "GPS",
+      "none": "아직 위치가 없습니다 — 지도에서 설정하세요."
     }
   },
   "history": {
@@ -213,7 +227,11 @@
       "cancel": "취소",
       "receipt": "영수증 사진",
       "updateReceipt": "영수증 사진 업데이트",
-      "receiptKept": "교체하지 않으면 현재 영수증이 유지됩니다."
+      "receiptKept": "교체하지 않으면 현재 영수증이 유지됩니다.",
+      "dateTime": "날짜 및 시간",
+      "location": "위치",
+      "invalidDate": "유효한 날짜와 시간을 입력하세요.",
+      "futureDate": "날짜/시간은 미래일 수 없습니다."
     },
     "delete": {
       "confirm": "이 기록을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
@@ -338,7 +356,9 @@
     "useValues": "값 사용",
     "discard": "버리기",
     "extractionFailed": "영수증에서 데이터를 추출하는 데 실패했습니다.",
-    "autoFilled": "영수증에서 필드가 자동 입력되었습니다!"
+    "autoFilled": "영수증에서 필드가 자동 입력되었습니다!",
+    "date": "날짜",
+    "location": "위치"
   },
   "import": {
     "title": "연료 기록 가져오기",
@@ -529,5 +549,10 @@
     "avgPrice": "평균: €{{price}}/L",
     "olderFuelings": "+ {{count}} 건의 이전 주유",
     "fuelingsAtStation": "이 주유소에서의 주유 {{count}} 건"
+  },
+  "locationPicker": {
+    "useCurrentLocation": "내 위치 사용",
+    "coords": "{{lat}}, {{lng}} — 핀을 탭하거나 드래그하여 조정",
+    "tapToPlace": "주유한 위치를 지도에서 탭하여 핀을 놓으세요."
   }
 }

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -60,7 +60,8 @@
     "sections": {
       "vehicleStation": "Kjøretøy og stasjon",
       "fuelCost": "Drivstoff og kostnad",
-      "receipt": "Kvittering"
+      "receipt": "Kvittering",
+      "location": "Sted"
     },
     "fields": {
       "vehicle": "Kjøretøy",
@@ -77,7 +78,8 @@
       "converted": "Konvertert: {{symbol}}{{amount}}",
       "odometerHintBaseline": "First odometer entry for this vehicle. Enter distance manually to establish a baseline.",
       "odometerHintCalculating": "Calculated from last log (Odo: {{last}} Km).",
-      "odometerErrorLower": "Odometer must be greater than previous ({{last}} Km)."
+      "odometerErrorLower": "Odometer must be greater than previous ({{last}} Km).",
+      "dateTime": "Dato og tid for fylling"
     },
     "submit": {
       "save": "Lagre drivstofflogg",
@@ -102,7 +104,19 @@
       "locationCapturedAt": "Located at {{station}}.",
       "receiptUploadWarning": "Kvitteringsbildet kunne ikke lastes opp, så loggen ble lagret uten det.",
       "stationLookupWarning": "Kunne ikke finne en stasjon i nærheten, så denne loggen ble ikke koblet til noen.",
-      "stationMetricsWarning": "Loggen din ble lagret, men stasjonens prisstatistikk kunne ikke oppdateres."
+      "stationMetricsWarning": "Loggen din ble lagret, men stasjonens prisstatistikk kunne ikke oppdateres.",
+      "invalidDate": "Skriv inn en gyldig dato og tid.",
+      "futureDate": "Dato/tid for fylling kan ikke være i fremtiden.",
+      "locationSet": "Plassering angitt."
+    },
+    "location": {
+      "adjustOnMap": "Juster på kartet",
+      "hideMap": "Skjul kart",
+      "resolving": "Finner nærmeste stasjon…",
+      "coords": "{{lat}}, {{lng}}",
+      "manualBadge": "Festet",
+      "gpsBadge": "GPS",
+      "none": "Ingen plassering ennå – angi den på kartet."
     }
   },
   "history": {
@@ -213,7 +227,11 @@
       "cancel": "Avbryt",
       "receipt": "Kvitteringsbilde",
       "updateReceipt": "Oppdater kvitteringsbilde",
-      "receiptKept": "Gjeldende kvittering beholdes med mindre den erstattes."
+      "receiptKept": "Gjeldende kvittering beholdes med mindre den erstattes.",
+      "dateTime": "Dato og tid",
+      "location": "Sted",
+      "invalidDate": "Skriv inn en gyldig dato og tid.",
+      "futureDate": "Dato/tid kan ikke være i fremtiden."
     },
     "delete": {
       "confirm": "Slett denne loggoppføringen? Denne handlingen kan ikke angres."
@@ -338,7 +356,9 @@
     "useValues": "Bruk verdier",
     "discard": "Forkast",
     "extractionFailed": "Kunne ikke hente data fra kvittering.",
-    "autoFilled": "Felt fylt ut automatisk fra kvittering!"
+    "autoFilled": "Felt fylt ut automatisk fra kvittering!",
+    "date": "Dato",
+    "location": "Sted"
   },
   "import": {
     "title": "Importer drivstofflogger",
@@ -529,5 +549,10 @@
     "avgPrice": "Gjennomsnitt: €{{price}}/L",
     "olderFuelings": "+ {{count}} eldre tanking",
     "fuelingsAtStation": "{{count}} tanking på denne stasjonen"
+  },
+  "locationPicker": {
+    "useCurrentLocation": "Bruk min posisjon",
+    "coords": "{{lat}}, {{lng}} – trykk eller dra nålen for å justere",
+    "tapToPlace": "Trykk på kartet for å plassere en nål der du fylte."
   }
 }

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -60,7 +60,8 @@
     "sections": {
       "vehicleStation": "Fordon & Station",
       "fuelCost": "Bränsle & Kostnad",
-      "receipt": "Kvitto"
+      "receipt": "Kvitto",
+      "location": "Plats"
     },
     "fields": {
       "vehicle": "Fordon",
@@ -77,7 +78,8 @@
       "converted": "Konverterat: {{symbol}}{{amount}}",
       "odometerHintBaseline": "First odometer entry for this vehicle. Enter distance manually to establish a baseline.",
       "odometerHintCalculating": "Calculated from last log (Odo: {{last}} Km).",
-      "odometerErrorLower": "Odometer must be greater than previous ({{last}} Km)."
+      "odometerErrorLower": "Odometer must be greater than previous ({{last}} Km).",
+      "dateTime": "Datum och tid för tankning"
     },
     "submit": {
       "save": "Spara bränslelogg",
@@ -102,7 +104,19 @@
       "locationCapturedAt": "Located at {{station}}.",
       "receiptUploadWarning": "Kvittofotot kunde inte laddas upp, så loggen sparades utan det.",
       "stationLookupWarning": "Det gick inte att hitta en station i närheten, så den här loggen kopplades inte till någon.",
-      "stationMetricsWarning": "Din logg sparades, men stationens prisstatistik kunde inte uppdateras."
+      "stationMetricsWarning": "Din logg sparades, men stationens prisstatistik kunde inte uppdateras.",
+      "invalidDate": "Ange ett giltigt datum och tid.",
+      "futureDate": "Tankningens datum/tid kan inte vara i framtiden.",
+      "locationSet": "Plats angiven."
+    },
+    "location": {
+      "adjustOnMap": "Justera på kartan",
+      "hideMap": "Dölj karta",
+      "resolving": "Söker närmaste station…",
+      "coords": "{{lat}}, {{lng}}",
+      "manualBadge": "Fäst",
+      "gpsBadge": "GPS",
+      "none": "Ingen plats ännu – ange den på kartan."
     }
   },
   "history": {
@@ -213,7 +227,11 @@
       "cancel": "Avbryt",
       "receipt": "Kvittofoto",
       "updateReceipt": "Uppdatera kvittofoto",
-      "receiptKept": "Nuvarande kvitto behålls om det inte ersätts."
+      "receiptKept": "Nuvarande kvitto behålls om det inte ersätts.",
+      "dateTime": "Datum och tid",
+      "location": "Plats",
+      "invalidDate": "Ange ett giltigt datum och tid.",
+      "futureDate": "Datum/tid kan inte vara i framtiden."
     },
     "delete": {
       "confirm": "Radera detta logginlägg? Denna åtgärd kan inte ångras."
@@ -338,7 +356,9 @@
     "useValues": "Använd värden",
     "discard": "Släng",
     "extractionFailed": "Misslyckades med att extrahera data från kvitto.",
-    "autoFilled": "Fält fylldes i automatiskt från kvitto!"
+    "autoFilled": "Fält fylldes i automatiskt från kvitto!",
+    "date": "Datum",
+    "location": "Plats"
   },
   "import": {
     "title": "Importera bränsleloggar",
@@ -529,5 +549,10 @@
     "avgPrice": "Genomsnitt: €{{price}}/L",
     "olderFuelings": "+ {{count}} äldre tankning",
     "fuelingsAtStation": "{{count}} tankning på denna station"
+  },
+  "locationPicker": {
+    "useCurrentLocation": "Använd min plats",
+    "coords": "{{lat}}, {{lng}} – tryck eller dra nålen för att justera",
+    "tapToPlace": "Tryck på kartan för att placera en nål där du tankade."
   }
 }

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -365,14 +365,13 @@ function HistoryPage(): JSX.Element {
         if (latitude && (isNaN(parsedLat!) || parsedLat! < -90 || parsedLat! > 90)) { setModalError('Latitude must be a number between -90 and 90.'); return; }
         if (longitude && (isNaN(parsedLon!) || parsedLon! < -180 || parsedLon! > 180)) { setModalError('Longitude must be a number between -180 and 180.'); return; }
 
-        // Validate the (optional) edited fuelling date/time.
-        let editedTimestamp: Timestamp | undefined;
-        if (loggedAt) {
-            const d = new Date(loggedAt);
-            if (isNaN(d.getTime())) { setModalError(t('history.edit.invalidDate', { defaultValue: 'Please enter a valid date and time.' })); return; }
-            if (d.getTime() > Date.now() + 60_000) { setModalError(t('history.edit.futureDate', { defaultValue: 'The date/time cannot be in the future.' })); return; }
-            editedTimestamp = Timestamp.fromDate(d);
-        }
+        // Validate the edited fuelling date/time (required — every log must keep
+        // a timestamp; an empty field would otherwise silently leave the old one).
+        if (!loggedAt) { setModalError(t('history.edit.invalidDate', { defaultValue: 'Please enter a valid date and time.' })); return; }
+        const editedDate = new Date(loggedAt);
+        if (isNaN(editedDate.getTime())) { setModalError(t('history.edit.invalidDate', { defaultValue: 'Please enter a valid date and time.' })); return; }
+        if (editedDate.getTime() > Date.now() + 60_000) { setModalError(t('history.edit.futureDate', { defaultValue: 'The date/time cannot be in the future.' })); return; }
+        const editedTimestamp: Timestamp = Timestamp.fromDate(editedDate);
 
         setIsUpdating(true); setModalError(null);
         try {
@@ -399,9 +398,7 @@ function HistoryPage(): JSX.Element {
                 updatedData.latitude = parsedLat;
                 updatedData.longitude = parsedLon;
             }
-            if (editedTimestamp) {
-                updatedData.timestamp = editedTimestamp;
-            }
+            updatedData.timestamp = editedTimestamp;
             await updateDoc(logRef, updatedData);
             setLogs(prev => prev.map(l => l.id === editingLog.id ? { ...l, ...updatedData } : l)
                 .filter(l => !filterVehicleId || l.vehicleId === filterVehicleId)
@@ -669,7 +666,7 @@ function HistoryPage(): JSX.Element {
                             {/* Date & time of fuelling */}
                             <div>
                                 <label htmlFor="edit-loggedAt" className="block text-sm font-medium text-gray-700 dark:text-gray-300">{t('history.edit.dateTime', { defaultValue: 'Date & time' })}</label>
-                                <input type="datetime-local" name="loggedAt" id="edit-loggedAt" value={editFormData.loggedAt || ''} max={toDatetimeLocal(new Date())} onChange={handleEditFormChange} className="mt-1 w-full px-3 py-2 border border-gray-300 dark:border-gray-700 dark:bg-gray-700 dark:text-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" />
+                                <input type="datetime-local" name="loggedAt" id="edit-loggedAt" value={editFormData.loggedAt || ''} max={toDatetimeLocal(new Date())} onChange={handleEditFormChange} required className="mt-1 w-full px-3 py-2 border border-gray-300 dark:border-gray-700 dark:bg-gray-700 dark:text-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" />
                             </div>
                             {/* Form Inputs (Brand, Cost, Distance, Fuel) */}
                             <div><label htmlFor="edit-brand" className="block text-sm font-medium text-gray-700 dark:text-gray-300">{t('history.edit.brand')}</label><input type="text" name="brand" id="edit-brand" value={editFormData.brand} onChange={handleEditFormChange} className="mt-1 w-full px-3 py-2 border border-gray-300 dark:border-gray-700 dark:bg-gray-700 dark:text-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" /></div>

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -23,7 +23,8 @@ import { COMMON_CURRENCIES } from '../utils/currencyApi';
 import ImageUpload from '../components/ImageUpload';
 import { uploadReceipt } from '../firebase/storageService';
 import { sanitizeUrl } from '../utils/sanitize';
-import { formatDate } from '../utils/formatDate';
+import { formatDate, toDatetimeLocal } from '../utils/formatDate';
+import LocationPicker, { PickerCoords } from '../components/LocationPicker';
 import { fetchUserStations } from '../firebase/firestoreService';
 import { Station } from '../utils/types';
 
@@ -320,7 +321,8 @@ function HistoryPage(): JSX.Element {
             odometerKm: log.odometerKm?.toString() || '',
             vehicleId: log.vehicleId || '',
             latitude: log.latitude?.toString() || '',
-            longitude: log.longitude?.toString() || ''
+            longitude: log.longitude?.toString() || '',
+            loggedAt: log.timestamp ? toDatetimeLocal(log.timestamp.toDate()) : ''
         });
         setEditReceiptFile(null);
         setModalError(null); setIsModalOpen(true);
@@ -329,7 +331,7 @@ function HistoryPage(): JSX.Element {
     /** Closes the edit modal and resets state. */
     const handleCloseModal = () => {
         setIsModalOpen(false); setEditingLog(null);
-        setEditFormData({ brand: '', cost: '', distanceKm: '', fuelAmountLiters: '', odometerKm: '', latitude: '', longitude: '' });
+        setEditFormData({ brand: '', cost: '', distanceKm: '', fuelAmountLiters: '', odometerKm: '', latitude: '', longitude: '', loggedAt: '' });
         setEditReceiptFile(null);
         setModalError(null); setIsUpdating(false);
     };
@@ -340,10 +342,19 @@ function HistoryPage(): JSX.Element {
         setEditFormData(prev => ({ ...prev, [name]: value }));
     };
 
+    /** Updates the edited log's coordinates when the map pin moves. */
+    const handleEditPinChange = (coords: PickerCoords) => {
+        setEditFormData(prev => ({
+            ...prev,
+            latitude: coords.latitude.toFixed(6),
+            longitude: coords.longitude.toFixed(6),
+        }));
+    };
+
     /** Handles submission of the edit form, validates, and updates Firestore. */
     const handleUpdateLog = async (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault(); if (!editingLog) return;
-        const { brand, cost, distanceKm, fuelAmountLiters, odometerKm, latitude, longitude } = editFormData;
+        const { brand, cost, distanceKm, fuelAmountLiters, odometerKm, latitude, longitude, loggedAt } = editFormData;
         if (!cost || !distanceKm || !fuelAmountLiters) { setModalError('Cost, Distance, and Fuel Amount cannot be empty.'); return; }
         const parsedCost = parseFloat(cost); const parsedDistanceKm = parseFloat(distanceKm); const parsedFuel = parseFloat(fuelAmountLiters);
         const parsedOdometer = parseFloat(odometerKm);
@@ -353,6 +364,15 @@ function HistoryPage(): JSX.Element {
         if (isNaN(parsedCost) || isNaN(parsedDistanceKm) || isNaN(parsedFuel) || parsedCost <= 0 || parsedDistanceKm <= 0 || parsedFuel <= 0) { setModalError('Cost, Distance (Km), and Fuel Amount must be valid positive numbers.'); return; }
         if (latitude && (isNaN(parsedLat!) || parsedLat! < -90 || parsedLat! > 90)) { setModalError('Latitude must be a number between -90 and 90.'); return; }
         if (longitude && (isNaN(parsedLon!) || parsedLon! < -180 || parsedLon! > 180)) { setModalError('Longitude must be a number between -180 and 180.'); return; }
+
+        // Validate the (optional) edited fuelling date/time.
+        let editedTimestamp: Timestamp | undefined;
+        if (loggedAt) {
+            const d = new Date(loggedAt);
+            if (isNaN(d.getTime())) { setModalError(t('history.edit.invalidDate', { defaultValue: 'Please enter a valid date and time.' })); return; }
+            if (d.getTime() > Date.now() + 60_000) { setModalError(t('history.edit.futureDate', { defaultValue: 'The date/time cannot be in the future.' })); return; }
+            editedTimestamp = Timestamp.fromDate(d);
+        }
 
         setIsUpdating(true); setModalError(null);
         try {
@@ -378,6 +398,9 @@ function HistoryPage(): JSX.Element {
             if (parsedLat !== undefined && parsedLon !== undefined) {
                 updatedData.latitude = parsedLat;
                 updatedData.longitude = parsedLon;
+            }
+            if (editedTimestamp) {
+                updatedData.timestamp = editedTimestamp;
             }
             await updateDoc(logRef, updatedData);
             setLogs(prev => prev.map(l => l.id === editingLog.id ? { ...l, ...updatedData } : l)
@@ -643,6 +666,11 @@ function HistoryPage(): JSX.Element {
                                     {vehicles.map(v => <option key={v.id} value={v.id}>{v.name}</option>)}
                                 </select>
                             </div>
+                            {/* Date & time of fuelling */}
+                            <div>
+                                <label htmlFor="edit-loggedAt" className="block text-sm font-medium text-gray-700 dark:text-gray-300">{t('history.edit.dateTime', { defaultValue: 'Date & time' })}</label>
+                                <input type="datetime-local" name="loggedAt" id="edit-loggedAt" value={editFormData.loggedAt || ''} max={toDatetimeLocal(new Date())} onChange={handleEditFormChange} className="mt-1 w-full px-3 py-2 border border-gray-300 dark:border-gray-700 dark:bg-gray-700 dark:text-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" />
+                            </div>
                             {/* Form Inputs (Brand, Cost, Distance, Fuel) */}
                             <div><label htmlFor="edit-brand" className="block text-sm font-medium text-gray-700 dark:text-gray-300">{t('history.edit.brand')}</label><input type="text" name="brand" id="edit-brand" value={editFormData.brand} onChange={handleEditFormChange} className="mt-1 w-full px-3 py-2 border border-gray-300 dark:border-gray-700 dark:bg-gray-700 dark:text-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" /></div>
                             <div><label htmlFor="edit-cost" className="block text-sm font-medium text-gray-700 dark:text-gray-300">{t('history.edit.cost', { currency: homeCurrency })}</label><input type="number" inputMode="decimal" name="cost" id="edit-cost" value={editFormData.cost} onChange={handleEditFormChange} step="0.01" min="0.01" required className="mt-1 w-full px-3 py-2 border border-gray-300 dark:border-gray-700 dark:bg-gray-700 dark:text-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" /></div>
@@ -653,6 +681,17 @@ function HistoryPage(): JSX.Element {
                                <div><label htmlFor="edit-distanceKm" className="block text-sm font-medium text-gray-700 dark:text-gray-300">{t('history.edit.distance')}</label><input type="number" inputMode="decimal" name="distanceKm" id="edit-distanceKm" value={editFormData.distanceKm} onChange={handleEditFormChange} step="0.1" min="0.1" required className="mt-1 w-full px-3 py-2 border border-gray-300 dark:border-gray-700 dark:bg-gray-700 dark:text-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" /></div>
                             </div>                            <div><label htmlFor="edit-fuelAmountLiters" className="block text-sm font-medium text-gray-700 dark:text-gray-300">{t('history.edit.fuel')}</label><input type="number" inputMode="decimal" name="fuelAmountLiters" id="edit-fuelAmountLiters" value={editFormData.fuelAmountLiters} onChange={handleEditFormChange} step="0.01" min="0.01" required className="w-full px-3 py-2 border border-gray-300 dark:border-gray-700 dark:bg-gray-700 dark:text-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" /></div>                            
                             {/* Location Editing */}
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{t('history.edit.location', { defaultValue: 'Location' })}</label>
+                                <LocationPicker
+                                    value={(() => {
+                                        const lat = parseFloat(editFormData.latitude || '');
+                                        const lng = parseFloat(editFormData.longitude || '');
+                                        return !isNaN(lat) && !isNaN(lng) ? { latitude: lat, longitude: lng } : null;
+                                    })()}
+                                    onChange={handleEditPinChange}
+                                />
+                            </div>
                             <div className="grid grid-cols-2 gap-3">
                                 <div><label htmlFor="edit-latitude" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Latitude</label><input type="number" inputMode="decimal" name="latitude" id="edit-latitude" value={editFormData.latitude} onChange={handleEditFormChange} step="0.000001" min="-90" max="90" className="mt-1 w-full px-3 py-2 border border-gray-300 dark:border-gray-700 dark:bg-gray-700 dark:text-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" placeholder="e.g. 51.5074" /></div>
                                 <div><label htmlFor="edit-longitude" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Longitude</label><input type="number" inputMode="decimal" name="longitude" id="edit-longitude" value={editFormData.longitude} onChange={handleEditFormChange} step="0.000001" min="-180" max="180" className="mt-1 w-full px-3 py-2 border border-gray-300 dark:border-gray-700 dark:bg-gray-700 dark:text-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" placeholder="e.g. -0.1278" /></div>

--- a/src/pages/QuickLogPage.test.tsx
+++ b/src/pages/QuickLogPage.test.tsx
@@ -4,9 +4,19 @@ import { addDoc, getDocs } from 'firebase/firestore';
 import { fetchExchangeRate } from '../utils/currencyApi';
 import { getLastOdometerReading, getOrCreateStation, updateStationMetrics } from '../firebase/firestoreService';
 import { extractDataFromReceipt } from '../utils/gemini';
-import { findNearestStation, isAccurateEnoughForStationMatch } from '../utils/locationService';
+import { findNearestStation, geocodeAddress, isAccurateEnoughForStationMatch } from '../utils/locationService';
 import QuickLogPage from './QuickLogPage';
 import { MemoryRouter } from 'react-router-dom';
+
+// Stub the Leaflet-based picker so these tests don't mount a real map; the
+// picker has its own unit tests. Exposes a button that reports a fixed pin.
+vi.mock('../components/LocationPicker', () => ({
+  default: ({ onChange }: { onChange: (c: { latitude: number; longitude: number }) => void }) => (
+    <button type="button" data-testid="pick-location" onClick={() => onChange({ latitude: 1.5, longitude: 2.5 })}>
+      pick
+    </button>
+  ),
+}));
 
 const mockT = (key: string, opts?: Record<string, unknown>) => {
   const template = opts && 'defaultValue' in opts ? (opts.defaultValue as string) : key;
@@ -211,6 +221,72 @@ describe('QuickLogPage', () => {
     expect((screen.getByLabelText('quickLog.fields.totalCost') as HTMLInputElement).value).toBe('42.5');
     expect((screen.getByLabelText('quickLog.fields.fuel') as HTMLInputElement).value).toBe('28');
     expect((screen.getByLabelText(/quickLog\.fields\.fillingStation/) as HTMLInputElement).value).toBe('Esso');
+  });
+
+  it('pre-fills the date/time field from the receipt', async () => {
+    vi.mocked(extractDataFromReceipt).mockResolvedValue({
+      cost: null, fuelAmountLiters: null, brand: null,
+      purchaseDate: '2026-06-20', purchaseTime: '14:30', address: null,
+    });
+
+    render(<MemoryRouter><QuickLogPage /></MemoryRouter>);
+    await waitFor(() => expect(screen.getByLabelText('quickLog.fields.totalCost')).toBeInTheDocument());
+
+    const file = new File(['mock'], 'receipt.jpg', { type: 'image/jpeg' });
+    fireEvent.change(document.querySelector('input[type="file"]') as HTMLInputElement, { target: { files: [file] } });
+    fireEvent.click(await screen.findByRole('button', { name: 'receipt.autoFillWithAI' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'receipt.useValues' }));
+
+    expect((screen.getByLabelText('Date & time of fuelling') as HTMLInputElement).value).toBe('2026-06-20T14:30');
+  });
+
+  it('geocodes the receipt address to default the map pin', async () => {
+    vi.mocked(extractDataFromReceipt).mockResolvedValue({
+      cost: 10, fuelAmountLiters: 5, brand: 'Esso',
+      purchaseDate: null, purchaseTime: null, address: '1 Main St, Dublin',
+    });
+    vi.mocked(geocodeAddress).mockResolvedValue({ latitude: 10, longitude: 20 });
+    vi.mocked(findNearestStation).mockResolvedValue(null);
+
+    render(<MemoryRouter><QuickLogPage /></MemoryRouter>);
+    await waitFor(() => expect(screen.getByLabelText('quickLog.fields.totalCost')).toBeInTheDocument());
+
+    const file = new File(['mock'], 'receipt.jpg', { type: 'image/jpeg' });
+    fireEvent.change(document.querySelector('input[type="file"]') as HTMLInputElement, { target: { files: [file] } });
+    fireEvent.click(await screen.findByRole('button', { name: 'receipt.autoFillWithAI' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'receipt.useValues' }));
+
+    await waitFor(() => expect(geocodeAddress).toHaveBeenCalledWith('1 Main St, Dublin'));
+    // The pin becomes a manual location once geocoded.
+    await waitFor(() => expect(screen.getByText('Pinned')).toBeInTheDocument());
+  });
+
+  it('saves a manually pinned location (no accuracy) and links its station', async () => {
+    const mockStation = {
+      id: 'station-9', osmId: 'node/9', name: 'Pinned Station', brand: 'Shell',
+      latitude: 1.5, longitude: 2.5,
+    };
+    vi.mocked(findNearestStation).mockResolvedValue(mockStation);
+    vi.mocked(getOrCreateStation).mockResolvedValue('station-9');
+
+    render(<MemoryRouter><QuickLogPage /></MemoryRouter>);
+    await waitFor(() => expect(screen.getByLabelText('quickLog.fields.totalCost')).toBeInTheDocument());
+
+    // Open the map and drop a pin via the stubbed picker.
+    fireEvent.click(screen.getByRole('button', { name: 'Adjust on map' }));
+    fireEvent.click(screen.getByTestId('pick-location'));
+    await waitFor(() => expect(findNearestStation).toHaveBeenCalledWith(1.5, 2.5));
+
+    fireEvent.change(screen.getByLabelText('quickLog.fields.totalCost'), { target: { value: '50' } });
+    fireEvent.change(screen.getByLabelText('quickLog.fields.distance'), { target: { value: '400' } });
+    fireEvent.change(screen.getByLabelText('quickLog.fields.fuel'), { target: { value: '30' } });
+    fireEvent.click(screen.getByRole('button', { name: /quickLog.submit.save/ }));
+
+    await waitFor(() => expect(addDoc).toHaveBeenCalledTimes(1));
+    const [, payload] = vi.mocked(addDoc).mock.calls[0];
+    expect(payload).toMatchObject({ latitude: 1.5, longitude: 2.5, stationId: 'station-9' });
+    // Manual pins carry no GPS accuracy figure.
+    expect(payload).not.toHaveProperty('locationAccuracy');
   });
 
   describe('low GPS accuracy warning', () => {

--- a/src/pages/QuickLogPage.test.tsx
+++ b/src/pages/QuickLogPage.test.tsx
@@ -74,6 +74,8 @@ vi.mock('../utils/gemini', () => ({
 
 vi.mock('../utils/locationService', () => ({
   findNearestStation: vi.fn().mockResolvedValue(null),
+  geocodeAddress: vi.fn().mockResolvedValue(null),
+  getCurrentPosition: vi.fn().mockResolvedValue(null),
   isAccurateEnoughForStationMatch: vi.fn(() => true),
   GPS_ACCURACY_THRESHOLD_METERS: 100,
 }));
@@ -188,7 +190,7 @@ describe('QuickLogPage', () => {
   });
 
   it('extracts and pre-fills form fields from a receipt image', async () => {
-    vi.mocked(extractDataFromReceipt).mockResolvedValue({ cost: 42.5, fuelAmountLiters: 28, brand: 'Esso' });
+    vi.mocked(extractDataFromReceipt).mockResolvedValue({ cost: 42.5, fuelAmountLiters: 28, brand: 'Esso', purchaseDate: null, purchaseTime: null, address: null });
 
     render(<MemoryRouter><QuickLogPage /></MemoryRouter>);
 

--- a/src/pages/QuickLogPage.tsx
+++ b/src/pages/QuickLogPage.tsx
@@ -125,9 +125,10 @@ function QuickLogPage(): JSX.Element {
         if (!isNaN(parsed.getTime())) setLoggedAt(toDatetimeLocal(parsed));
       }
 
-      // Best-effort: geocode the receipt's address (or brand) to default the
-      // map pin near the station. Falls back silently to the existing pin.
-      const geoQuery = extractedData.address || extractedData.brand;
+      // Best-effort: geocode the receipt's printed address to default the map
+      // pin near the station. Only a specific address — geocoding a bare brand
+      // ("Shell") would resolve to a random matching location worldwide.
+      const geoQuery = extractedData.address;
       if (geoQuery) {
         geocodeAddress(geoQuery).then(coords => {
           if (coords) {

--- a/src/pages/QuickLogPage.tsx
+++ b/src/pages/QuickLogPage.tsx
@@ -12,8 +12,10 @@ import { uploadReceipt } from '../firebase/storageService';
 import { getLastOdometerReading, getOrCreateStation, updateStationMetrics } from '../firebase/firestoreService';
 import { extractDataFromReceipt, ReceiptData } from '../utils/gemini';
 import { calculateDistance } from '../utils/calculations';
-import { findNearestStation, isAccurateEnoughForStationMatch, GPS_ACCURACY_THRESHOLD_METERS } from '../utils/locationService';
+import { toDatetimeLocal } from '../utils/formatDate';
+import { findNearestStation, geocodeAddress, isAccurateEnoughForStationMatch, OSMStation } from '../utils/locationService';
 import ReceiptAISection from '../components/ReceiptAISection';
+import LocationPicker, { PickerCoords } from '../components/LocationPicker';
 import { useTranslation } from 'react-i18next';
 
 // Types
@@ -22,12 +24,15 @@ interface MessageState {
   type: MessageType;
   text: string;
 }
-// Type for location data we want to store
+// Type for location data we want to store. `locationAccuracy` is only present
+// for GPS-derived fixes; a manually pinned location has no accuracy figure.
 interface LocationData {
     latitude: number;
     longitude: number;
-    locationAccuracy: number;
+    locationAccuracy?: number;
 }
+
+type LocationMode = 'gps' | 'manual';
 
 
 function QuickLogPage(): JSX.Element {
@@ -68,6 +73,22 @@ function QuickLogPage(): JSX.Element {
   const [isExtracting, setIsExtracting] = useState<boolean>(false);
   const [extractedData, setExtractedData] = useState<ReceiptData | null>(null);
 
+  // --- Date/Time of fuelling ---
+  // Defaults to "now" but is fully editable so a delayed entry keeps the real
+  // fuelling time rather than the submission time.
+  const [loggedAt, setLoggedAt] = useState<string>(() => toDatetimeLocal(new Date()));
+
+  // --- Location State ---
+  // Location is resolved into state (rather than grabbed inline at submit) so
+  // the user can review it and override it on a map before saving. This fixes
+  // late entries getting the submission-time location instead of the fuelling
+  // location.
+  const [location, setLocation] = useState<LocationData | null>(null);
+  const [locationMode, setLocationMode] = useState<LocationMode>('gps');
+  const [showMap, setShowMap] = useState<boolean>(false);
+  const [matchedStation, setMatchedStation] = useState<OSMStation | null>(null);
+  const [isResolvingStation, setIsResolvingStation] = useState<boolean>(false);
+
   // --- Handle AI Extraction ---
   const handleExtractData = async () => {
     if (!receiptFile) return;
@@ -93,6 +114,30 @@ function QuickLogPage(): JSX.Element {
       if (extractedData.cost != null) setCost(extractedData.cost.toString());
       if (extractedData.fuelAmountLiters != null) setFuelAmountLiters(extractedData.fuelAmountLiters.toString());
       if (extractedData.brand != null) setBrand(extractedData.brand);
+
+      // Apply the receipt's printed date/time so a late entry is dated to the
+      // actual fuelling, not when it was logged.
+      if (extractedData.purchaseDate) {
+        const dateTime = extractedData.purchaseTime
+          ? `${extractedData.purchaseDate}T${extractedData.purchaseTime}`
+          : `${extractedData.purchaseDate}T12:00`;
+        const parsed = new Date(dateTime);
+        if (!isNaN(parsed.getTime())) setLoggedAt(toDatetimeLocal(parsed));
+      }
+
+      // Best-effort: geocode the receipt's address (or brand) to default the
+      // map pin near the station. Falls back silently to the existing pin.
+      const geoQuery = extractedData.address || extractedData.brand;
+      if (geoQuery) {
+        geocodeAddress(geoQuery).then(coords => {
+          if (coords) {
+            setLocation({ latitude: coords.latitude, longitude: coords.longitude });
+            setLocationMode('manual');
+            setShowMap(true);
+          }
+        });
+      }
+
       setExtractedData(null);
       setMessage({ type: 'success', text: t('receipt.autoFilled') });
       setTimeout(() => setMessage({ type: '', text: '' }), 3000);
@@ -165,7 +210,10 @@ function QuickLogPage(): JSX.Element {
     const getRate = async () => {
       setIsFetchingRate(true);
       try {
-        const rate = await fetchExchangeRate(new Date(), currency, homeCurrency);
+        // Use the fuelling date (not today) so a back-dated entry gets that
+        // day's exchange rate. Fall back to now if the input isn't parseable yet.
+        const rateDate = loggedAt ? new Date(loggedAt) : new Date();
+        const rate = await fetchExchangeRate(isNaN(rateDate.getTime()) ? new Date() : rateDate, currency, homeCurrency);
         setExchangeRate(rate);
       } catch (error) {
         console.error("Failed to fetch rate:", error);
@@ -176,7 +224,7 @@ function QuickLogPage(): JSX.Element {
     };
 
     getRate();
-  }, [currency, homeCurrency, t]);
+  }, [currency, homeCurrency, loggedAt, t]);
 
   // --- Fetch known brands effect ---
   useEffect(() => {
@@ -254,6 +302,45 @@ function QuickLogPage(): JSX.Element {
     });
   };
 
+  // --- Resolve a station preview whenever a MANUAL pin is set/moved ---
+  // A manually placed pin is authoritative (no GPS accuracy gate). This is
+  // read-only (Overpass); the station document is only created/metered at
+  // submit time. GPS-mode location is resolved at submit (see handleSubmit),
+  // keeping the fast at-pump path unchanged.
+  useEffect(() => {
+    if (locationMode !== 'manual' || !location) return;
+
+    let cancelled = false;
+    setIsResolvingStation(true);
+    setStationWarning('');
+    (async () => {
+      try {
+        const nearest = await findNearestStation(location.latitude, location.longitude);
+        if (cancelled) return;
+        setMatchedStation(nearest);
+        if (nearest) {
+          // Only auto-fill an empty brand; never clobber what the user typed.
+          setBrand(prev => prev.trim() ? prev : nearest.name);
+        }
+      } catch (err) {
+        if (cancelled) return;
+        console.error('Station lookup failed:', err);
+        setMatchedStation(null);
+        setStationWarning(t('quickLog.messages.stationLookupWarning'));
+      } finally {
+        if (!cancelled) setIsResolvingStation(false);
+      }
+    })();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location, locationMode]);
+
+  // --- Map pin change handler ---
+  const handlePinChange = (coords: PickerCoords) => {
+    setLocation({ latitude: coords.latitude, longitude: coords.longitude });
+    setLocationMode('manual');
+  };
+
 
   // --- Form Submit Handler ---
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
@@ -274,65 +361,82 @@ function QuickLogPage(): JSX.Element {
       return;
     }
 
+    // --- Validate the fuelling date/time ---
+    const loggedDate = new Date(loggedAt);
+    if (isNaN(loggedDate.getTime())) {
+      setMessage({ type: 'error', text: t('quickLog.messages.invalidDate', { defaultValue: 'Please enter a valid date and time.' }) });
+      return;
+    }
+    if (loggedDate.getTime() > Date.now() + 60_000) {
+      setMessage({ type: 'error', text: t('quickLog.messages.futureDate', { defaultValue: 'The fuelling date/time cannot be in the future.' }) });
+      return;
+    }
+
     setIsSaving(true);
-    setSavingStep('locating');
     setStationWarning('');
-    setMessage({ type: 'info', text: t('quickLog.messages.gettingLocation') });
-
-    // --- Get Location ---
-    const locationData = await getCurrentLocation();
-
-    // --- Find Station ---
-    let linkedStationId: string | undefined;
-    let stationName: string | undefined;
-
-    if (locationData) {
-        if (!isAccurateEnoughForStationMatch(locationData.locationAccuracy)) {
-            console.warn(
-                `GPS accuracy (${locationData.locationAccuracy.toFixed(0)}m) exceeds threshold ` +
-                `(${GPS_ACCURACY_THRESHOLD_METERS}m); skipping automatic station association.`
-            );
-            setStationWarning(t('quickLog.messages.lowAccuracySkippedStation', {
-                accuracy: locationData.locationAccuracy.toFixed(0),
-                defaultValue: 'GPS accuracy is low ({{accuracy}}m); skipping station detection.',
-            }));
-        } else {
-            try {
-                const nearest = await findNearestStation(locationData.latitude, locationData.longitude);
-                if (nearest) {
-                    linkedStationId = await getOrCreateStation(nearest);
-                    stationName = nearest.name;
-                    // If brand is empty, auto-fill it with station name
-                    if (!brand.trim()) {
-                        setBrand(nearest.name);
-                    }
-                }
-            } catch (err) {
-                console.error("Station lookup failed:", err);
-                setStationWarning(t('quickLog.messages.stationLookupWarning'));
-            }
-        }
-    }
-
-    setSavingStep('saving');
-    let locationMessage: string;
-    if (locationData) {
-        locationMessage = stationName 
-            ? t('quickLog.messages.locationCapturedAt', { station: stationName })
-            : t('quickLog.messages.locationCaptured', { accuracy: locationData.locationAccuracy.toFixed(0) });
-    } else if (!navigator.geolocation) {
-        locationMessage = t('quickLog.messages.locationNotSupported');
-    } else {
-        locationMessage = t('quickLog.messages.locationNotSupported');
-    }
-    // --- End Get Location & Station ---
-
-    setMessage({ type: 'info', text: t('quickLog.messages.savingLog', { locationMsg: locationMessage }) });
 
     // Non-fatal problems collected during save (e.g. receipt upload or station
     // linking failed). These don't block saving the log itself; we surface them
     // to the user so they know something needs attention without the console.
     const saveWarnings: string[] = [];
+
+    // --- Resolve location & station ---
+    // Manual pin: the user explicitly chose where they fuelled — use it as-is
+    // (no GPS accuracy gate). GPS mode: acquire a fresh fix at submit time, the
+    // same fast at-pump path as before. Either way the user could have overridden
+    // it on the map, which is what fixes late entries getting the wrong place.
+    let locationData: LocationData | null = null;
+    let linkedStationId: string | undefined;
+    let stationName: string | undefined;
+
+    if (locationMode === 'manual' && location) {
+      locationData = location;
+      try {
+        const nearest = matchedStation ?? await findNearestStation(location.latitude, location.longitude);
+        if (nearest) {
+          linkedStationId = await getOrCreateStation(nearest);
+          stationName = nearest.name;
+          if (!brand.trim()) setBrand(nearest.name);
+        }
+      } catch (err) {
+        console.error("Station lookup failed:", err);
+        saveWarnings.push(t('quickLog.messages.stationLookupWarning'));
+      }
+    } else {
+      setSavingStep('locating');
+      setMessage({ type: 'info', text: t('quickLog.messages.gettingLocation') });
+      locationData = await getCurrentLocation();
+      if (locationData) {
+        const accuracy = locationData.locationAccuracy ?? Infinity;
+        if (!isAccurateEnoughForStationMatch(accuracy)) {
+          setStationWarning(t('quickLog.messages.lowAccuracySkippedStation', {
+            accuracy: accuracy.toFixed(0),
+            defaultValue: 'GPS accuracy is low ({{accuracy}}m); skipping station detection.',
+          }));
+        } else {
+          try {
+            const nearest = await findNearestStation(locationData.latitude, locationData.longitude);
+            if (nearest) {
+              linkedStationId = await getOrCreateStation(nearest);
+              stationName = nearest.name;
+              if (!brand.trim()) setBrand(nearest.name);
+            }
+          } catch (err) {
+            console.error("Station lookup failed:", err);
+            setStationWarning(t('quickLog.messages.stationLookupWarning'));
+          }
+        }
+      }
+    }
+
+    setSavingStep('saving');
+    const locationMessage = locationData
+        ? (stationName
+            ? t('quickLog.messages.locationCapturedAt', { station: stationName })
+            : t('quickLog.messages.locationSet', { defaultValue: 'Location set.' }))
+        : t('quickLog.messages.locationNotSupported');
+
+    setMessage({ type: 'info', text: t('quickLog.messages.savingLog', { locationMsg: locationMessage }) });
 
     try {
       // --- Handle Receipt Upload (non-fatal) ---
@@ -356,7 +460,7 @@ function QuickLogPage(): JSX.Element {
       const logData: Omit<FuelLogData, 'timestamp'> & { timestamp: Timestamp; userId: string } = {
         userId: user.uid,
         vehicleId: selectedVehicleId,
-        timestamp: Timestamp.now(),
+        timestamp: Timestamp.fromDate(loggedDate),
         brand: brand.trim() || stationName || 'Unknown',
         cost: costHomeCurrency,
         distanceKm: parsedDistanceKm,
@@ -377,7 +481,10 @@ function QuickLogPage(): JSX.Element {
       if (locationData) {
         logData.latitude = locationData.latitude;
         logData.longitude = locationData.longitude;
-        logData.locationAccuracy = locationData.locationAccuracy;
+        // Manual pins have no accuracy figure — only store it for GPS fixes.
+        if (locationData.locationAccuracy !== undefined) {
+          logData.locationAccuracy = locationData.locationAccuracy;
+        }
       }
 
       // Save to Firestore — this is the only fatal step; if it throws the log
@@ -400,6 +507,11 @@ function QuickLogPage(): JSX.Element {
       setBrand(''); setCost(''); setDistanceKmInput(''); setFuelAmountLiters('');
       setOdometerKmInput('');
       setReceiptFile(null);
+      setLoggedAt(toDatetimeLocal(new Date()));
+      setLocation(null);
+      setLocationMode('gps');
+      setMatchedStation(null);
+      setShowMap(false);
       if (saveWarnings.length > 0) {
         // Saved, but something non-critical needs the user's attention.
         const base = locationData ? t('quickLog.messages.savedSuccess') : t('quickLog.messages.savedNoLocation');
@@ -525,6 +637,62 @@ function QuickLogPage(): JSX.Element {
                 </div>
               </div>
 
+              {/* Section: Where (location) */}
+              <div className="group bg-white/40 dark:bg-white/[0.02] p-5 rounded-2xl border border-gray-100 dark:border-white/5 shadow-sm hover:shadow-md transition-all duration-300 backdrop-blur-md">
+                <div className="flex items-center justify-between gap-2 mb-4">
+                  <div className="flex items-center gap-2">
+                    <div className="w-1.5 h-4 bg-brand-primary rounded-full"></div>
+                    <h3 className="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-widest">{t('quickLog.sections.location', { defaultValue: 'Location' })}</h3>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setShowMap(s => !s)}
+                    disabled={isSaving}
+                    className="text-xs font-semibold text-brand-primary dark:text-brand-primary-glow hover:underline disabled:opacity-50"
+                  >
+                    {showMap
+                      ? t('quickLog.location.hideMap', { defaultValue: 'Hide map' })
+                      : t('quickLog.location.adjustOnMap', { defaultValue: 'Adjust on map' })}
+                  </button>
+                </div>
+
+                <div className="text-sm text-gray-600 dark:text-gray-400 mb-3 flex items-center gap-2 flex-wrap">
+                  {isResolvingStation ? (
+                    <span className="flex items-center gap-1.5 text-gray-500">
+                      <svg className="animate-spin h-3.5 w-3.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle><path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path></svg>
+                      {t('quickLog.location.resolving', { defaultValue: 'Finding nearest station…' })}
+                    </span>
+                  ) : location ? (
+                    <>
+                      <span className="font-medium text-gray-800 dark:text-gray-200">
+                        {matchedStation
+                          ? matchedStation.name
+                          : t('quickLog.location.coords', {
+                              lat: location.latitude.toFixed(4),
+                              lng: location.longitude.toFixed(4),
+                              defaultValue: '{{lat}}, {{lng}}',
+                            })}
+                      </span>
+                      <span className={`text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full ${locationMode === 'manual' ? 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300' : 'bg-brand-primary/10 text-brand-primary dark:text-brand-primary-glow'}`}>
+                        {locationMode === 'manual'
+                          ? t('quickLog.location.manualBadge', { defaultValue: 'Pinned' })
+                          : t('quickLog.location.gpsBadge', { defaultValue: 'GPS' })}
+                      </span>
+                    </>
+                  ) : (
+                    <span className="text-gray-500">{t('quickLog.location.none', { defaultValue: 'No location yet — adjust on map to set one.' })}</span>
+                  )}
+                </div>
+
+                {showMap && (
+                  <LocationPicker
+                    value={location ? { latitude: location.latitude, longitude: location.longitude } : null}
+                    onChange={handlePinChange}
+                    defaultCenter={location ? { latitude: location.latitude, longitude: location.longitude } : undefined}
+                  />
+                )}
+              </div>
+
               {/* Section 2: Transaction Details */}
               <div className="group bg-white/40 dark:bg-white/[0.02] p-5 rounded-2xl border border-gray-100 dark:border-white/5 shadow-sm hover:shadow-md transition-all duration-300 backdrop-blur-md">
                 <div className="flex items-center gap-2 mb-4">
@@ -533,6 +701,19 @@ function QuickLogPage(): JSX.Element {
                 </div>
 
                 <div className="space-y-5">
+                  <div>
+                    <label htmlFor="loggedAt" className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1.5">{t('quickLog.fields.dateTime', { defaultValue: 'Date & time of fuelling' })}</label>
+                    <input
+                      type="datetime-local"
+                      id="loggedAt"
+                      value={loggedAt}
+                      max={toDatetimeLocal(new Date())}
+                      onChange={(e) => setLoggedAt(e.target.value)}
+                      className="w-full px-4 py-3 bg-gray-50/50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-xl shadow-inner focus:outline-none focus:ring-2 focus:ring-amber-400/50 focus:border-amber-400 text-gray-900 dark:text-gray-100 transition-all duration-300 hover:bg-white dark:hover:bg-gray-800 font-medium"
+                      disabled={isSaving}
+                    />
+                  </div>
+
                   <div className="grid grid-cols-5 gap-3">
                     <div className="col-span-3">
                       <label htmlFor="cost" className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1.5">{t('quickLog.fields.totalCost')}</label>

--- a/src/utils/formatDate.test.ts
+++ b/src/utils/formatDate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatDate } from './formatDate';
+import { formatDate, toDatetimeLocal } from './formatDate';
 
 describe('formatDate', () => {
   it('zero-pads single-digit day and month', () => {
@@ -13,5 +13,20 @@ describe('formatDate', () => {
   it('handles year boundaries correctly', () => {
     expect(formatDate(new Date(1999, 11, 31))).toBe('31/12/1999');
     expect(formatDate(new Date(2000, 0, 1))).toBe('01/01/2000');
+  });
+});
+
+describe('toDatetimeLocal', () => {
+  it('formats a date as the datetime-local string in local time', () => {
+    expect(toDatetimeLocal(new Date(2026, 5, 20, 14, 30))).toBe('2026-06-20T14:30');
+  });
+
+  it('zero-pads month, day, hour and minute', () => {
+    expect(toDatetimeLocal(new Date(2026, 0, 5, 9, 7))).toBe('2026-01-05T09:07');
+  });
+
+  it('round-trips back to the same instant via new Date()', () => {
+    const original = new Date(2026, 2, 9, 8, 5);
+    expect(new Date(toDatetimeLocal(original)).getTime()).toBe(original.getTime());
   });
 });

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -7,3 +7,12 @@ export const formatDate = (date: Date): string => {
   const year = date.getFullYear();
   return `${day}/${month}/${year}`;
 };
+
+/**
+ * Formats a Date as the "YYYY-MM-DDTHH:MM" string an
+ * <input type="datetime-local"> expects, in the user's local timezone.
+ */
+export const toDatetimeLocal = (date: Date): string => {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+};

--- a/src/utils/gemini.ts
+++ b/src/utils/gemini.ts
@@ -5,6 +5,9 @@ export interface ReceiptData {
   cost: number | null;
   fuelAmountLiters: number | null;
   brand: string | null;
+  purchaseDate: string | null; // ISO date "YYYY-MM-DD" as printed on the receipt
+  purchaseTime: string | null; // 24-hour time "HH:MM" as printed on the receipt
+  address: string | null;      // Station address/location, used to geocode a default map pin
 }
 
 // Local `vercel dev` uses Express with a ~100KB body limit.

--- a/src/utils/locationService.test.ts
+++ b/src/utils/locationService.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { findNearestStation, isAccurateEnoughForStationMatch, GPS_ACCURACY_THRESHOLD_METERS } from './locationService';
+import { findNearestStation, geocodeAddress, isAccurateEnoughForStationMatch, GPS_ACCURACY_THRESHOLD_METERS } from './locationService';
 
 describe('isAccurateEnoughForStationMatch', () => {
     it('returns true when accuracy is within the threshold', () => {
@@ -135,5 +135,42 @@ describe('locationService', () => {
         
         expect(mockFetch).toHaveBeenCalledTimes(2);
         expect(result?.name).toBe('Retry Station');
+    });
+});
+
+describe('geocodeAddress', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+        global.fetch = vi.fn();
+    });
+
+    it('returns coordinates for the first Nominatim match', async () => {
+        vi.mocked(global.fetch).mockResolvedValue({
+            ok: true,
+            json: async () => ([{ lat: '53.3498', lon: '-6.2603' }]),
+        } as Response);
+
+        const result = await geocodeAddress('Shell, O Connell Street, Dublin');
+        expect(result).toEqual({ latitude: 53.3498, longitude: -6.2603 });
+    });
+
+    it('returns null for an empty query without calling the API', async () => {
+        const result = await geocodeAddress('   ');
+        expect(result).toBeNull();
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('returns null when no results are found', async () => {
+        vi.mocked(global.fetch).mockResolvedValue({
+            ok: true,
+            json: async () => ([]),
+        } as Response);
+
+        expect(await geocodeAddress('nowhere at all')).toBeNull();
+    });
+
+    it('returns null on a network/API error', async () => {
+        vi.mocked(global.fetch).mockRejectedValue(new Error('network down'));
+        expect(await geocodeAddress('anywhere')).toBeNull();
     });
 });

--- a/src/utils/locationService.ts
+++ b/src/utils/locationService.ts
@@ -32,6 +32,7 @@ interface OverpassElement {
 }
 
 const OVERPASS_URL = 'https://overpass-api.de/api/interpreter';
+const NOMINATIM_URL = 'https://nominatim.openstreetmap.org/search';
 
 /**
  * GPS accuracy (in metres) beyond which we no longer trust a position
@@ -90,6 +91,48 @@ export function getCurrentPosition(): Promise<Coordinates | null> {
             { enableHighAccuracy: true, timeout: 10000, maximumAge: 60000 }
         );
     });
+}
+
+/**
+ * Forward-geocode a free-text address (or station name) into coordinates using
+ * OpenStreetMap's Nominatim service. Best-effort: resolves null when nothing
+ * matches or the request fails, so callers can fall back to GPS/defaults.
+ *
+ * Used to guess a sensible default map pin from a receipt's printed address
+ * when logging a fuelling after the fact.
+ */
+export async function geocodeAddress(query: string): Promise<Coordinates | null> {
+    const trimmed = query.trim();
+    if (!trimmed) return null;
+
+    const url = `${NOMINATIM_URL}?format=json&limit=1&q=${encodeURIComponent(trimmed)}`;
+
+    try {
+        const response = await fetch(url, {
+            headers: {
+                // Nominatim's usage policy asks for an identifying request; the
+                // browser sets User-Agent automatically, so we send Accept only.
+                Accept: 'application/json',
+            },
+        });
+
+        if (!response.ok) {
+            console.warn(`Nominatim responded with status ${response.status}`);
+            return null;
+        }
+
+        const results = await response.json();
+        if (!Array.isArray(results) || results.length === 0) return null;
+
+        const lat = parseFloat(results[0].lat);
+        const lon = parseFloat(results[0].lon);
+        if (Number.isNaN(lat) || Number.isNaN(lon)) return null;
+
+        return { latitude: lat, longitude: lon };
+    } catch (error) {
+        console.warn('Nominatim geocoding failed:', error);
+        return null;
+    }
 }
 
 /**

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -85,6 +85,7 @@ interface EditFormData {
     vehicleId?: string; // Multi-vehicle support
     latitude?: string;
     longitude?: string;
+    loggedAt?: string;  // datetime-local string for editing the fuelling date/time
 }
 // Type for view mode state
 type ViewMode = 'table' | 'cards';


### PR DESCRIPTION
## 📋 Description

QuickLog recorded **where** and **when** at the moment you pressed *Save*, not at the moment you actually fuelled. If you logged a fill-up after the fact (e.g. later from home), the entry got your current GPS location + possibly a wrong/absent station, and its date was `Timestamp.now()` rather than the real fuelling time. This PR gives the user explicit control over both the date/time and the location, with the receipt photo able to pre-fill them.

## 🚀 Proposed Changes

- **Date/time of fuelling**
  - Added an editable `datetime-local` field to QuickLog (defaults to now, capped at the present) and to the History edit modal.
  - `handleSubmit` now stamps the log with the chosen date/time (`Timestamp.fromDate(...)`) instead of `Timestamp.now()`, and the exchange-rate lookup uses the fuelling date so back-dated entries get that day's rate.
- **Location**
  - New reusable `LocationPicker` component (Leaflet draggable / tap-to-place pin) with a "Use my location" button.
  - QuickLog shows the resolved location + matched station and an **Adjust on map** toggle. A manual pin is authoritative (skips the GPS accuracy gate); the fast at-pump GPS path is unchanged. The same picker was added to the History edit modal (alongside the existing lat/long fields, kept in sync).
- **Receipt extraction**
  - Gemini prompt/response in `api/extract-receipt.ts` now also returns `purchaseDate`, `purchaseTime`, and `address` (with the existing type-guard/null-fallback pattern); `ReceiptData` updated.
  - Confirming a scanned receipt pre-fills the date/time and forward-geocodes the address via OSM Nominatim (`geocodeAddress` in `locationService.ts`) to default the map pin near the station.
- **i18n**: new strings added to all 10 locale files.
- **Tests**: extended `extract-receipt.test.ts`, `gemini.test.ts`, `QuickLogPage.test.tsx`, and added `geocodeAddress` cases to `locationService.test.ts`.

## 🛡️ Checklist

- [x] I have verified that all unit tests pass locally (`npm run test`).
- [x] I have verified that the build succeeds locally (`npm run build`).
- [x] I have added/updated unit tests for my changes.
- [x] I have followed the project's coding standards and naming conventions.
- [ ] I have updated the documentation (`docs/`) if necessary.
- [ ] New features are gated behind a Remote Config flag (refer to FEATURE_RELEASING.md).

> Note on Remote Config: the date/time and map-pin controls extend the existing always-on QuickLog form rather than introducing a new standalone feature, so they aren't behind a new flag. The receipt date/time/address extraction rides on the existing `receiptDigitizationEnabled` / `receiptAutoFillEnabled` gates. Happy to add a dedicated flag if preferred.

## 📸 Screenshots (if applicable)

_n/a — UI changes are best reviewed running locally._

## 🔗 Related Issues/PRs

_n/a_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9GR121VdLzGAwcudanfRR)_