### PR TITLE
Open receipt images in a modal instead of navigating away

### DIFF
--- a/src/components/LogCard.test.tsx
+++ b/src/components/LogCard.test.tsx
@@ -23,6 +23,7 @@ vi.mock('react-i18next', () => ({
         'logCard.unknownStation': 'Unknown Station',
         'logCard.editEntry': 'Edit Entry',
         'logCard.deleteEntry': 'Delete Entry',
+        'logCard.closeReceipt': 'Close',
       };
       return strings[key] ?? key;
     },
@@ -150,6 +151,27 @@ describe('LogCard', () => {
 
     expect(onDelete).toHaveBeenCalledTimes(1);
     expect(onDelete).toHaveBeenCalledWith(mockLog.id);
+  });
+
+  it('opens the receipt in a modal instead of navigating away when the thumbnail is clicked', () => {
+    const onEdit = vi.fn();
+    const onDelete = vi.fn();
+    const logWithReceipt: Log = { ...mockLog, receiptUrl: 'https://example.com/receipt.jpg' };
+
+    render(<LogCard log={logWithReceipt} onEdit={onEdit} onDelete={onDelete} />);
+
+    // The thumbnail should not be a link that navigates away from the app.
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByAltText('Receipt'));
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getAllByAltText('Receipt')).toHaveLength(2); // thumbnail + enlarged image
+
+    fireEvent.click(screen.getByLabelText('Close'));
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 });
 

--- a/src/components/LogCard.tsx
+++ b/src/components/LogCard.tsx
@@ -13,6 +13,7 @@ import { COMMON_CURRENCIES } from '../utils/currencyApi';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '../context/ThemeContext';
 import { MAP_TILES } from '../utils/mapConstants';
+import ReceiptModal from './ReceiptModal';
 
 // CSS for card flip and map container
 import 'leaflet/dist/leaflet.css';
@@ -47,6 +48,7 @@ function LogCard({ log, onEdit, onDelete, vehicleName, stationName }: LogCardPro
   const { t } = useTranslation();
   const { theme } = useTheme();
   const [isFlipped, setIsFlipped] = useState(false);
+  const [isReceiptOpen, setIsReceiptOpen] = useState(false);
   const hasGeo = log.latitude !== undefined && log.longitude !== undefined;
   const pointerDownPos = useRef<{ x: number; y: number } | null>(null);
   // Threshold (px) beyond which a pointer down→up is treated as a scroll/drag
@@ -95,6 +97,7 @@ function LogCard({ log, onEdit, onDelete, vehicleName, stationName }: LogCardPro
   const center: L.LatLngExpression = [log.latitude || 0, log.longitude || 0];
 
   return (
+    <>
     <div
       className="relative w-full h-[320px] perspective-1000 group"
       onPointerDown={handlePointerDown}
@@ -158,18 +161,16 @@ function LogCard({ log, onEdit, onDelete, vehicleName, stationName }: LogCardPro
           {log.receiptUrl && (
             <div className="mb-3">
               <span className="text-[10px] text-gray-400 dark:text-gray-500 uppercase font-bold tracking-tight block mb-1">{t('logCard.receipt')}</span>
-              <a
-                href={sanitizeUrl(log.receiptUrl!)}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={(e) => e.stopPropagation()}
+              <button
+                type="button"
+                onClick={(e) => { e.stopPropagation(); setIsReceiptOpen(true); }}
                 className="inline-block relative rounded-lg overflow-hidden border border-gray-100 dark:border-gray-700 hover:opacity-80 transition-opacity"
               >
                 <img src={sanitizeUrl(log.receiptUrl!)} alt="Receipt" className="h-10 w-16 object-cover" />
                 <div className="absolute inset-0 flex items-center justify-center bg-black/20">
                   <FileText size={12} className="text-white" />
                 </div>
-              </a>
+              </button>
             </div>
           )}
 
@@ -224,6 +225,10 @@ function LogCard({ log, onEdit, onDelete, vehicleName, stationName }: LogCardPro
 
       </div>
     </div>
+    {isReceiptOpen && log.receiptUrl && (
+      <ReceiptModal url={log.receiptUrl} onClose={() => setIsReceiptOpen(false)} />
+    )}
+    </>
   );
 }
 

--- a/src/components/ReceiptModal.test.tsx
+++ b/src/components/ReceiptModal.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import ReceiptModal from './ReceiptModal';
+
+// Mock react-i18next so tests don't need a real i18n instance
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => {
+      const strings: Record<string, string> = {
+        'logCard.receipt': 'Receipt',
+      };
+      return strings[key] ?? options?.defaultValue ?? key;
+    },
+  }),
+}));
+
+describe('ReceiptModal', () => {
+  afterEach(() => {
+    document.body.style.overflow = '';
+  });
+
+  it('renders the receipt image', () => {
+    render(<ReceiptModal url="https://example.com/receipt.jpg" onClose={vi.fn()} />);
+
+    const img = screen.getByAltText('Receipt');
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute('src', 'https://example.com/receipt.jpg');
+  });
+
+  it('locks body scroll while open and restores it on unmount', () => {
+    const { unmount } = render(<ReceiptModal url="https://example.com/receipt.jpg" onClose={vi.fn()} />);
+
+    expect(document.body.style.overflow).toBe('hidden');
+
+    unmount();
+
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  it('calls onClose when the close button is clicked', () => {
+    const onClose = vi.fn();
+    render(<ReceiptModal url="https://example.com/receipt.jpg" onClose={onClose} />);
+
+    fireEvent.click(screen.getByLabelText('Close'));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when the backdrop is clicked', () => {
+    const onClose = vi.fn();
+    render(<ReceiptModal url="https://example.com/receipt.jpg" onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('dialog'));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onClose when the image itself is clicked', () => {
+    const onClose = vi.fn();
+    render(<ReceiptModal url="https://example.com/receipt.jpg" onClose={onClose} />);
+
+    fireEvent.click(screen.getByAltText('Receipt'));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('calls onClose when the Escape key is pressed', () => {
+    const onClose = vi.fn();
+    render(<ReceiptModal url="https://example.com/receipt.jpg" onClose={onClose} />);
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ReceiptModal.tsx
+++ b/src/components/ReceiptModal.tsx
@@ -20,6 +20,13 @@ function ReceiptModal({ url, onClose }: ReceiptModalProps): JSX.Element {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [onClose]);
 
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, []);
+
   return (
     <div
       className="fixed inset-0 z-[2000] flex items-center justify-center bg-black/80 backdrop-blur-sm p-4"
@@ -30,8 +37,9 @@ function ReceiptModal({ url, onClose }: ReceiptModalProps): JSX.Element {
     >
       <button
         type="button"
-        onClick={onClose}
+        onClick={(e) => { e.stopPropagation(); onClose(); }}
         title={t('logCard.closeReceipt', { defaultValue: 'Close' })}
+        aria-label={t('logCard.closeReceipt', { defaultValue: 'Close' })}
         className="absolute top-4 right-4 p-2 rounded-full bg-white/10 hover:bg-white/20 text-white transition-colors"
       >
         <X size={24} />

--- a/src/components/ReceiptModal.tsx
+++ b/src/components/ReceiptModal.tsx
@@ -1,0 +1,49 @@
+// src/components/ReceiptModal.tsx
+import { JSX, useEffect } from 'react';
+import { X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { sanitizeUrl } from '../utils/sanitize';
+
+interface ReceiptModalProps {
+  url: string;
+  onClose: () => void;
+}
+
+function ReceiptModal({ url, onClose }: ReceiptModalProps): JSX.Element {
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-[2000] flex items-center justify-center bg-black/80 backdrop-blur-sm p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('logCard.receipt')}
+      onClick={onClose}
+    >
+      <button
+        type="button"
+        onClick={onClose}
+        title={t('logCard.closeReceipt', { defaultValue: 'Close' })}
+        className="absolute top-4 right-4 p-2 rounded-full bg-white/10 hover:bg-white/20 text-white transition-colors"
+      >
+        <X size={24} />
+      </button>
+      <img
+        src={sanitizeUrl(url)}
+        alt={t('logCard.receipt')}
+        className="max-w-full max-h-full object-contain rounded-lg shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      />
+    </div>
+  );
+}
+
+export default ReceiptModal;

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -267,7 +267,8 @@
     "noLocation": "Kein Standort",
     "unknownStation": "Unbekannte Tankstelle",
     "editEntry": "Eintrag bearbeiten",
-    "deleteEntry": "Eintrag löschen"
+    "deleteEntry": "Eintrag löschen",
+    "closeReceipt": "Schließen"
   },
   "profile": {
     "appPreferences": "App-Einstellungen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -267,7 +267,8 @@
     "noLocation": "No location",
     "unknownStation": "Unknown Station",
     "editEntry": "Edit Entry",
-    "deleteEntry": "Delete Entry"
+    "deleteEntry": "Delete Entry",
+    "closeReceipt": "Close"
   },
   "profile": {
     "appPreferences": "App Preferences",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -267,7 +267,8 @@
     "noLocation": "Sin ubicación",
     "unknownStation": "Estación Desconocida",
     "editEntry": "Editar Entrada",
-    "deleteEntry": "Eliminar Entrada"
+    "deleteEntry": "Eliminar Entrada",
+    "closeReceipt": "Cerrar"
   },
   "profile": {
     "appPreferences": "Preferencias de la App",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -267,7 +267,8 @@
     "noLocation": "Ei sijaintia",
     "unknownStation": "Tuntematon asema",
     "editEntry": "Muokkaa",
-    "deleteEntry": "Poista"
+    "deleteEntry": "Poista",
+    "closeReceipt": "Sulje"
   },
   "profile": {
     "appPreferences": "Sovelluksen asetukset",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -267,7 +267,8 @@
     "noLocation": "Pas de localisation",
     "unknownStation": "Station Inconnue",
     "editEntry": "Modifier la Saisie",
-    "deleteEntry": "Supprimer la Saisie"
+    "deleteEntry": "Supprimer la Saisie",
+    "closeReceipt": "Fermer"
   },
   "profile": {
     "appPreferences": "Préférences de l'App",

--- a/src/i18n/locales/ga.json
+++ b/src/i18n/locales/ga.json
@@ -267,7 +267,8 @@
     "noLocation": "Gan suíomh",
     "unknownStation": "Stáisiún Anaithnid",
     "editEntry": "Cuir Iontráil in Eagar",
-    "deleteEntry": "Scrios Iontráil"
+    "deleteEntry": "Scrios Iontráil",
+    "closeReceipt": "Dún"
   },
   "profile": {
     "appPreferences": "Roghanna an Aip",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -267,7 +267,8 @@
     "noLocation": "位置情報なし",
     "unknownStation": "不明なスタンド",
     "editEntry": "記録を編集",
-    "deleteEntry": "記録を削除"
+    "deleteEntry": "記録を削除",
+    "closeReceipt": "閉じる"
   },
   "profile": {
     "appPreferences": "アプリ設定",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -267,7 +267,8 @@
     "noLocation": "위치 정보 없음",
     "unknownStation": "알 수 없는 주유소",
     "editEntry": "기록 수정",
-    "deleteEntry": "기록 삭제"
+    "deleteEntry": "기록 삭제",
+    "closeReceipt": "닫기"
   },
   "profile": {
     "appPreferences": "앱 설정",

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -267,7 +267,8 @@
     "noLocation": "Ingen posisjon",
     "unknownStation": "Ukjent stasjon",
     "editEntry": "Rediger oppføring",
-    "deleteEntry": "Slett oppføring"
+    "deleteEntry": "Slett oppføring",
+    "closeReceipt": "Lukk"
   },
   "profile": {
     "appPreferences": "App-innstillinger",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -267,7 +267,8 @@
     "noLocation": "Ingen plats",
     "unknownStation": "Okänd station",
     "editEntry": "Redigera inlägg",
-    "deleteEntry": "Radera inlägg"
+    "deleteEntry": "Radera inlägg",
+    "closeReceipt": "Stäng"
   },
   "profile": {
     "appPreferences": "Appinställningar",

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -27,6 +27,7 @@ import { formatDate, toDatetimeLocal } from '../utils/formatDate';
 import LocationPicker, { PickerCoords } from '../components/LocationPicker';
 import { fetchUserStations } from '../firebase/firestoreService';
 import { Station } from '../utils/types';
+import ReceiptModal from '../components/ReceiptModal';
 
 // --- React Component ---
 function HistoryPage(): JSX.Element {
@@ -63,6 +64,9 @@ function HistoryPage(): JSX.Element {
     const [editReceiptFile, setEditReceiptFile] = useState<File | null>(null); // New receipt file
     const [isUpdating, setIsUpdating] = useState<boolean>(false); // Tracks if an update operation is in progress
     const [modalError, setModalError] = useState<string | null>(null); // Stores error messages specific to the edit modal form
+
+    // --- State for Receipt Image Modal ---
+    const [receiptModalUrl, setReceiptModalUrl] = useState<string | null>(null); // Receipt URL currently shown enlarged, or null when closed
 
     // --- State for Filtering ---
     const [filterStartDate, setFilterStartDate] = useState<string>(''); // Format: YYYY-MM-DD
@@ -570,12 +574,12 @@ function HistoryPage(): JSX.Element {
                                             {receiptDigitizationEnabled && (
                                               <td className="px-3 py-3 whitespace-nowrap text-center">
                                                 {log.receiptUrl ? (
-                                                  <a href={sanitizeUrl(log.receiptUrl)} target="_blank" rel="noopener noreferrer" className="inline-block relative rounded overflow-hidden border border-gray-100 dark:border-gray-700 hover:opacity-80 transition-opacity">
+                                                  <button type="button" onClick={() => setReceiptModalUrl(log.receiptUrl!)} className="inline-block relative rounded overflow-hidden border border-gray-100 dark:border-gray-700 hover:opacity-80 transition-opacity">
                                                     <img src={sanitizeUrl(log.receiptUrl)} alt="Receipt" className="h-6 w-10 object-cover" />
                                                     <div className="absolute inset-0 flex items-center justify-center bg-black/10">
                                                       <FileText size={10} className="text-white" />
                                                     </div>
-                                                  </a>
+                                                  </button>
                                                 ) : (
                                                   <span className="text-[10px] text-gray-300 dark:text-gray-600">-</span>
                                                 )}
@@ -724,6 +728,10 @@ function HistoryPage(): JSX.Element {
                 </div>
             )}
             {/* --- End Edit Modal --- */}
+
+            {receiptModalUrl && (
+                <ReceiptModal url={receiptModalUrl} onClose={() => setReceiptModalUrl(null)} />
+            )}
 
         </div> // End main page container
     );


### PR DESCRIPTION
## 📋 Description
Tapping a receipt thumbnail in History previously linked directly to the raw image URL via `<a target="_blank">`, which opened just the JPG and felt like it took you out of the app (especially when installed as a PWA on mobile). This adds a shared modal so the receipt opens enlarged in place, without leaving the site.

## 🚀 Proposed Changes
- Added a new `ReceiptModal` component (`src/components/ReceiptModal.tsx`) that shows the receipt image enlarged over a backdrop, closable via the X button, Escape key, or backdrop click.
- Replaced the receipt thumbnail `<a target="_blank">` with a `<button>` that opens `ReceiptModal` in `LogCard.tsx` (mobile card view).
- Replaced the receipt thumbnail `<a target="_blank">` with a `<button>` that opens `ReceiptModal` in `HistoryPage.tsx` (desktop table view).
- Added the `logCard.closeReceipt` translation key across all locale files.

## 🛡️ Checklist
- [x] I have verified that all unit tests pass locally (`npm run test`).
- [x] I have verified that the build succeeds locally (`npm run build`).
- [ ] I have added/updated unit tests for my changes.
- [x] I have followed the project's coding standards and naming conventions.
- [ ] I have updated the documentation (`docs/`) if necessary.
- [ ] New features are gated behind a Remote Config flag (refer to FEATURE_RELEASING.md).

## 📸 Screenshots (if applicable)
N/A — bug fix to existing receipt viewing interaction.

## 🔗 Related Issues/PRs
N/A


---
_Generated by [Claude Code](https://claude.ai/code/session_0162qVVMKoV8k4Gg2L4kYcnc)_