### PR TITLE
feat(functions): backfill odometer readings from distance history

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -9,6 +9,7 @@
     "deploy": "firebase deploy --only functions",
     "logs": "firebase functions:log",
     "recompress-receipts": "npm run build && node lib/scripts/recompressReceipts.js",
+    "backfill-odometer": "npm run build && node lib/scripts/backfillOdometer.js",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/functions/src/__tests__/backfillOdometer.test.ts
+++ b/functions/src/__tests__/backfillOdometer.test.ts
@@ -133,6 +133,30 @@ describe('planOdometerBackfill', () => {
     expect(plan.skipped).toBe(1);
   });
 
+  it('allows a reconstructed reading of exactly zero (brand-new vehicle)', () => {
+    const logs = [
+      makeLog('a', 1, 100), // earliest fill of a brand-new car
+      makeLog('b', 2, 100, 100), // anchor: 100 km on the clock
+    ];
+
+    const plan = planOdometerBackfill(logs);
+
+    // a = 100 - 100 = 0, which is a valid reading and must not be skipped.
+    expect(odoOf(plan, 'a')).toBe(0);
+    expect(plan.skipped).toBe(0);
+  });
+
+  it('skips records with a missing or malformed timestamp instead of crashing', () => {
+    const good = makeLog('good', 2, 100, 500);
+    const broken = { id: 'broken', userId: 'user1', vehicleId: 'car1', distanceKm: 50 } as unknown as BackfillLog;
+
+    const plan = planOdometerBackfill([good, broken]);
+
+    // The broken record is dropped; the good anchor still processes cleanly.
+    expect(odoOf(plan, 'broken')).toBeUndefined();
+    expect(plan.alreadySet).toBe(1);
+  });
+
   it('does not produce negative odometer readings', () => {
     const logs = [
       makeLog('a', 1, 100),

--- a/functions/src/__tests__/backfillOdometer.test.ts
+++ b/functions/src/__tests__/backfillOdometer.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import { planOdometerBackfill, BackfillLog } from '../scripts/backfillOdometer';
+
+// Build a log with a fake Timestamp ordered by `day`.
+const makeLog = (
+  id: string,
+  day: number,
+  distanceKm: number,
+  odometerKm?: number,
+  vehicleId = 'car1',
+  userId = 'user1',
+): BackfillLog => ({
+  id,
+  userId,
+  vehicleId,
+  timestamp: { toMillis: () => day },
+  distanceKm,
+  ...(odometerKm !== undefined ? { odometerKm } : {}),
+});
+
+const odoOf = (plan: ReturnType<typeof planOdometerBackfill>, id: string) =>
+  plan.updates.find((u) => u.id === id)?.odometerKm;
+
+describe('planOdometerBackfill', () => {
+  it('reconstructs earlier readings by walking backwards from the latest known value', () => {
+    const logs = [
+      makeLog('a', 1, 100),
+      makeLog('b', 2, 200),
+      makeLog('c', 3, 300),
+      makeLog('d', 4, 150, 1000), // anchor
+    ];
+
+    const plan = planOdometerBackfill(logs);
+
+    // d = 1000 (known). c = 1000 - 150 = 850. b = 850 - 300 = 550. a = 550 - 200 = 350.
+    expect(odoOf(plan, 'c')).toBe(850);
+    expect(odoOf(plan, 'b')).toBe(550);
+    expect(odoOf(plan, 'a')).toBe(350);
+    expect(plan.updates).toHaveLength(3);
+    expect(plan.alreadySet).toBe(1);
+    expect(plan.skipped).toBe(0);
+    expect(plan.vehiclesAnchored).toBe(1);
+    expect(plan.vehiclesWithoutAnchor).toBe(0);
+  });
+
+  it('walks forwards to fill gaps after a known reading', () => {
+    const logs = [
+      makeLog('a', 1, 100, 500), // anchor
+      makeLog('b', 2, 200),
+      makeLog('c', 3, 300),
+    ];
+
+    const plan = planOdometerBackfill(logs);
+
+    expect(odoOf(plan, 'b')).toBe(700); // 500 + 200
+    expect(odoOf(plan, 'c')).toBe(1000); // 700 + 300
+    expect(plan.skipped).toBe(0);
+  });
+
+  it('never overwrites existing readings and re-anchors on them', () => {
+    const logs = [
+      makeLog('a', 1, 100),
+      makeLog('b', 2, 200, 600), // known anchor in the middle
+      makeLog('c', 3, 300),
+      makeLog('d', 4, 150, 999), // a second known reading
+    ];
+
+    const plan = planOdometerBackfill(logs);
+
+    expect(odoOf(plan, 'b')).toBeUndefined();
+    expect(odoOf(plan, 'd')).toBeUndefined();
+    expect(odoOf(plan, 'a')).toBe(400); // 600 - 200, backwards from b
+    // c sits between two anchors; the forward pass from the earliest anchor (b)
+    // reaches it first: 600 + 300 = 900.
+    expect(odoOf(plan, 'c')).toBe(900);
+    expect(plan.alreadySet).toBe(2);
+  });
+
+  it('reconstructs each vehicle independently', () => {
+    const logs = [
+      makeLog('a1', 1, 50, undefined, 'car1'),
+      makeLog('a2', 2, 50, 2000, 'car1'),
+      makeLog('b1', 1, 80, undefined, 'car2'),
+      makeLog('b2', 2, 80, 5000, 'car2'),
+    ];
+
+    const plan = planOdometerBackfill(logs);
+
+    expect(odoOf(plan, 'a1')).toBe(1950); // 2000 - 50
+    expect(odoOf(plan, 'b1')).toBe(4920); // 5000 - 80
+    expect(plan.vehiclesAnchored).toBe(2);
+  });
+
+  it('keeps different users separate even on the same vehicle id', () => {
+    const logs = [
+      makeLog('u1', 2, 50, 2000, 'shared', 'userA'),
+      makeLog('u1prev', 1, 50, undefined, 'shared', 'userA'),
+      makeLog('u2', 2, 80, 9000, 'shared', 'userB'),
+      makeLog('u2prev', 1, 80, undefined, 'shared', 'userB'),
+    ];
+
+    const plan = planOdometerBackfill(logs);
+
+    expect(odoOf(plan, 'u1prev')).toBe(1950); // anchored on userA's 2000
+    expect(odoOf(plan, 'u2prev')).toBe(8920); // anchored on userB's 9000
+    expect(plan.vehiclesAnchored).toBe(2);
+  });
+
+  it('reports vehicles that have no reading to anchor from', () => {
+    const logs = [makeLog('a', 1, 100), makeLog('b', 2, 200)];
+
+    const plan = planOdometerBackfill(logs);
+
+    expect(plan.updates).toHaveLength(0);
+    expect(plan.skipped).toBe(2);
+    expect(plan.vehiclesAnchored).toBe(0);
+    expect(plan.vehiclesWithoutAnchor).toBe(1);
+  });
+
+  it('stops the backward chain on a missing/invalid distance rather than guessing', () => {
+    const logs = [
+      makeLog('a', 1, 100),
+      makeLog('b', 2, 0), // invalid distance breaks the chain below it
+      makeLog('c', 3, 300),
+      makeLog('d', 4, 150, 1000), // anchor
+    ];
+
+    const plan = planOdometerBackfill(logs);
+
+    expect(odoOf(plan, 'c')).toBe(850); // 1000 - 150
+    expect(odoOf(plan, 'b')).toBe(550); // 850 - 300
+    expect(odoOf(plan, 'a')).toBeUndefined(); // needs b's distance (0) — invalid
+    expect(plan.skipped).toBe(1);
+  });
+
+  it('does not produce negative odometer readings', () => {
+    const logs = [
+      makeLog('a', 1, 100),
+      makeLog('b', 2, 5000), // huge distance would push a negative
+      makeLog('c', 3, 100, 200), // small anchor
+    ];
+
+    const plan = planOdometerBackfill(logs);
+
+    expect(odoOf(plan, 'b')).toBe(100); // 200 - 100
+    expect(odoOf(plan, 'a')).toBeUndefined(); // 100 - 5000 < 0, rejected
+  });
+});

--- a/functions/src/scripts/backfillOdometer.ts
+++ b/functions/src/scripts/backfillOdometer.ts
@@ -1,0 +1,234 @@
+// functions/src/scripts/backfillOdometer.ts
+//
+// One-off backfill job.
+//
+// Odometer tracking (fuelLogs.odometerKm) was added long after logging began,
+// so older logs only carry `distanceKm` — the distance covered since the
+// previous fill-up — and have no absolute odometer reading.
+//
+// The odometer is just the running sum of those distances, so a single known
+// reading lets us reconstruct every other reading for that vehicle:
+//
+//   odometer[i]   = odometer[i-1] + distanceKm[i]      (walking forwards)
+//   odometer[i-1] = odometer[i]   - distanceKm[i]      (walking backwards)
+//
+// Because the only readings we have are recent ones, the job mostly walks
+// *backwards* from the earliest known reading to fill in the history. Each
+// vehicle has its own odometer, so logs are reconstructed per (user, vehicle).
+// Existing readings are never overwritten — they act as anchors the
+// reconstruction radiates out from, re-anchoring on any reading it meets so
+// rounding drift can't accumulate across the whole history.
+//
+// Usage (from the functions/ directory):
+//   npm run backfill-odometer                   # write reconstructed readings
+//   npm run backfill-odometer -- --dry-run      # report what would change
+//   npm run backfill-odometer -- --user=<uid>   # limit to a single user
+//
+// Credentials are read via application default credentials, e.g.:
+//   GOOGLE_APPLICATION_CREDENTIALS=../service-account.json npm run backfill-odometer
+
+import { initializeApp, getApps, applicationDefault } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const USER_ARG = process.argv.find((a) => a.startsWith('--user='));
+const ONLY_USER = USER_ARG ? USER_ARG.slice('--user='.length) : undefined;
+
+const NO_VEHICLE = '__no_vehicle__';
+
+/** Minimal shape of a log needed to plan a backfill. Decoupled from Firestore
+ *  so the planner can be unit-tested with plain objects. */
+export interface BackfillLog {
+  id: string;
+  userId: string;
+  vehicleId?: string;
+  /** Anything exposing toMillis() (a Firestore Timestamp) — used for ordering. */
+  timestamp: { toMillis: () => number };
+  distanceKm: number;
+  odometerKm?: number;
+}
+
+/** A single computed odometer value to write back to a log. */
+export interface OdometerBackfillUpdate {
+  id: string;
+  odometerKm: number;
+}
+
+export interface OdometerBackfillPlan {
+  /** Logs that should be written with a reconstructed odometer reading. */
+  updates: OdometerBackfillUpdate[];
+  /** Logs that already had an odometer reading and were left untouched. */
+  alreadySet: number;
+  /** Logs that could not be reconstructed (no anchor reachable, or a missing/
+   *  invalid distance broke the chain). */
+  skipped: number;
+  /** (user, vehicle) groups that had at least one reading to anchor from. */
+  vehiclesAnchored: number;
+  /** (user, vehicle) groups with logs but no reading at all. */
+  vehiclesWithoutAnchor: number;
+}
+
+const isValidReading = (value: number | undefined): value is number =>
+  typeof value === 'number' && Number.isFinite(value) && value >= 0;
+
+const isValidDistance = (value: number | undefined): value is number =>
+  typeof value === 'number' && Number.isFinite(value) && value > 0;
+
+/**
+ * Reconstructs missing odometer readings for one vehicle's logs (sorted
+ * oldest-first), pushing results onto the shared `updates` array. Returns
+ * whether the group had any reading to anchor from.
+ */
+function planVehicleGroup(sorted: BackfillLog[], updates: OdometerBackfillUpdate[]): boolean {
+  const firstAnchor = sorted.findIndex((log) => isValidReading(log.odometerKm));
+  if (firstAnchor === -1) return false;
+
+  // Walk forwards from the earliest known reading, filling any later gaps.
+  let running: number | null = sorted[firstAnchor].odometerKm!;
+  for (let i = firstAnchor + 1; i < sorted.length; i++) {
+    const log = sorted[i];
+    if (isValidReading(log.odometerKm)) {
+      running = log.odometerKm; // re-anchor on the next real reading
+      continue;
+    }
+    if (running !== null && isValidDistance(log.distanceKm)) {
+      running += log.distanceKm;
+      updates.push({ id: log.id, odometerKm: running });
+    } else {
+      running = null; // chain broken until the next real reading
+    }
+  }
+
+  // Walk backwards from the earliest known reading, filling older logs.
+  running = sorted[firstAnchor].odometerKm!;
+  for (let i = firstAnchor; i > 0; i--) {
+    const current = sorted[i];
+    const previous = sorted[i - 1];
+    if (isValidReading(previous.odometerKm)) {
+      running = previous.odometerKm; // re-anchor on the next real reading
+      continue;
+    }
+    // distanceKm on `current` is the distance travelled to reach it from `previous`.
+    if (running !== null && isValidDistance(current.distanceKm)) {
+      const previousOdometer: number = running - current.distanceKm;
+      if (previousOdometer > 0) {
+        updates.push({ id: previous.id, odometerKm: previousOdometer });
+        running = previousOdometer;
+        continue;
+      }
+    }
+    running = null; // can't sensibly go further back
+  }
+
+  return true;
+}
+
+/**
+ * Pure planner: given every fuel log, works out which logs can have their
+ * odometer reconstructed and what value each should take. No Firestore access,
+ * so it is fully unit-testable.
+ */
+export function planOdometerBackfill(logs: BackfillLog[]): OdometerBackfillPlan {
+  // Group per (user, vehicle) — odometers are per-vehicle, and logs predating
+  // multi-vehicle support have no vehicleId, so they share a single group.
+  const groups = new Map<string, BackfillLog[]>();
+  for (const log of logs) {
+    const key = `${log.userId}::${log.vehicleId ?? NO_VEHICLE}`;
+    const group = groups.get(key);
+    if (group) group.push(log);
+    else groups.set(key, [log]);
+  }
+
+  const updates: OdometerBackfillUpdate[] = [];
+  let vehiclesAnchored = 0;
+  let vehiclesWithoutAnchor = 0;
+
+  for (const group of groups.values()) {
+    const sorted = [...group].sort((a, b) => a.timestamp.toMillis() - b.timestamp.toMillis());
+    if (planVehicleGroup(sorted, updates)) vehiclesAnchored++;
+    else vehiclesWithoutAnchor++;
+  }
+
+  const alreadySet = logs.filter((log) => isValidReading(log.odometerKm)).length;
+  const skipped = logs.length - alreadySet - updates.length;
+
+  return { updates, alreadySet, skipped, vehiclesAnchored, vehiclesWithoutAnchor };
+}
+
+async function main(): Promise<void> {
+  if (getApps().length === 0) {
+    initializeApp({ credential: applicationDefault() });
+  }
+  const db = getFirestore();
+
+  console.log(
+    'Reconstructing odometer readings from distance history' +
+      (ONLY_USER ? ` for user ${ONLY_USER}` : ' for all users') +
+      (DRY_RUN ? '  (dry run — nothing will be written)' : ''),
+  );
+
+  let queryRef = db.collection('fuelLogs') as FirebaseFirestore.Query;
+  if (ONLY_USER) queryRef = queryRef.where('userId', '==', ONLY_USER);
+
+  const snapshot = await queryRef.get();
+  const logs: BackfillLog[] = snapshot.docs.map((d) => {
+    const data = d.data();
+    return {
+      id: d.id,
+      userId: data.userId,
+      vehicleId: data.vehicleId,
+      timestamp: data.timestamp,
+      distanceKm: data.distanceKm,
+      odometerKm: data.odometerKm,
+    };
+  });
+
+  console.log(`Fetched ${logs.length} logs.`);
+
+  const plan = planOdometerBackfill(logs);
+
+  console.log(`\nPlan:`);
+  console.log(`  ${DRY_RUN ? 'Would reconstruct' : 'Reconstruct'}: ${plan.updates.length}`);
+  console.log(`  Already set:        ${plan.alreadySet}`);
+  console.log(`  Skipped:            ${plan.skipped}`);
+  console.log(`  Vehicles anchored:  ${plan.vehiclesAnchored}`);
+  console.log(`  Vehicles w/o anchor: ${plan.vehiclesWithoutAnchor}`);
+
+  if (plan.updates.length === 0) {
+    console.log('\nNothing to do.');
+    return;
+  }
+
+  if (DRY_RUN) {
+    const sample = plan.updates.slice(0, 10);
+    console.log('\nSample of reconstructed readings (first 10):');
+    sample.forEach((u) => console.log(`  ${u.id}  ->  ${Math.round(u.odometerKm)} km`));
+    return;
+  }
+
+  // Firestore caps writes at 500 per batch.
+  const batchSize = 500;
+  let written = 0;
+  for (let i = 0; i < plan.updates.length; i += batchSize) {
+    const batch = db.batch();
+    const chunk = plan.updates.slice(i, i + batchSize);
+    chunk.forEach(({ id, odometerKm }) => {
+      // Round to whole km — odometers are integers and this absorbs the
+      // floating-point drift from summing distances.
+      batch.update(db.collection('fuelLogs').doc(id), { odometerKm: Math.round(odometerKm) });
+    });
+    await batch.commit();
+    written += chunk.length;
+    console.log(`  Wrote ${written}/${plan.updates.length}`);
+  }
+
+  console.log('\nDone.');
+}
+
+// Only run when invoked directly, so the planner can be imported by tests.
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/functions/src/scripts/backfillOdometer.ts
+++ b/functions/src/scripts/backfillOdometer.ts
@@ -111,7 +111,8 @@ function planVehicleGroup(sorted: BackfillLog[], updates: OdometerBackfillUpdate
     // distanceKm on `current` is the distance travelled to reach it from `previous`.
     if (running !== null && isValidDistance(current.distanceKm)) {
       const previousOdometer: number = running - current.distanceKm;
-      if (previousOdometer > 0) {
+      // >= 0: a brand-new vehicle can legitimately read 0, matching isValidReading.
+      if (previousOdometer >= 0) {
         updates.push({ id: previous.id, odometerKm: previousOdometer });
         running = previousOdometer;
         continue;
@@ -144,7 +145,11 @@ export function planOdometerBackfill(logs: BackfillLog[]): OdometerBackfillPlan 
   let vehiclesWithoutAnchor = 0;
 
   for (const group of groups.values()) {
-    const sorted = [...group].sort((a, b) => a.timestamp.toMillis() - b.timestamp.toMillis());
+    // Drop records with a missing/malformed timestamp — they can't be ordered,
+    // and calling toMillis() on them would crash the whole job.
+    const sorted = [...group]
+      .filter((log) => log.timestamp && typeof log.timestamp.toMillis === 'function')
+      .sort((a, b) => a.timestamp.toMillis() - b.timestamp.toMillis());
     if (planVehicleGroup(sorted, updates)) vehiclesAnchored++;
     else vehiclesWithoutAnchor++;
   }
@@ -167,7 +172,11 @@ async function main(): Promise<void> {
       (DRY_RUN ? '  (dry run — nothing will be written)' : ''),
   );
 
-  let queryRef = db.collection('fuelLogs') as FirebaseFirestore.Query;
+  // Select only the fields the backfill needs — fuelLogs can carry large fields
+  // (receipt URLs, etc.) we never read, so this keeps memory and bandwidth down.
+  let queryRef: FirebaseFirestore.Query = db
+    .collection('fuelLogs')
+    .select('userId', 'vehicleId', 'timestamp', 'distanceKm', 'odometerKm');
   if (ONLY_USER) queryRef = queryRef.where('userId', '==', ONLY_USER);
 
   const snapshot = await queryRef.get();


### PR DESCRIPTION
## 📋 Description

Odometer tracking (`fuelLogs.odometerKm`) was added long after logging began, so older logs only carry `distanceKm` — the distance covered since the previous fill-up — and have no absolute odometer reading.

Because the odometer is simply the running sum of those distances, a single known reading lets us reconstruct every other reading for the same vehicle:

```
odometer[i]   = odometer[i-1] + distanceKm[i]   (walking forwards)
odometer[i-1] = odometer[i]   - distanceKm[i]   (walking backwards)
```

Since the only readings we have are recent ones, the job mainly walks **backwards** from the earliest known reading to fill in history — exactly the "moving backwards" reconstruction requested.

This is delivered as a one-off admin script, in the same style as the existing `recompress-receipts` backfill — no UI or runtime code changes.

## 🚀 Proposed Changes

- Added `functions/src/scripts/backfillOdometer.ts`:
  - Pure, exported `planOdometerBackfill()` that reconstructs missing odometer readings per `(user, vehicle)` group.
  - Walks backwards from the earliest known reading, and forwards to close any later gaps, **re-anchoring on any existing reading** so rounding drift can't accumulate across the whole history.
  - Never overwrites existing readings; skips logs it can't reconstruct (no anchor, or a missing/invalid distance breaks the chain) and won't produce negative readings.
  - Runnable `main()` (guarded by `require.main === module`) using `firebase-admin`, with `--dry-run` (reports counts + a sample, writes nothing) and `--user=<uid>` (limit to one user). Writes are batched at Firestore's 500-per-batch limit and rounded to whole km.
- Added `functions/src/__tests__/backfillOdometer.test.ts` covering backward fill, forward gap fill, never-overwrite/re-anchoring, per-vehicle and per-user isolation, missing-anchor reporting, chain breaks on invalid distance, and the no-negative guard.
- Registered the `backfill-odometer` npm script in `functions/package.json`.

Usage (from `functions/`):

```bash
npm run backfill-odometer                 # write reconstructed readings
npm run backfill-odometer -- --dry-run    # report what would change
npm run backfill-odometer -- --user=<uid> # limit to a single user
```

## 🛡️ Checklist

- [x] I have verified that all unit tests pass locally (`npm run test`).
- [x] I have verified that the build succeeds locally (`npm run build`).
- [x] I have added/updated unit tests for my changes.
- [x] I have followed the project's coding standards and naming conventions.
- [ ] I have updated the documentation (`docs/`) if necessary. <!-- N/A — script is self-documented in its header, matching recompress-receipts -->
- [ ] New features are gated behind a Remote Config flag. <!-- N/A — one-off admin script, not a user-facing runtime feature -->

## 📸 Screenshots (if applicable)

N/A — command-line script.

## 🔗 Related Issues/PRs

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmiGZXwdJ58yGAkw5s9Mtv)_