### PR TITLE
fix: allow log updates without a receipt and stop modal viewport clipping

### DIFF
--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -383,8 +383,12 @@ function HistoryPage(): JSX.Element {
                 cost: parsedCost,
                 distanceKm: parsedDistanceKm,
                 fuelAmountLiters: parsedFuel,
-                vehicleId: editFormData.vehicleId,
             };
+            // vehicleId is optional on the form type; only write it when set so we
+            // never pass `undefined` (which updateDoc rejects) or an empty string.
+            if (editFormData.vehicleId) {
+                updatedData.vehicleId = editFormData.vehicleId;
+            }
             if (editReceiptFile && user) {
                 // Only write receiptUrl when a new receipt was uploaded. Firestore's
                 // updateDoc() rejects `undefined`, so we must never include optional

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -375,24 +375,24 @@ function HistoryPage(): JSX.Element {
 
         setIsUpdating(true); setModalError(null);
         try {
-            let receiptUrl = editingLog.receiptUrl || "";
-            if (editReceiptFile && user) {
-                receiptUrl = await uploadReceipt(editReceiptFile, user.uid);
-            }
-
+            // A receipt is optional — only upload/replace it when the user picked a
+            // new file. Otherwise keep whatever the log already had (which may be none).
             const logRef = doc(db, "fuelLogs", editingLog.id);
-            const updatedData: Partial<FuelLogData> = { 
-                brand: brand.trim() || 'Unknown', 
-                cost: parsedCost, 
-                distanceKm: parsedDistanceKm, 
+            const updatedData: Partial<FuelLogData> = {
+                brand: brand.trim() || 'Unknown',
+                cost: parsedCost,
+                distanceKm: parsedDistanceKm,
                 fuelAmountLiters: parsedFuel,
                 vehicleId: editFormData.vehicleId,
-                receiptUrl: receiptUrl || undefined
             };
+            if (editReceiptFile && user) {
+                // Only write receiptUrl when a new receipt was uploaded. Firestore's
+                // updateDoc() rejects `undefined`, so we must never include optional
+                // fields that don't have a concrete value.
+                updatedData.receiptUrl = await uploadReceipt(editReceiptFile, user.uid);
+            }
             if (!isNaN(parsedOdometer)) {
                 updatedData.odometerKm = parsedOdometer;
-            } else {
-                updatedData.odometerKm = undefined;
             }
             if (parsedLat !== undefined && parsedLon !== undefined) {
                 updatedData.latitude = parsedLat;
@@ -645,8 +645,12 @@ function HistoryPage(): JSX.Element {
             {/* --- Edit Modal --- */}
             {/* Conditionally render the modal based on isModalOpen state */}
             {isModalOpen && editingLog && (
-                <div className="fixed inset-0 z-50 overflow-y-auto bg-gray-600 dark:bg-gray-900 bg-opacity-75 dark:bg-opacity-80 transition-opacity flex items-center justify-center" aria-labelledby="modal-title" role="dialog" aria-modal="true">
-                    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-6 w-full max-w-md m-4 space-y-4 transform transition-all">
+                <div className="fixed inset-0 z-50 overflow-y-auto bg-gray-600 dark:bg-gray-900 bg-opacity-75 dark:bg-opacity-80 transition-opacity" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+                    {/* min-h-full + flex centering on an inner wrapper (rather than on the
+                        scroll container itself) keeps tall modals fully scrollable so the
+                        top is never clipped on short screens. */}
+                    <div className="flex min-h-full items-center justify-center p-4">
+                    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-6 w-full max-w-md space-y-4 transform transition-all">
                         <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-300" id="modal-title">{t('history.edit.title')} ({formatDate(editingLog.timestamp.toDate())})</h3>
                         {/* Edit Form */}
                         <form onSubmit={handleUpdateLog} className="space-y-4">
@@ -711,6 +715,7 @@ function HistoryPage(): JSX.Element {
                                 <button type="button" onClick={handleCloseModal} disabled={isUpdating} className="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-700 shadow-sm px-4 py-2 bg-white dark:bg-gray-700 text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:col-start-1 sm:text-sm disabled:opacity-50">{t('history.edit.cancel')}</button>
                             </div>
                         </form>
+                    </div>
                     </div>
                 </div>
             )}


### PR DESCRIPTION
## 📋 Description

Editing a fuel log could fail with:

> `FirebaseError: Function updateDoc() called with invalid data. Unsupported field value: undefined (found in field receiptUrl ...)`

This happened because the edit form always included optional fields (`receiptUrl`, `odometerKm`) in the update payload, setting them to `undefined` when no value was present. Firestore's `updateDoc()` rejects `undefined`. Updating a log now only requires the minimum needed information — a receipt (and other extras) is optional.

This PR also fixes the edit modal being clipped at the top of the viewport on shorter screens, making it difficult to use.

## 🚀 Proposed Changes
- Only write `receiptUrl` to the update payload when a new receipt file was actually uploaded; otherwise leave the existing value untouched.
- Only write `odometerKm` (and lat/lng) when a concrete value is present, instead of explicitly passing `undefined`.
- Restructure the edit modal to the standard two-layer scroll pattern: the scroll container no longer also handles flex centering. Centering now lives on an inner `min-h-full` wrapper, so tall modals stay fully scrollable and the top is never clipped.

## 🛡️ Checklist
- [x] I have verified that all unit tests pass locally (`npm run test`).
- [ ] I have verified that the build succeeds locally (`npm run build`).
- [ ] I have added/updated unit tests for my changes.
- [x] I have followed the project's coding standards and naming conventions.
- [ ] I have updated the documentation (`docs/`) if necessary.
- [ ] New features are gated behind a Remote Config flag (refer to FEATURE_RELEASING.md).

## 📸 Screenshots (if applicable)
N/A — layout-only CSS change to keep the existing modal fully reachable.

## 🔗 Related Issues/PRs
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Phq8EKt8pSZsak4cb2pjS)_