### PR TITLE
feat(functions): add --verbose per-vehicle breakdown to odometer backfill

### DIFF
--- a/functions/src/__tests__/backfillOdometer.test.ts
+++ b/functions/src/__tests__/backfillOdometer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { planOdometerBackfill, BackfillLog } from '../scripts/backfillOdometer';
+import { planOdometerBackfill, summarizeGroups, BackfillLog } from '../scripts/backfillOdometer';
 
 // Build a log with a fake Timestamp ordered by `day`.
 const makeLog = (
@@ -168,5 +168,59 @@ describe('planOdometerBackfill', () => {
 
     expect(odoOf(plan, 'b')).toBe(100); // 200 - 100
     expect(odoOf(plan, 'a')).toBeUndefined(); // 100 - 5000 < 0, rejected
+  });
+});
+
+describe('summarizeGroups', () => {
+  const groupFor = (summaries: ReturnType<typeof summarizeGroups>, vehicleId: string | null) =>
+    summaries.find((s) => s.vehicleId === vehicleId);
+
+  it('reports counts, anchor status, and date range per vehicle', () => {
+    const logs = [
+      makeLog('a', 10, 100, 500, 'car1'),
+      makeLog('b', 20, 100, undefined, 'car1'),
+      makeLog('c', 30, 100, undefined, 'car2'), // car2 has no reading anywhere
+    ];
+
+    const summaries = summarizeGroups(logs);
+
+    const car1 = groupFor(summaries, 'car1')!;
+    expect(car1.total).toBe(2);
+    expect(car1.withOdometer).toBe(1);
+    expect(car1.hasAnchor).toBe(true);
+    expect(car1.earliestMillis).toBe(10);
+    expect(car1.latestMillis).toBe(20);
+
+    const car2 = groupFor(summaries, 'car2')!;
+    expect(car2.total).toBe(1);
+    expect(car2.withOdometer).toBe(0);
+    expect(car2.hasAnchor).toBe(false);
+  });
+
+  it('buckets logs with no vehicleId into a null group', () => {
+    // Built directly so vehicleId is genuinely absent (makeLog's default would
+    // otherwise replace an explicit undefined with 'car1').
+    const logs: BackfillLog[] = [
+      { id: 'a', userId: 'user1', timestamp: { toMillis: () => 1 }, distanceKm: 100 },
+    ];
+
+    const summaries = summarizeGroups(logs);
+
+    const noVehicle = groupFor(summaries, null)!;
+    expect(noVehicle).toBeDefined();
+    expect(noVehicle.hasAnchor).toBe(false);
+    expect(noVehicle.total).toBe(1);
+  });
+
+  it('lists anchorless groups before anchored ones for the same user', () => {
+    const logs = [
+      makeLog('a', 1, 100, 500, 'anchored'),
+      makeLog('b', 2, 100, undefined, 'orphan'),
+    ];
+
+    const summaries = summarizeGroups(logs);
+
+    expect(summaries[0].vehicleId).toBe('orphan'); // no anchor first
+    expect(summaries[1].vehicleId).toBe('anchored');
   });
 });

--- a/functions/src/scripts/backfillOdometer.ts
+++ b/functions/src/scripts/backfillOdometer.ts
@@ -24,6 +24,12 @@
 //   npm run backfill-odometer -- --dry-run        # report what would change
 //   npm run backfill-odometer -- --user=<uid>     # limit to a single user
 //   npm run backfill-odometer -- --project=<id>   # target a specific project
+//   npm run backfill-odometer -- --verbose        # print a per-vehicle breakdown
+//
+// The per-vehicle breakdown (--verbose) shows each (user, vehicle) group, how
+// many logs it has, how many already have an odometer reading, whether it has
+// an anchor to reconstruct from, and its date range. Use it to diagnose why
+// logs are skipped: a group with NO ANCHOR has no reading to count from.
 //
 // The Firestore project defaults to fuelog-paddez and can be overridden with
 // --project=<id> or GOOGLE_CLOUD_PROJECT. Credentials are read via application
@@ -34,6 +40,7 @@ import { initializeApp, getApps, applicationDefault } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
 
 const DRY_RUN = process.argv.includes('--dry-run');
+const VERBOSE = process.argv.includes('--verbose');
 const USER_ARG = process.argv.find((a) => a.startsWith('--user='));
 const ONLY_USER = USER_ARG ? USER_ARG.slice('--user='.length) : undefined;
 
@@ -174,6 +181,62 @@ export function planOdometerBackfill(logs: BackfillLog[]): OdometerBackfillPlan 
   return { updates, alreadySet, skipped, vehiclesAnchored, vehiclesWithoutAnchor };
 }
 
+/** A per-(user, vehicle) breakdown, for diagnosing why logs were skipped. */
+export interface GroupSummary {
+  userId: string;
+  /** null for logs that predate multi-vehicle support (no vehicleId). */
+  vehicleId: string | null;
+  total: number;
+  withOdometer: number;
+  /** True if the group has at least one reading to anchor reconstruction. */
+  hasAnchor: boolean;
+  earliestMillis: number | null;
+  latestMillis: number | null;
+}
+
+/**
+ * Pure diagnostic: summarises each (user, vehicle) group so it's clear which
+ * groups can be reconstructed (hasAnchor) and which can't, and over what date
+ * range. Sorted by user, then anchorless groups first, then by vehicle id.
+ */
+export function summarizeGroups(logs: BackfillLog[]): GroupSummary[] {
+  const groups = new Map<string, GroupSummary>();
+  for (const log of logs) {
+    const vehicleId = log.vehicleId ?? null;
+    const key = `${log.userId}::${vehicleId ?? NO_VEHICLE}`;
+    let summary = groups.get(key);
+    if (!summary) {
+      summary = {
+        userId: log.userId,
+        vehicleId,
+        total: 0,
+        withOdometer: 0,
+        hasAnchor: false,
+        earliestMillis: null,
+        latestMillis: null,
+      };
+      groups.set(key, summary);
+    }
+    summary.total++;
+    if (isValidReading(log.odometerKm)) {
+      summary.withOdometer++;
+      summary.hasAnchor = true;
+    }
+    if (log.timestamp && typeof log.timestamp.toMillis === 'function') {
+      const ms = log.timestamp.toMillis();
+      if (summary.earliestMillis === null || ms < summary.earliestMillis) summary.earliestMillis = ms;
+      if (summary.latestMillis === null || ms > summary.latestMillis) summary.latestMillis = ms;
+    }
+  }
+
+  return Array.from(groups.values()).sort(
+    (a, b) =>
+      a.userId.localeCompare(b.userId) ||
+      Number(a.hasAnchor) - Number(b.hasAnchor) || // anchorless groups first
+      (a.vehicleId ?? '').localeCompare(b.vehicleId ?? ''),
+  );
+}
+
 async function main(): Promise<void> {
   if (getApps().length === 0) {
     initializeApp({ credential: applicationDefault(), projectId: PROJECT_ID });
@@ -217,6 +280,20 @@ async function main(): Promise<void> {
         (ONLY_USER ? `\n  - Confirm --user=${ONLY_USER} is the correct UID.` : ''),
     );
     return;
+  }
+
+  if (VERBOSE) {
+    const fmt = (ms: number | null) => (ms === null ? '—' : new Date(ms).toISOString().slice(0, 10));
+    console.log('\nPer-vehicle breakdown:');
+    for (const g of summarizeGroups(logs)) {
+      const vehicle = g.vehicleId ?? '<no vehicle>';
+      const anchor = g.hasAnchor ? 'anchor ✓' : 'NO ANCHOR';
+      console.log(
+        `  user ${g.userId}  vehicle ${vehicle}  ` +
+          `${g.total} logs, ${g.withOdometer} with odometer  [${anchor}]  ` +
+          `${fmt(g.earliestMillis)} → ${fmt(g.latestMillis)}`,
+      );
+    }
   }
 
   const plan = planOdometerBackfill(logs);

--- a/functions/src/scripts/backfillOdometer.ts
+++ b/functions/src/scripts/backfillOdometer.ts
@@ -224,14 +224,18 @@ export function summarizeGroups(logs: BackfillLog[]): GroupSummary[] {
     }
     if (log.timestamp && typeof log.timestamp.toMillis === 'function') {
       const ms = log.timestamp.toMillis();
-      if (summary.earliestMillis === null || ms < summary.earliestMillis) summary.earliestMillis = ms;
-      if (summary.latestMillis === null || ms > summary.latestMillis) summary.latestMillis = ms;
+      // Only record finite values so earliestMillis/latestMillis stay safe to
+      // format later (a malformed timestamp returning NaN would break Date).
+      if (Number.isFinite(ms)) {
+        if (summary.earliestMillis === null || ms < summary.earliestMillis) summary.earliestMillis = ms;
+        if (summary.latestMillis === null || ms > summary.latestMillis) summary.latestMillis = ms;
+      }
     }
   }
 
   return Array.from(groups.values()).sort(
     (a, b) =>
-      a.userId.localeCompare(b.userId) ||
+      (a.userId ?? '').localeCompare(b.userId ?? '') ||
       Number(a.hasAnchor) - Number(b.hasAnchor) || // anchorless groups first
       (a.vehicleId ?? '').localeCompare(b.vehicleId ?? ''),
   );
@@ -283,7 +287,8 @@ async function main(): Promise<void> {
   }
 
   if (VERBOSE) {
-    const fmt = (ms: number | null) => (ms === null ? '—' : new Date(ms).toISOString().slice(0, 10));
+    const fmt = (ms: number | null) =>
+      ms === null || !Number.isFinite(ms) ? '—' : new Date(ms).toISOString().slice(0, 10);
     console.log('\nPer-vehicle breakdown:');
     for (const g of summarizeGroups(logs)) {
       const vehicle = g.vehicleId ?? '<no vehicle>';


### PR DESCRIPTION
## 📋 Description

Follow-up to #216 / #217. A dry-run reported `Reconstruct: 0` with 55 logs skipped across "4 vehicles w/o anchor", but there was no way to see *which* groups those were or why. This adds a diagnostic so the skip reasons are visible.

The backfill reconstructs odometers **per `(user, vehicle)` group**, and a group can only be filled if it contains at least one existing reading to anchor from (distances are relative; an absolute odometer needs one real number to count from). Logs that predate multi-vehicle support have no `vehicleId` and bucket into a separate "no vehicle" group, which is a common reason a group ends up anchorless.

## 🚀 Proposed Changes

- Added a `--verbose` flag that prints a per-`(user, vehicle)` breakdown: log count, how many already have an odometer reading, whether the group has an anchor (`anchor ✓` / `NO ANCHOR`), and its date range.
- Extracted the breakdown into a pure, unit-tested `summarizeGroups()` function; anchorless groups are listed first so the problem groups stand out.
- Added tests for counts/anchor status/date range, the null (`<no vehicle>`) bucket, and ordering.
- Documented `--verbose` in the script's usage header.

Example:
```bash
npm run backfill-odometer -- --dry-run --verbose --user=<uid>
```
```
Per-vehicle breakdown:
  user abc123  vehicle car-xyz   8 logs, 8 with odometer  [anchor ✓]  2026-01-04 → 2026-06-20
  user abc123  vehicle <no vehicle>  41 logs, 0 with odometer  [NO ANCHOR]  2021-03-11 → 2025-12-30
  ...
```

## 🛡️ Checklist

- [x] I have verified that all unit tests pass locally (`npm run test`).
- [x] I have verified that the build succeeds locally (`npm run build`).
- [x] I have added/updated unit tests for my changes.
- [x] I have followed the project's coding standards and naming conventions.
- [ ] I have updated the documentation (`docs/`) if necessary. <!-- N/A — script is self-documented in its header -->
- [ ] New features are gated behind a Remote Config flag. <!-- N/A — one-off admin script -->

## 🔗 Related Issues/PRs

Follow-up to #216 and #217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmiGZXwdJ58yGAkw5s9Mtv)_