### PR TITLE
feat(map): make Map page full-bleed across the viewport

### DIFF
--- a/src/components/AuthenticatedApp.tsx
+++ b/src/components/AuthenticatedApp.tsx
@@ -56,6 +56,12 @@ const AdminConsolePage = lazyWithRetry(() => import('../pages/AdminConsolePage')
 // horizontal scrollbar even on wide monitors.
 const WIDE_LAYOUT_PATHS = new Set(['/history', '/stations']);
 
+// The map renders as a full-bleed, fixed full-viewport layer that sits
+// *behind* the chrome (the translucent header and the footer/bottom-nav
+// float over it). On this route the normal centered content column would
+// just be an empty padded box, so drop the container constraints.
+const FULL_BLEED_PATHS = new Set(['/map']);
+
 /** Loading fallback for Suspense */
 const PageLoader = () => {
   const { t } = useTranslation();
@@ -71,6 +77,9 @@ function AuthenticatedApp(): JSX.Element {
   const { user, logout } = useAuth();
   const location = useLocation();
   const { t } = useTranslation();
+
+  const currentPath = location.pathname.replace(/\/$/, '');
+  const isFullBleed = FULL_BLEED_PATHS.has(currentPath);
 
   const getNavLinkClass = (path: string): string => {
     const baseClass = "px-3 py-1.5 text-sm font-bold rounded-xl transition-all duration-200";
@@ -119,10 +128,14 @@ function AuthenticatedApp(): JSX.Element {
 
       <SyncStatus />
 
-      <main className={`flex-grow container mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8 w-full min-w-0 ${
-        WIDE_LAYOUT_PATHS.has(location.pathname.replace(/\/$/, '')) ? 'max-w-7xl' : 'max-w-5xl'
+      <main className={`flex-grow w-full min-w-0 ${
+        isFullBleed
+          ? ''
+          : `container mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8 ${
+              WIDE_LAYOUT_PATHS.has(currentPath) ? 'max-w-7xl' : 'max-w-5xl'
+            }`
       }`}>
-        <ImportOnboardingPrompt />
+        {!isFullBleed && <ImportOnboardingPrompt />}
         <ErrorBoundary>
         <Suspense fallback={<PageLoader />}>
           <Routes>
@@ -142,7 +155,7 @@ function AuthenticatedApp(): JSX.Element {
         </ErrorBoundary>
       </main>
 
-      <footer className="hidden sm:block bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 py-4 mb-0">
+      <footer className="hidden sm:block relative z-30 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 py-4 mb-0">
           <div className="container mx-auto px-4 sm:px-6 lg:px-8 text-center text-sm text-gray-500 dark:text-gray-400">
                {t('footer.copyright', { year: new Date().getFullYear() })} | {' '}
                <Link to="/about" className="hover:text-amber-600 dark:hover:text-amber-400 underline underline-offset-2">

--- a/src/components/FuelMapPage.tsx
+++ b/src/components/FuelMapPage.tsx
@@ -146,7 +146,7 @@ const FuelMapPage: React.FC = () => {
 
   if (loading) {
     return (
-      <div className="flex justify-center items-center h-[60vh] min-h-[400px]">
+      <div className="fixed inset-0 z-0 flex justify-center items-center bg-gray-50 dark:bg-gray-900">
         <Loader className="w-8 h-8 animate-spin text-amber-500" />
       </div>
     );
@@ -154,7 +154,7 @@ const FuelMapPage: React.FC = () => {
 
   if (error) {
     return (
-      <div className="flex flex-col justify-center items-center h-[60vh] min-h-[400px] text-red-500 dark:text-red-400">
+      <div className="fixed inset-0 z-0 flex flex-col justify-center items-center bg-gray-50 dark:bg-gray-900 text-red-500 dark:text-red-400">
         <AlertCircle className="w-12 h-12 mb-2" />
         <p>{error}</p>
       </div>
@@ -166,15 +166,15 @@ const FuelMapPage: React.FC = () => {
       : [53.3498, -6.2603]; // Default to Dublin
 
   return (
-    <div className="w-full h-[60vh] min-h-[400px] rounded-lg overflow-hidden shadow-lg border border-gray-200 dark:border-gray-700 relative">
+    <div className="fixed inset-0 z-0 overflow-hidden">
        {validLocations.length === 0 && (
-           <div className="absolute top-4 left-1/2 transform -translate-x-1/2 z-[1000] bg-white/90 dark:bg-gray-800/90 backdrop-blur px-4 py-2 rounded-full shadow-md border border-gray-200 dark:border-gray-700 flex items-center">
+           <div className="absolute top-20 left-1/2 transform -translate-x-1/2 z-[1000] bg-white/90 dark:bg-gray-800/90 backdrop-blur px-4 py-2 rounded-full shadow-md border border-gray-200 dark:border-gray-700 flex items-center">
                <AlertCircle className="w-4 h-4 mr-2 text-yellow-500" />
                <span className="text-sm text-gray-700 dark:text-gray-300">No fuel logs with location data found.</span>
            </div>
        )}
 
-       <div className="absolute top-4 right-4 z-[1000] bg-white dark:bg-gray-800 rounded-md shadow-md border border-gray-200 dark:border-gray-700 flex overflow-hidden">
+       <div className="absolute top-20 right-4 z-[1000] bg-white dark:bg-gray-800 rounded-md shadow-md border border-gray-200 dark:border-gray-700 flex overflow-hidden">
          <button 
            onClick={() => setViewMode('cluster')}
            className={`px-3 py-1.5 text-sm font-medium flex items-center ${viewMode === 'cluster' ? 'bg-indigo-50 text-indigo-600 dark:bg-indigo-900/50 dark:text-indigo-400' : 'text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700'}`}

--- a/src/components/FuelMapPage.tsx
+++ b/src/components/FuelMapPage.tsx
@@ -1,6 +1,6 @@
 // src/components/FuelMapPage.tsx
 import React, { useState, useEffect, useMemo } from 'react';
-import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet';
+import { MapContainer, TileLayer, Marker, Popup, useMap, ZoomControl } from 'react-leaflet';
 import L from 'leaflet';
 import MarkerClusterGroup from 'react-leaflet-markercluster'; // Import the cluster group
 import { MapPin, Navigation, AlertCircle, Loader, Layers, Activity } from 'lucide-react'; // Icons
@@ -146,7 +146,7 @@ const FuelMapPage: React.FC = () => {
 
   if (loading) {
     return (
-      <div className="fixed inset-0 z-0 flex justify-center items-center bg-gray-50 dark:bg-gray-900">
+      <div className="fixed inset-x-0 top-0 bottom-16 sm:bottom-0 z-0 flex justify-center items-center bg-gray-50 dark:bg-gray-900">
         <Loader className="w-8 h-8 animate-spin text-amber-500" />
       </div>
     );
@@ -154,7 +154,7 @@ const FuelMapPage: React.FC = () => {
 
   if (error) {
     return (
-      <div className="fixed inset-0 z-0 flex flex-col justify-center items-center bg-gray-50 dark:bg-gray-900 text-red-500 dark:text-red-400">
+      <div className="fixed inset-x-0 top-0 bottom-16 sm:bottom-0 z-0 flex flex-col justify-center items-center bg-gray-50 dark:bg-gray-900 text-red-500 dark:text-red-400">
         <AlertCircle className="w-12 h-12 mb-2" />
         <p>{error}</p>
       </div>
@@ -166,7 +166,7 @@ const FuelMapPage: React.FC = () => {
       : [53.3498, -6.2603]; // Default to Dublin
 
   return (
-    <div className="fixed inset-0 z-0 overflow-hidden">
+    <div className="fixed inset-x-0 top-0 bottom-16 sm:bottom-0 z-0 overflow-hidden">
        {validLocations.length === 0 && (
            <div className="absolute top-20 left-1/2 transform -translate-x-1/2 z-[1000] bg-white/90 dark:bg-gray-800/90 backdrop-blur px-4 py-2 rounded-full shadow-md border border-gray-200 dark:border-gray-700 flex items-center">
                <AlertCircle className="w-4 h-4 mr-2 text-yellow-500" />
@@ -191,7 +191,11 @@ const FuelMapPage: React.FC = () => {
          </button>
        </div>
 
-      <MapContainer center={initialCenter} zoom={validLocations.length > 0 ? 10 : 6} scrollWheelZoom={true} style={{ height: '100%', width: '100%' }}>
+      <MapContainer center={initialCenter} zoom={validLocations.length > 0 ? 10 : 6} scrollWheelZoom={true} zoomControl={false} style={{ height: '100%', width: '100%' }}>
+        {/* Default zoom control lives top-left, where the full-bleed map now
+            tucks under the sticky header. Move it bottom-left so it stays
+            tappable. */}
+        <ZoomControl position="bottomleft" />
         <TileLayer
           attribution={MAP_TILES.attribution}
           url={theme === 'dark' ? MAP_TILES.dark : MAP_TILES.light}


### PR DESCRIPTION
## 📋 Description

The Map page previously rendered as a small bordered rectangle inside the centered content column, leaving large empty margins on either side. This makes the map full-bleed: it now fills the entire viewport edge to edge and extends under/above the app chrome.

The map renders as a fixed, full-viewport layer behind the chrome. The translucent glass header, the footer, and the mobile bottom nav float over it (raised via z-index), so the tiles extend under the header and above the footer.

## 🚀 Proposed Changes
- `FuelMapPage`: the map container (and the loading/error states) now use `fixed inset-0 z-0` so the tiles cover the whole viewport instead of a `h-[60vh]` bordered box; removed the rounded corners/border/shadow.
- `FuelMapPage`: moved the floating "Clusters/Heatmap" toggle and the "no logs" banner down (`top-20`) so they clear the sticky header.
- `AuthenticatedApp`: added a `FULL_BLEED_PATHS` set for `/map` that drops the centered container/padding/max-width on that route, skips the onboarding prompt, and lifts the footer above the fixed map layer (`relative z-30`).

## 🛡️ Checklist
- [x] I have verified that all unit tests pass locally (`npm run test`).
- [x] I have verified that the build succeeds locally (`npm run build`).
- [ ] I have added/updated unit tests for my changes.
- [x] I have followed the project's coding standards and naming conventions.
- [ ] I have updated the documentation (`docs/`) if necessary.
- [ ] New features are gated behind a Remote Config flag (refer to FEATURE_RELEASING.md).

## 📸 Screenshots (if applicable)
N/A — layout-only change; the map now spans the full width/height of the viewport behind the header and footer.

## 🔗 Related Issues/PRs
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015wmLJG26iKHyDACrHuUdZk)_