### PR TITLE
feat(functions): add script to assign stations to coordinate-only logs

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -10,6 +10,7 @@
     "logs": "firebase functions:log",
     "recompress-receipts": "npm run build && node lib/scripts/recompressReceipts.js",
     "backfill-odometer": "npm run build && node lib/scripts/backfillOdometer.js",
+    "assign-stations": "npm run build && node lib/scripts/assignStationsToLogs.js",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/functions/src/__tests__/assignStationsToLogs.test.ts
+++ b/functions/src/__tests__/assignStationsToLogs.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import {
+  selectUnassignedLogs,
+  pickNearestStation,
+  stationDocId,
+  pricePerLitre,
+  haversineDistanceKm,
+  AssignLog,
+  OverpassElement,
+} from '../scripts/assignStationsToLogs';
+
+const log = (over: Partial<AssignLog> = {}): AssignLog => ({
+  id: 'l1',
+  userId: 'u1',
+  latitude: 53.34,
+  longitude: -6.26,
+  ...over,
+});
+
+describe('selectUnassignedLogs', () => {
+  it('keeps logs with coordinates and no station', () => {
+    const result = selectUnassignedLogs([log({ id: 'keep' })]);
+    expect(result.map((l) => l.id)).toEqual(['keep']);
+  });
+
+  it('drops logs that already have a station', () => {
+    expect(selectUnassignedLogs([log({ stationId: 'node_1' })])).toHaveLength(0);
+  });
+
+  it('drops logs missing either coordinate', () => {
+    expect(selectUnassignedLogs([log({ latitude: undefined })])).toHaveLength(0);
+    expect(selectUnassignedLogs([log({ longitude: undefined })])).toHaveLength(0);
+  });
+
+  it('keeps logs sitting exactly on the equator/prime meridian (0 is valid)', () => {
+    expect(selectUnassignedLogs([log({ latitude: 0, longitude: 0 })])).toHaveLength(1);
+  });
+
+  it('drops logs with non-finite coordinates', () => {
+    expect(selectUnassignedLogs([log({ latitude: NaN })])).toHaveLength(0);
+  });
+});
+
+describe('pickNearestStation', () => {
+  const node = (
+    id: number,
+    lat: number,
+    lon: number,
+    tags: OverpassElement['tags'] = {},
+  ): OverpassElement => ({
+    type: 'node',
+    id,
+    lat,
+    lon,
+    tags: { amenity: 'fuel', ...tags },
+  });
+
+  it('returns null when no fuel elements are present', () => {
+    const nonFuel: OverpassElement = { type: 'node', id: 1, lat: 53.34, lon: -6.26, tags: {} };
+    expect(pickNearestStation([nonFuel], 53.34, -6.26)).toBeNull();
+  });
+
+  it('chooses the closest station to the query point', () => {
+    const far = node(1, 53.4, -6.3, { name: 'Far' });
+    const near = node(2, 53.341, -6.261, { name: 'Near' });
+    const result = pickNearestStation([far, near], 53.34, -6.26);
+    expect(result?.name).toBe('Near');
+    expect(result?.id).toBe('node/2');
+  });
+
+  it('builds name, brand and address from tags', () => {
+    const station = node(7, 53.34, -6.26, {
+      name: 'Circle K',
+      brand: 'Circle K',
+      'addr:street': 'Main St',
+      'addr:housenumber': '12',
+    });
+    const result = pickNearestStation([station], 53.34, -6.26);
+    expect(result).toMatchObject({
+      osmId: 'node/7',
+      name: 'Circle K',
+      brand: 'Circle K',
+      address: 'Main St 12',
+    });
+  });
+
+  it('falls back to brand then a placeholder name, and operator for brand', () => {
+    const brandOnly = pickNearestStation([node(1, 53.34, -6.26, { brand: 'Shell' })], 53.34, -6.26);
+    expect(brandOnly?.name).toBe('Shell');
+
+    const operatorOnly = pickNearestStation(
+      [node(2, 53.34, -6.26, { operator: 'Maxol' })],
+      53.34,
+      -6.26,
+    );
+    expect(operatorOnly?.name).toBe('Unknown Station');
+    expect(operatorOnly?.brand).toBe('Maxol');
+  });
+
+  it('uses the center of a way/relation for its coordinates', () => {
+    const way: OverpassElement = {
+      type: 'way',
+      id: 99,
+      lat: 0,
+      lon: 0,
+      center: { lat: 53.34, lon: -6.26 },
+      tags: { amenity: 'fuel', name: 'Big Forecourt' },
+    };
+    const result = pickNearestStation([way], 53.34, -6.26);
+    expect(result?.id).toBe('way/99');
+    expect(result?.latitude).toBeCloseTo(53.34);
+    expect(result?.longitude).toBeCloseTo(-6.26);
+  });
+});
+
+describe('stationDocId', () => {
+  it('replaces every slash so the id is a valid Firestore doc id', () => {
+    expect(stationDocId('node/123')).toBe('node_123');
+    expect(stationDocId('relation/1/2')).toBe('relation_1_2');
+  });
+});
+
+describe('pricePerLitre', () => {
+  it('divides cost by litres', () => {
+    expect(pricePerLitre(75, 50)).toBeCloseTo(1.5);
+  });
+
+  it('returns null for missing, non-finite, or non-positive litres', () => {
+    expect(pricePerLitre(undefined, 50)).toBeNull();
+    expect(pricePerLitre(75, undefined)).toBeNull();
+    expect(pricePerLitre(75, 0)).toBeNull();
+    expect(pricePerLitre(75, -10)).toBeNull();
+    expect(pricePerLitre(NaN, 50)).toBeNull();
+  });
+});
+
+describe('haversineDistanceKm', () => {
+  it('is zero for identical points', () => {
+    expect(haversineDistanceKm(53.34, -6.26, 53.34, -6.26)).toBe(0);
+  });
+
+  it('approximates a known short distance', () => {
+    // ~111 m north (0.001 deg latitude).
+    expect(haversineDistanceKm(53.34, -6.26, 53.341, -6.26)).toBeCloseTo(0.111, 2);
+  });
+});

--- a/functions/src/scripts/assignStationsToLogs.ts
+++ b/functions/src/scripts/assignStationsToLogs.ts
@@ -1,0 +1,428 @@
+// functions/src/scripts/assignStationsToLogs.ts
+//
+// One-off backfill job.
+//
+// Station association (fuelLogs.stationId) links a fuelling to a physical
+// petrol station so the map can group fillings by station instead of by raw
+// GPS proximity. Logs that have coordinates but no stationId — including ones
+// whose locations were pinned retroactively by hand — have nothing to group on,
+// so the map falls back to rounding their coordinates and renders them as
+// loose "unassigned" clusters (see src/components/FuelMapPage.tsx).
+//
+// This job resolves each such log to a station the same way live logging does:
+// it queries the OpenStreetMap Overpass API for the nearest `amenity=fuel`
+// within a radius, gets-or-creates the matching global `stations` document,
+// writes its id back onto the log, and folds the log's price into the station's
+// running average. It mirrors the in-app "Identify Stations" maintenance action
+// (src/utils/migrationService.ts) but runs server-side over every user at once.
+//
+// Usage (from the functions/ directory):
+//   npm run assign-stations                       # assign stations, write changes
+//   npm run assign-stations -- --dry-run          # report what would change
+//   npm run assign-stations -- --user=<uid>       # limit to a single user
+//   npm run assign-stations -- --project=<id>     # target a specific project
+//   npm run assign-stations -- --radius=250       # search radius in metres (default 150)
+//   npm run assign-stations -- --delay=1500       # ms between Overpass calls (default 1100)
+//   npm run assign-stations -- --verbose          # print each log as it is resolved
+//
+// Overpass enforces fair-use rate limits, so calls are spaced out (--delay) and
+// retried with exponential backoff on HTTP 429. A large backlog therefore takes
+// a while; the radius and delay let you trade speed against accuracy and load.
+//
+// The Firestore project defaults to fuelog-paddez and can be overridden with
+// --project=<id> or GOOGLE_CLOUD_PROJECT. Credentials are read via application
+// default credentials, e.g.:
+//   GOOGLE_APPLICATION_CREDENTIALS=../service-account.json npm run assign-stations
+
+import { initializeApp, getApps, applicationDefault } from 'firebase-admin/app';
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const VERBOSE = process.argv.includes('--verbose');
+const USER_ARG = process.argv.find((a) => a.startsWith('--user='));
+const ONLY_USER = USER_ARG ? USER_ARG.slice('--user='.length) : undefined;
+
+const RADIUS_ARG = process.argv.find((a) => a.startsWith('--radius='));
+const RADIUS_METERS = RADIUS_ARG ? Number(RADIUS_ARG.slice('--radius='.length)) : 150;
+
+const DELAY_ARG = process.argv.find((a) => a.startsWith('--delay='));
+const DELAY_MS = DELAY_ARG ? Number(DELAY_ARG.slice('--delay='.length)) : 1100;
+
+// Pin the Firestore project explicitly. Without this, applicationDefault()
+// resolves to whatever project the ambient credentials default to, which can
+// silently be the wrong (empty) project — the symptom is "Fetched 0 logs".
+// Override with --project=<id> or the standard GOOGLE_CLOUD_PROJECT env var.
+const PROJECT_ARG = process.argv.find((a) => a.startsWith('--project='));
+const PROJECT_ID =
+  (PROJECT_ARG ? PROJECT_ARG.slice('--project='.length) : undefined) ??
+  process.env.GOOGLE_CLOUD_PROJECT ??
+  process.env.GCLOUD_PROJECT ??
+  'fuelog-paddez';
+
+const OVERPASS_URL = 'https://overpass-api.de/api/interpreter';
+
+/** A petrol station resolved from OpenStreetMap. Mirrors OSMStation in
+ *  src/utils/locationService.ts so the data written here matches live logging. */
+export interface OSMStation {
+  id: string; // e.g. "node/123" — unique OSM identifier
+  osmId: string;
+  name: string;
+  brand?: string;
+  latitude: number;
+  longitude: number;
+  address?: string;
+}
+
+/** The raw shape Overpass returns for a single map element. */
+export interface OverpassElement {
+  type: 'node' | 'way' | 'relation';
+  id: number;
+  lat: number;
+  lon: number;
+  tags?: {
+    amenity?: string;
+    name?: string;
+    brand?: string;
+    operator?: string;
+    'addr:street'?: string;
+    'addr:housenumber'?: string;
+  };
+  center?: { lat: number; lon: number };
+}
+
+/** Minimal shape of a log needed to assign a station. Decoupled from Firestore
+ *  so the planner can be unit-tested with plain objects. */
+export interface AssignLog {
+  id: string;
+  userId: string;
+  latitude?: number;
+  longitude?: number;
+  stationId?: string;
+  cost?: number;
+  fuelAmountLiters?: number;
+}
+
+const isValidCoord = (value: number | undefined): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+/**
+ * Pure selector: the logs this job can act on are the ones with usable
+ * coordinates but no station yet — exactly the entries that surface as
+ * "unassigned" clusters on the map. No Firestore access, so it is unit-testable.
+ */
+export function selectUnassignedLogs(logs: AssignLog[]): AssignLog[] {
+  return logs.filter(
+    (log) => !log.stationId && isValidCoord(log.latitude) && isValidCoord(log.longitude),
+  );
+}
+
+const EARTH_RADIUS_KM = 6371;
+
+/**
+ * Great-circle distance between two coordinates, in kilometres. Mirrors
+ * haversineDistanceKm in src/utils/locationService.ts.
+ */
+export function haversineDistanceKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+  return EARTH_RADIUS_KM * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+/**
+ * Pure picker: given the elements Overpass returned around (lat, lon), choose
+ * the closest fuel station and map it to an OSMStation, or null if none qualify.
+ * Mirrors the selection logic in src/utils/locationService.ts so the script and
+ * the app agree on which station a coordinate resolves to.
+ */
+export function pickNearestStation(
+  elements: OverpassElement[],
+  lat: number,
+  lon: number,
+): OSMStation | null {
+  const stations = elements.filter((el) => el.tags && el.tags.amenity === 'fuel');
+  if (stations.length === 0) return null;
+
+  // A way/relation has no lat/lon of its own; fall back to its center, then to
+  // the query point, so distance comparisons always have real coordinates.
+  const coordsOf = (el: OverpassElement): { lat: number; lon: number } => {
+    if (el.type === 'node') return { lat: el.lat, lon: el.lon };
+    if (el.center) return { lat: el.center.lat, lon: el.center.lon };
+    return { lat, lon };
+  };
+
+  const best = stations.reduce((closest, candidate) => {
+    const c = coordsOf(candidate);
+    const b = coordsOf(closest);
+    return haversineDistanceKm(c.lat, c.lon, lat, lon) <
+      haversineDistanceKm(b.lat, b.lon, lat, lon)
+      ? candidate
+      : closest;
+  });
+
+  const { lat: finalLat, lon: finalLon } = coordsOf(best);
+  const street = best.tags?.['addr:street'];
+
+  return {
+    id: `${best.type}/${best.id}`,
+    osmId: `${best.type}/${best.id}`,
+    name: best.tags?.name || best.tags?.brand || 'Unknown Station',
+    brand: best.tags?.brand || best.tags?.operator,
+    latitude: finalLat,
+    longitude: finalLon,
+    address: street ? `${street} ${best.tags?.['addr:housenumber'] || ''}`.trim() : undefined,
+  };
+}
+
+/**
+ * Firestore document id for a station. OSM ids contain "/", which is a path
+ * separator in Firestore, so it is swapped for "_". Mirrors getOrCreateStation
+ * in src/firebase/firestoreService.ts so both paths address the same document.
+ */
+export function stationDocId(osmId: string): string {
+  return osmId.replace(/\//g, '_');
+}
+
+/**
+ * Price per litre for a log, or null when the figures are missing/unusable so
+ * callers can skip folding a bogus value into a station's average.
+ */
+export function pricePerLitre(cost: number | undefined, liters: number | undefined): number | null {
+  if (typeof cost !== 'number' || typeof liters !== 'number') return null;
+  if (!Number.isFinite(cost) || !Number.isFinite(liters) || liters <= 0) return null;
+  return cost / liters;
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Queries Overpass for fuel stations within `radiusMeters` of (lat, lon) and
+ * returns the nearest as an OSMStation, or null when none are nearby. Retries
+ * with exponential backoff on HTTP 429; other failures propagate so the caller
+ * can count them as errors rather than silently skipping a log.
+ */
+export async function findNearestStation(
+  lat: number,
+  lon: number,
+  radiusMeters: number = RADIUS_METERS,
+): Promise<OSMStation | null> {
+  const query = `
+    [out:json][timeout:25];
+    (
+      node["amenity"="fuel"](around:${radiusMeters},${lat},${lon});
+      way["amenity"="fuel"](around:${radiusMeters},${lat},${lon});
+      relation["amenity"="fuel"](around:${radiusMeters},${lat},${lon});
+    );
+    out body;
+    >;
+    out center qt;
+  `;
+
+  const maxRetries = 3;
+  let delay = 2000;
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    const response = await fetch(OVERPASS_URL, {
+      method: 'POST',
+      body: `data=${encodeURIComponent(query)}`,
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    });
+
+    if (response.status === 429) {
+      console.warn(
+        `  Overpass rate limit hit, retrying in ${delay}ms (attempt ${attempt + 1}/${maxRetries})`,
+      );
+      await sleep(delay);
+      delay *= 2;
+      continue;
+    }
+
+    if (!response.ok) {
+      throw new Error(`Overpass API responded with status ${response.status}`);
+    }
+
+    const data = (await response.json()) as { elements?: OverpassElement[] };
+    return pickNearestStation(data.elements ?? [], lat, lon);
+  }
+
+  throw new Error('Overpass API unavailable after maximum retries.');
+}
+
+export interface AssignResult {
+  assigned: number;
+  /** Logs with no station within the search radius. */
+  skipped: number;
+  /** Logs whose lookup threw (network/Overpass errors). */
+  failed: number;
+}
+
+async function main(): Promise<void> {
+  if (getApps().length === 0) {
+    initializeApp({ credential: applicationDefault(), projectId: PROJECT_ID });
+  }
+  const db = getFirestore();
+
+  if (!Number.isFinite(RADIUS_METERS) || RADIUS_METERS <= 0) {
+    throw new Error(`Invalid --radius value: ${RADIUS_ARG}`);
+  }
+
+  console.log(
+    'Assigning stations to coordinate-only logs' +
+      (ONLY_USER ? ` for user ${ONLY_USER}` : ' for all users') +
+      (DRY_RUN ? '  (dry run — nothing will be written)' : ''),
+  );
+  console.log(`Project: ${PROJECT_ID}  radius: ${RADIUS_METERS}m  delay: ${DELAY_MS}ms`);
+
+  // Pull only the fields needed to resolve and price a station; fuelLogs can
+  // carry large fields (receipt URLs, etc.) we never read here.
+  let queryRef: FirebaseFirestore.Query = db
+    .collection('fuelLogs')
+    .select('userId', 'latitude', 'longitude', 'stationId', 'cost', 'fuelAmountLiters');
+  if (ONLY_USER) queryRef = queryRef.where('userId', '==', ONLY_USER);
+
+  const snapshot = await queryRef.get();
+  const logs: AssignLog[] = snapshot.docs.map((d) => {
+    const data = d.data();
+    return {
+      id: d.id,
+      userId: data.userId,
+      latitude: data.latitude,
+      longitude: data.longitude,
+      stationId: data.stationId,
+      cost: data.cost,
+      fuelAmountLiters: data.fuelAmountLiters,
+    };
+  });
+
+  console.log(`Fetched ${logs.length} logs.`);
+
+  if (logs.length === 0) {
+    console.warn(
+      `\nNo logs found in project "${PROJECT_ID}".\n` +
+        '  - Confirm the credentials target this project (GOOGLE_APPLICATION_CREDENTIALS).\n' +
+        '  - Override the project with --project=<id> or GOOGLE_CLOUD_PROJECT=<id>.' +
+        (ONLY_USER ? `\n  - Confirm --user=${ONLY_USER} is the correct UID.` : ''),
+    );
+    return;
+  }
+
+  const toAssign = selectUnassignedLogs(logs);
+  console.log(`${toAssign.length} have coordinates but no station.`);
+
+  if (toAssign.length === 0) {
+    console.log('\nNothing to do.');
+    return;
+  }
+
+  const result: AssignResult = { assigned: 0, skipped: 0, failed: 0 };
+
+  for (let i = 0; i < toAssign.length; i++) {
+    const log = toAssign[i];
+    // Space out Overpass calls to stay within its fair-use limits.
+    if (i > 0) await sleep(DELAY_MS);
+
+    try {
+      const nearest = await findNearestStation(log.latitude!, log.longitude!, RADIUS_METERS);
+      if (!nearest) {
+        result.skipped++;
+        if (VERBOSE) {
+          console.log(`  ${log.id}  no station within ${RADIUS_METERS}m — skipped`);
+        }
+        continue;
+      }
+
+      const docId = stationDocId(nearest.id);
+      const price = pricePerLitre(log.cost, log.fuelAmountLiters);
+
+      if (VERBOSE || DRY_RUN) {
+        console.log(
+          `  ${log.id}  ->  ${nearest.name} (${docId})` +
+            (price !== null ? `  @ ${price.toFixed(3)}/L` : ''),
+        );
+      }
+
+      if (DRY_RUN) {
+        result.assigned++;
+        continue;
+      }
+
+      await getOrCreateStation(db, nearest);
+      await db.collection('fuelLogs').doc(log.id).update({ stationId: docId });
+      if (price !== null) await updateStationMetrics(db, docId, price);
+
+      result.assigned++;
+    } catch (error) {
+      console.error(`  Failed to assign station for log ${log.id}:`, error);
+      result.failed++;
+    }
+  }
+
+  console.log(`\n${DRY_RUN ? 'Plan' : 'Result'}:`);
+  console.log(`  ${DRY_RUN ? 'Would assign' : 'Assigned'}: ${result.assigned}`);
+  console.log(`  Skipped (no station nearby): ${result.skipped}`);
+  console.log(`  Failed (lookup errors):      ${result.failed}`);
+  console.log(DRY_RUN ? '\nDry run complete.' : '\nDone.');
+}
+
+/**
+ * Gets-or-creates the global station document for an OSM station, keyed by its
+ * sanitised OSM id. Mirrors getOrCreateStation in firestoreService.ts; existing
+ * documents are left untouched so concurrent app writes are never clobbered.
+ */
+async function getOrCreateStation(
+  db: FirebaseFirestore.Firestore,
+  osmStation: OSMStation,
+): Promise<string> {
+  const docId = stationDocId(osmStation.id);
+  const ref = db.collection('stations').doc(docId);
+  const snap = await ref.get();
+  if (snap.exists) return docId;
+
+  await ref.set({
+    osmId: osmStation.osmId,
+    name: osmStation.name,
+    brand: osmStation.brand || '',
+    latitude: osmStation.latitude,
+    longitude: osmStation.longitude,
+    address: osmStation.address || '',
+    logCount: 0,
+    avgPrice: 0,
+  });
+  return docId;
+}
+
+/**
+ * Folds one log's price per litre into a station's running average, in a
+ * transaction. Mirrors updateStationMetrics in firestoreService.ts so the
+ * figures stay consistent with averages produced during live logging.
+ */
+async function updateStationMetrics(
+  db: FirebaseFirestore.Firestore,
+  stationId: string,
+  pricePerLitreValue: number,
+): Promise<void> {
+  const ref = db.collection('stations').doc(stationId);
+  await db.runTransaction(async (tx) => {
+    const snap = await tx.get(ref);
+    if (!snap.exists) return;
+    const data = snap.data() as { logCount?: number; avgPrice?: number };
+    const currentCount = data.logCount || 0;
+    const currentAvg = data.avgPrice || 0;
+    const newAvg = (currentAvg * currentCount + pricePerLitreValue) / (currentCount + 1);
+    tx.update(ref, {
+      logCount: FieldValue.increment(1),
+      avgPrice: newAvg,
+      lastPrice: pricePerLitreValue,
+    });
+  });
+}
+
+// Only run when invoked directly, so the pure helpers can be imported by tests.
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/functions/src/scripts/assignStationsToLogs.ts
+++ b/functions/src/scripts/assignStationsToLogs.ts
@@ -61,6 +61,10 @@ const PROJECT_ID =
 
 const OVERPASS_URL = 'https://overpass-api.de/api/interpreter';
 
+// Cap a single Overpass request so a hung connection can't stall the batch
+// indefinitely. The query itself also self-limits server-side ([timeout:25]).
+const REQUEST_TIMEOUT_MS = 30000;
+
 /** A petrol station resolved from OpenStreetMap. Mirrors OSMStation in
  *  src/utils/locationService.ts so the data written here matches live logging. */
 export interface OSMStation {
@@ -224,27 +228,45 @@ export async function findNearestStation(
   const maxRetries = 3;
   let delay = 2000;
   for (let attempt = 0; attempt < maxRetries; attempt++) {
-    const response = await fetch(OVERPASS_URL, {
-      method: 'POST',
-      body: `data=${encodeURIComponent(query)}`,
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    });
+    const isLastAttempt = attempt === maxRetries - 1;
+    try {
+      const response = await fetch(OVERPASS_URL, {
+        method: 'POST',
+        body: `data=${encodeURIComponent(query)}`,
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
 
-    if (response.status === 429) {
+      // 429 (rate limited) and 5xx (server) are transient — back off and retry.
+      if (response.status === 429 || response.status >= 500) {
+        if (isLastAttempt) {
+          throw new Error(`Overpass API responded with status ${response.status}`);
+        }
+        console.warn(
+          `  Overpass returned ${response.status}, retrying in ${delay}ms (attempt ${attempt + 1}/${maxRetries})`,
+        );
+        await sleep(delay);
+        delay *= 2;
+        continue;
+      }
+
+      if (!response.ok) {
+        throw new Error(`Overpass API responded with status ${response.status}`);
+      }
+
+      const data = (await response.json()) as { elements?: OverpassElement[] };
+      return pickNearestStation(data.elements ?? [], lat, lon);
+    } catch (err) {
+      // Network failures and the AbortSignal timeout land here; retry them too,
+      // but let the final failure propagate so the caller counts it as an error.
+      if (isLastAttempt) throw err;
       console.warn(
-        `  Overpass rate limit hit, retrying in ${delay}ms (attempt ${attempt + 1}/${maxRetries})`,
+        `  Overpass request failed, retrying in ${delay}ms (attempt ${attempt + 1}/${maxRetries}):`,
+        err,
       );
       await sleep(delay);
       delay *= 2;
-      continue;
     }
-
-    if (!response.ok) {
-      throw new Error(`Overpass API responded with status ${response.status}`);
-    }
-
-    const data = (await response.json()) as { elements?: OverpassElement[] };
-    return pickNearestStation(data.elements ?? [], lat, lon);
   }
 
   throw new Error('Overpass API unavailable after maximum retries.');
@@ -349,8 +371,7 @@ async function main(): Promise<void> {
       }
 
       await getOrCreateStation(db, nearest);
-      await db.collection('fuelLogs').doc(log.id).update({ stationId: docId });
-      if (price !== null) await updateStationMetrics(db, docId, price);
+      await assignLogToStation(db, log.id, docId, price);
 
       result.assigned++;
     } catch (error) {
@@ -394,28 +415,40 @@ async function getOrCreateStation(
 }
 
 /**
- * Folds one log's price per litre into a station's running average, in a
- * transaction. Mirrors updateStationMetrics in firestoreService.ts so the
- * figures stay consistent with averages produced during live logging.
+ * Atomically stamps a log with its stationId and folds its price per litre into
+ * the station's running average, in a single transaction. Doing both together
+ * means a metrics failure can never leave the log marked as assigned (and thus
+ * skipped on re-run) with its price silently dropped from the station average.
+ * When the price is unusable, only the stationId is written. The averaging
+ * mirrors updateStationMetrics in firestoreService.ts so figures stay
+ * consistent with those produced during live logging.
  */
-async function updateStationMetrics(
+async function assignLogToStation(
   db: FirebaseFirestore.Firestore,
+  logId: string,
   stationId: string,
-  pricePerLitreValue: number,
+  pricePerLitreValue: number | null,
 ): Promise<void> {
-  const ref = db.collection('stations').doc(stationId);
+  const stationRef = db.collection('stations').doc(stationId);
+  const logRef = db.collection('fuelLogs').doc(logId);
+
   await db.runTransaction(async (tx) => {
-    const snap = await tx.get(ref);
-    if (!snap.exists) return;
-    const data = snap.data() as { logCount?: number; avgPrice?: number };
-    const currentCount = data.logCount || 0;
-    const currentAvg = data.avgPrice || 0;
-    const newAvg = (currentAvg * currentCount + pricePerLitreValue) / (currentCount + 1);
-    tx.update(ref, {
-      logCount: FieldValue.increment(1),
-      avgPrice: newAvg,
-      lastPrice: pricePerLitreValue,
-    });
+    // Read before any write (Firestore requires reads first).
+    if (pricePerLitreValue !== null) {
+      const snap = await tx.get(stationRef);
+      if (snap.exists) {
+        const data = snap.data() as { logCount?: number; avgPrice?: number };
+        const currentCount = data.logCount || 0;
+        const currentAvg = data.avgPrice || 0;
+        const newAvg = (currentAvg * currentCount + pricePerLitreValue) / (currentCount + 1);
+        tx.update(stationRef, {
+          logCount: FieldValue.increment(1),
+          avgPrice: newAvg,
+          lastPrice: pricePerLitreValue,
+        });
+      }
+    }
+    tx.update(logRef, { stationId });
   });
 }
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,6 +15,36 @@ Then, you can open `mock_logs.tsv` in a text editor, copy its content, and paste
 ### Configuration
 You can edit the `numEntries`, `brands`, and date range variables directly at the top of the script to customize the generated data.
 
+## Assigning stations to coordinate-only logs
+
+Logs that have coordinates but no `stationId` — including fuel station locations
+pinned retroactively by hand — have nothing to group on, so the map renders them
+as loose "unassigned" clusters. The one-off job at
+[`functions/src/scripts/assignStationsToLogs.ts`](../functions/src/scripts/assignStationsToLogs.ts)
+resolves each of these to a station the same way live logging does: it looks up
+the nearest `amenity=fuel` via the OpenStreetMap Overpass API, gets-or-creates
+the matching `stations` document, writes its id back onto the log, and folds the
+log's price into the station's running average. It is the batch, server-side
+equivalent of the in-app **Profile → Maintenance → Identify Stations** action.
+
+Existing stations are never overwritten and logs that already have a `stationId`
+are skipped, so the job is safe to re-run.
+
+### Usage
+Run from the `functions/` directory with application default credentials:
+
+```bash
+cd functions
+GOOGLE_APPLICATION_CREDENTIALS=../service-account.json npm run assign-stations -- --dry-run   # preview
+GOOGLE_APPLICATION_CREDENTIALS=../service-account.json npm run assign-stations                # apply
+```
+
+Flags: `--dry-run` (report only), `--user=<uid>` (one user), `--project=<id>`
+(target project, defaults to `fuelog-paddez`), `--radius=<m>` (search radius,
+default 150), `--delay=<ms>` (spacing between Overpass calls, default 1100), and
+`--verbose` (print each log as it resolves). Overpass enforces fair-use limits,
+so a large backlog is processed slowly and retried with backoff on rate limits.
+
 ## Re-compressing legacy receipt images
 
 PR #211 added client-side compression so newly uploaded receipts are resized to a


### PR DESCRIPTION
## 📋 Description

Fuel logs that have coordinates but no `stationId` — including station locations that were pinned retroactively by hand — have nothing to group on, so `FuelMapPage` falls back to rounding their raw coordinates and renders them as loose **"unassigned"** clusters.

This adds a one-off, server-side backfill job that resolves each such log to a real station the same way live logging does, clearing the unassigned clusters. It is the batch equivalent of the existing in-app **Profile → Maintenance → Identify Stations** action (`src/utils/migrationService.ts`), but runs over every user at once with admin credentials.

## 🚀 Proposed Changes

- Added `functions/src/scripts/assignStationsToLogs.ts`: for each log with coordinates and no `stationId`, looks up the nearest `amenity=fuel` via the OSM Overpass API, gets-or-creates the matching `stations` document, writes its id back onto the log, and folds the log's price into the station's running average. Existing stations are never overwritten and already-assigned logs are skipped, so it is safe to re-run.
- Mirrored the `backfillOdometer` conventions: pure, unit-tested helpers (`selectUnassignedLogs`, `pickNearestStation`, `stationDocId`, `pricePerLitre`, `haversineDistanceKm`) separated from the Firestore/Overpass I/O, plus a `require.main` guard.
- CLI flags: `--dry-run`, `--user=<uid>`, `--project=<id>` (defaults to `fuelog-paddez`), `--radius=<m>` (default 150), `--delay=<ms>` (default 1100, to respect Overpass fair-use limits, with backoff on HTTP 429), and `--verbose`.
- Added the `assign-stations` npm script to `functions/package.json`.
- Added `functions/src/__tests__/assignStationsToLogs.test.ts` (15 tests covering selection, nearest-station pick incl. ways/relations and tag fallbacks, id sanitisation, and pricing edge cases).
- Documented usage in `scripts/README.md`.

## 🛡️ Checklist
- [x] I have verified that all unit tests pass locally (`npm run test`). — full `functions` suite: 83 passed.
- [ ] I have verified that the build succeeds locally (`npm run build`). — `tsc` fails on a pre-existing `TS5011` (missing `rootDir`) that also fails on `main`/clean tree; type-checks clean with `tsc --noEmit --rootDir src`.
- [x] I have added/updated unit tests for my changes.
- [x] I have followed the project's coding standards and naming conventions.
- [x] I have updated the documentation (`docs/`) if necessary. — updated `scripts/README.md`.
- [ ] New features are gated behind a Remote Config flag. — N/A; this is a one-off maintenance script, not a user-facing feature.

## 🔗 Related Issues/PRs
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQxYdmgVAufn4dcGZTLeBb)_