### PR TITLE
fix(functions): avoid Overpass 406 in assign-stations script

### DIFF
--- a/functions/src/__tests__/assignStationsToLogs.test.ts
+++ b/functions/src/__tests__/assignStationsToLogs.test.ts
@@ -1,10 +1,12 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   selectUnassignedLogs,
   pickNearestStation,
   stationDocId,
   pricePerLitre,
   haversineDistanceKm,
+  findNearestStation,
+  NonRetryableOverpassError,
   AssignLog,
   OverpassElement,
 } from '../scripts/assignStationsToLogs';
@@ -142,5 +144,50 @@ describe('haversineDistanceKm', () => {
   it('approximates a known short distance', () => {
     // ~111 m north (0.001 deg latitude).
     expect(haversineDistanceKm(53.34, -6.26, 53.341, -6.26)).toBeCloseTo(0.111, 2);
+  });
+});
+
+describe('findNearestStation', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const jsonResponse = (body: unknown): Response =>
+    ({ status: 200, ok: true, json: async () => body }) as Response;
+
+  it('parses the response and returns the nearest station', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        elements: [
+          { type: 'node', id: 5, lat: 53.34, lon: -6.26, tags: { amenity: 'fuel', name: 'Texaco' } },
+        ],
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await findNearestStation(53.34, -6.26);
+    expect(result?.name).toBe('Texaco');
+    expect(result?.id).toBe('node/5');
+  });
+
+  it('sends an identifying User-Agent so the request is not bounced with 406', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ elements: [] }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await findNearestStation(53.34, -6.26);
+
+    const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>;
+    expect(headers['User-Agent']).toMatch(/fuelog/);
+    expect(headers['Accept-Language']).toBeTruthy();
+  });
+
+  it('throws a non-retryable error on 406 without retrying the same host', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ status: 406, ok: false } as Response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(findNearestStation(53.34, -6.26)).rejects.toBeInstanceOf(
+      NonRetryableOverpassError,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/functions/src/scripts/assignStationsToLogs.ts
+++ b/functions/src/scripts/assignStationsToLogs.ts
@@ -23,11 +23,17 @@
 //   npm run assign-stations -- --project=<id>     # target a specific project
 //   npm run assign-stations -- --radius=250       # search radius in metres (default 150)
 //   npm run assign-stations -- --delay=1500       # ms between Overpass calls (default 1100)
+//   npm run assign-stations -- --overpass-url=<u> # use a different Overpass mirror
 //   npm run assign-stations -- --verbose          # print each log as it is resolved
 //
 // Overpass enforces fair-use rate limits, so calls are spaced out (--delay) and
 // retried with exponential backoff on HTTP 429. A large backlog therefore takes
 // a while; the radius and delay let you trade speed against accuracy and load.
+//
+// The default instance (overpass-api.de) increasingly rejects programmatic
+// requests with HTTP 406 when overloaded. If that happens, point at a mirror:
+//   npm run assign-stations -- --overpass-url=https://overpass.kumi.systems/api/interpreter
+// (or set the OVERPASS_URL env var).
 //
 // The Firestore project defaults to fuelog-paddez and can be overridden with
 // --project=<id> or GOOGLE_CLOUD_PROJECT. Credentials are read via application
@@ -59,7 +65,27 @@ const PROJECT_ID =
   process.env.GCLOUD_PROJECT ??
   'fuelog-paddez';
 
-const OVERPASS_URL = 'https://overpass-api.de/api/interpreter';
+// The main Overpass instance increasingly bounces requests that look
+// programmatic (missing/odd User-Agent, no Accept-Language) with HTTP 406, and
+// is often overloaded. Allow pointing at a mirror (e.g. Kumi Systems) via
+// --overpass-url=<url> or the OVERPASS_URL env var when that happens.
+const DEFAULT_OVERPASS_URL = 'https://overpass-api.de/api/interpreter';
+const OVERPASS_URL_ARG = process.argv.find((a) => a.startsWith('--overpass-url='));
+const OVERPASS_URL =
+  (OVERPASS_URL_ARG ? OVERPASS_URL_ARG.slice('--overpass-url='.length) : undefined) ??
+  process.env.OVERPASS_URL ??
+  DEFAULT_OVERPASS_URL;
+
+// Identify the client per the OSM usage policy. Node's fetch sends no
+// meaningful User-Agent, and Overpass now rejects such requests with HTTP 406
+// (works in a browser, fails from a script) — these headers are what make the
+// difference. The contact URL lets the operator reach us if the job misbehaves.
+const OVERPASS_HEADERS = {
+  'Content-Type': 'application/x-www-form-urlencoded',
+  Accept: 'application/json',
+  'Accept-Language': 'en',
+  'User-Agent': 'fuelog-assign-stations/1.0 (+https://fuelog.paddez.com)',
+};
 
 // Cap a single Overpass request so a hung connection can't stall the batch
 // indefinitely. The query itself also self-limits server-side ([timeout:25]).
@@ -202,11 +228,16 @@ export function pricePerLitre(cost: number | undefined, liters: number | undefin
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+/** A failure that won't be fixed by retrying the same host (e.g. HTTP 406, a
+ *  host-policy rejection) — propagated immediately instead of being retried. */
+export class NonRetryableOverpassError extends Error {}
+
 /**
  * Queries Overpass for fuel stations within `radiusMeters` of (lat, lon) and
  * returns the nearest as an OSMStation, or null when none are nearby. Retries
- * with exponential backoff on HTTP 429; other failures propagate so the caller
- * can count them as errors rather than silently skipping a log.
+ * with exponential backoff on HTTP 429/5xx and network/timeout errors; a 406
+ * host-policy rejection is non-retryable and throws immediately. Other failures
+ * propagate so the caller can count them rather than silently skipping a log.
  */
 export async function findNearestStation(
   lat: number,
@@ -233,9 +264,19 @@ export async function findNearestStation(
       const response = await fetch(OVERPASS_URL, {
         method: 'POST',
         body: `data=${encodeURIComponent(query)}`,
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        headers: OVERPASS_HEADERS,
         signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       });
+
+      // 406 is a host-policy rejection (the instance is bouncing the request,
+      // often due to load), not a transient error — retrying the same host is
+      // pointless, so fail fast with a hint to switch to a mirror.
+      if (response.status === 406) {
+        throw new NonRetryableOverpassError(
+          `Overpass returned 406 (request rejected by ${OVERPASS_URL}). ` +
+            'Try a mirror, e.g. --overpass-url=https://overpass.kumi.systems/api/interpreter',
+        );
+      }
 
       // 429 (rate limited) and 5xx (server) are transient — back off and retry.
       if (response.status === 429 || response.status >= 500) {
@@ -258,8 +299,9 @@ export async function findNearestStation(
       return pickNearestStation(data.elements ?? [], lat, lon);
     } catch (err) {
       // Network failures and the AbortSignal timeout land here; retry them too,
-      // but let the final failure propagate so the caller counts it as an error.
-      if (isLastAttempt) throw err;
+      // but let the final failure — and any non-retryable rejection (406) —
+      // propagate so the caller counts it as an error.
+      if (isLastAttempt || err instanceof NonRetryableOverpassError) throw err;
       console.warn(
         `  Overpass request failed, retrying in ${delay}ms (attempt ${attempt + 1}/${maxRetries}):`,
         err,
@@ -375,6 +417,12 @@ async function main(): Promise<void> {
 
       result.assigned++;
     } catch (error) {
+      // A host-policy rejection (406) dooms every remaining lookup against the
+      // same endpoint, so abort the whole run rather than hammer a dead host.
+      if (error instanceof NonRetryableOverpassError) {
+        console.error(`\n${error.message}`);
+        break;
+      }
       console.error(`  Failed to assign station for log ${log.id}:`, error);
       result.failed++;
     }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -41,9 +41,21 @@ GOOGLE_APPLICATION_CREDENTIALS=../service-account.json npm run assign-stations  
 
 Flags: `--dry-run` (report only), `--user=<uid>` (one user), `--project=<id>`
 (target project, defaults to `fuelog-paddez`), `--radius=<m>` (search radius,
-default 150), `--delay=<ms>` (spacing between Overpass calls, default 1100), and
-`--verbose` (print each log as it resolves). Overpass enforces fair-use limits,
-so a large backlog is processed slowly and retried with backoff on rate limits.
+default 150), `--delay=<ms>` (spacing between Overpass calls, default 1100),
+`--overpass-url=<url>` (use a different Overpass instance, or set `OVERPASS_URL`),
+and `--verbose` (print each log as it resolves). Overpass enforces fair-use
+limits, so a large backlog is processed slowly and retried with backoff on rate
+limits.
+
+The default instance (`overpass-api.de`) increasingly rejects programmatic
+requests with **HTTP 406** when it is overloaded. The script identifies itself
+with a `User-Agent` to avoid this where possible, but if you still hit 406, point
+it at a mirror:
+
+```bash
+GOOGLE_APPLICATION_CREDENTIALS=../service-account.json \
+  npm run assign-stations -- --overpass-url=https://overpass.kumi.systems/api/interpreter
+```
 
 ## Re-compressing legacy receipt images
 


### PR DESCRIPTION
## 📋 Description

The `assign-stations` backfill script (added in #219) was failing with **`Overpass request failed, status 406`**. `overpass-api.de` has tightened an upstream filter that rejects requests which look programmatic — missing a `User-Agent` / `Accept-Language` — with HTTP 406. The same query works from the browser (which always sends those headers) but Node's `fetch` does not, so the script got bounced.

## 🚀 Proposed Changes

- **Send OSM-policy headers** on every Overpass request: an identifying `User-Agent` (with contact URL), plus `Accept: application/json` and `Accept-Language: en`. This is what makes the request acceptable and is required by the OSM usage policy.
- **Make the endpoint configurable** via `--overpass-url=<url>` or the `OVERPASS_URL` env var, so a busy/overloaded host can be swapped for a mirror (e.g. `https://overpass.kumi.systems/api/interpreter`).
- **Treat 406 as non-retryable** (new `NonRetryableOverpassError`): retrying the same host is pointless, so the script fails fast with a hint to use a mirror and aborts the whole run instead of re-failing the dead host once per log.
- Added unit tests (mocking `fetch`) covering the success parse, the identifying headers, and the 406 fail-fast (no retry). Updated `scripts/README.md` and the in-file usage docs.

> Note: I couldn't exercise the live Overpass endpoint from CI/sandbox (network egress allowlist blocks `overpass-api.de`), so the headers/mirror behaviour is covered by mocked-`fetch` unit tests rather than a live call. The root cause is confirmed against OSM community reports of the 2024–2026 406 filter changes.

## 🛡️ Checklist
- [x] I have verified that all unit tests pass locally (`npm run test`). — full `functions` suite: 86 passed.
- [ ] I have verified that the build succeeds locally (`npm run build`). — `tsc -b` fails on the pre-existing `TS5011` (missing `rootDir`) unrelated to this change; type-checks clean with `tsc --noEmit --rootDir src`.
- [x] I have added/updated unit tests for my changes.
- [x] I have followed the project's coding standards and naming conventions.
- [x] I have updated the documentation (`docs/`) if necessary. — updated `scripts/README.md`.
- [ ] New features are gated behind a Remote Config flag. — N/A; one-off maintenance script.

## 🔗 Related Issues/PRs
Follow-up to #219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQxYdmgVAufn4dcGZTLeBb)_