### PR TITLE
fix(functions): pin Firestore project in odometer backfill script

### DIFF
--- a/functions/src/scripts/backfillOdometer.ts
+++ b/functions/src/scripts/backfillOdometer.ts
@@ -20,11 +20,14 @@
 // rounding drift can't accumulate across the whole history.
 //
 // Usage (from the functions/ directory):
-//   npm run backfill-odometer                   # write reconstructed readings
-//   npm run backfill-odometer -- --dry-run      # report what would change
-//   npm run backfill-odometer -- --user=<uid>   # limit to a single user
+//   npm run backfill-odometer                     # write reconstructed readings
+//   npm run backfill-odometer -- --dry-run        # report what would change
+//   npm run backfill-odometer -- --user=<uid>     # limit to a single user
+//   npm run backfill-odometer -- --project=<id>   # target a specific project
 //
-// Credentials are read via application default credentials, e.g.:
+// The Firestore project defaults to fuelog-paddez and can be overridden with
+// --project=<id> or GOOGLE_CLOUD_PROJECT. Credentials are read via application
+// default credentials, e.g.:
 //   GOOGLE_APPLICATION_CREDENTIALS=../service-account.json npm run backfill-odometer
 
 import { initializeApp, getApps, applicationDefault } from 'firebase-admin/app';
@@ -33,6 +36,17 @@ import { getFirestore } from 'firebase-admin/firestore';
 const DRY_RUN = process.argv.includes('--dry-run');
 const USER_ARG = process.argv.find((a) => a.startsWith('--user='));
 const ONLY_USER = USER_ARG ? USER_ARG.slice('--user='.length) : undefined;
+
+// Pin the Firestore project explicitly. Without this, applicationDefault()
+// resolves to whatever project the ambient credentials default to, which can
+// silently be the wrong (empty) project — the symptom is "Fetched 0 logs".
+// Override with --project=<id> or the standard GOOGLE_CLOUD_PROJECT env var.
+const PROJECT_ARG = process.argv.find((a) => a.startsWith('--project='));
+const PROJECT_ID =
+  (PROJECT_ARG ? PROJECT_ARG.slice('--project='.length) : undefined) ??
+  process.env.GOOGLE_CLOUD_PROJECT ??
+  process.env.GCLOUD_PROJECT ??
+  'fuelog-paddez';
 
 const NO_VEHICLE = '__no_vehicle__';
 
@@ -162,7 +176,7 @@ export function planOdometerBackfill(logs: BackfillLog[]): OdometerBackfillPlan 
 
 async function main(): Promise<void> {
   if (getApps().length === 0) {
-    initializeApp({ credential: applicationDefault() });
+    initializeApp({ credential: applicationDefault(), projectId: PROJECT_ID });
   }
   const db = getFirestore();
 
@@ -171,6 +185,7 @@ async function main(): Promise<void> {
       (ONLY_USER ? ` for user ${ONLY_USER}` : ' for all users') +
       (DRY_RUN ? '  (dry run — nothing will be written)' : ''),
   );
+  console.log(`Project: ${PROJECT_ID}`);
 
   // Select only the fields the backfill needs — fuelLogs can carry large fields
   // (receipt URLs, etc.) we never read, so this keeps memory and bandwidth down.
@@ -193,6 +208,16 @@ async function main(): Promise<void> {
   });
 
   console.log(`Fetched ${logs.length} logs.`);
+
+  if (logs.length === 0) {
+    console.warn(
+      `\nNo logs found in project "${PROJECT_ID}".\n` +
+        '  - Confirm the credentials target this project (GOOGLE_APPLICATION_CREDENTIALS).\n' +
+        '  - Override the project with --project=<id> or GOOGLE_CLOUD_PROJECT=<id>.' +
+        (ONLY_USER ? `\n  - Confirm --user=${ONLY_USER} is the correct UID.` : ''),
+    );
+    return;
+  }
 
   const plan = planOdometerBackfill(logs);
 


### PR DESCRIPTION
## 📋 Description

Follow-up to #216. Running the backfill with `--dry-run` reported **"Fetched 0 logs"** even though logs with missing odometer readings exist.

The cause: `initializeApp()` used `applicationDefault()` **without a `projectId`**, so the Admin SDK resolved to whatever project the ambient credentials defaulted to — not the fuelog project. It then queried an empty `(default)` Firestore and returned zero documents **with no error**, so the failure was silent.

## 🚀 Proposed Changes

- Pin the Firestore project explicitly in `initializeApp({ ..., projectId })`. Defaults to `fuelog-paddez`, overridable via a new `--project=<id>` flag or the standard `GOOGLE_CLOUD_PROJECT` / `GCLOUD_PROJECT` env vars.
- Log `Project: <id>` at startup so it's always clear which project is being hit.
- Warn loudly with remediation steps (credentials, `--project`, `--user`) when zero logs are fetched, so a misconfigured project can't fail silently again.
- Updated the script's usage header to document `--project`.

No change to the reconstruction logic — the pure planner and its 10 tests are untouched.

Usage:
```bash
npm run backfill-odometer -- --dry-run                  # defaults to fuelog-paddez
npm run backfill-odometer -- --dry-run --project=<id>   # or override
GOOGLE_CLOUD_PROJECT=<id> npm run backfill-odometer -- --dry-run
```

## 🛡️ Checklist

- [x] I have verified that all unit tests pass locally (`npm run test`).
- [x] I have verified that the build succeeds locally (`npm run build`).
- [x] I have added/updated unit tests for my changes. <!-- planner logic unchanged; change is in SDK init/CLI plumbing -->
- [x] I have followed the project's coding standards and naming conventions.
- [ ] I have updated the documentation (`docs/`) if necessary. <!-- N/A — script is self-documented in its header -->
- [ ] New features are gated behind a Remote Config flag. <!-- N/A — one-off admin script -->

## 🔗 Related Issues/PRs

Follow-up to #216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmiGZXwdJ58yGAkw5s9Mtv)_