### PR TITLE
feat(ui): redesign app with the Nocturne design system

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,12 +11,12 @@
     <meta name="keywords" content="fuel tracker, fuel log, vehicle maintenance, fuel consumption, mpg, km per litre, cost per mile, car expenses" />
     <meta name="author" content="Fuelog" />
     <meta name="robots" content="index, follow" />
-    <meta name="theme-color" content="#D97706" />
+    <meta name="theme-color" content="#161826" />
 
-    <!-- Fonts: Space Grotesk (display) + Space Mono (data) -->
+    <!-- Fonts: Inter carries headings and body (Nocturne) -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Space+Mono:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
 
     <!-- Canonical -->
     <link rel="canonical" href="https://fuelog.paddez.com" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -8383,9 +8383,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true,
       "optionalDependencies": {
@@ -16533,9 +16533,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17449,9 +17449,9 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,35 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Fuelog">
-  <!--
-    Gauge scaled from 512×512 logo (factor 32/512 = 0.0625).
-    center: (16, 17.2) ≈ (16, 17)  radius: 10
-    E (200°): (6.6, 13.8)           F (340°): (25.4, 13.8)
-    Active arc end — 3/4 (305°): (21.7, 9.0)
-    Needle tip (r=8.75, 305°): (21.0, 9.8)
-  -->
-  <style>
-    @media (prefers-color-scheme: light) {
-      .bg   { fill: #FFFFFF; }
-      .track { stroke: #E2E8F0; }
-    }
-  </style>
-
-  <!-- Background -->
-  <rect class="bg" width="32" height="32" rx="7" fill="#0A0F1E"/>
-
-  <!-- Track (200° → 340°, 140° CW) -->
-  <path class="track"
-        d="M 6.6 13.8 A 10 10 0 0 1 25.4 13.8"
-        fill="none" stroke="#1A2744" stroke-width="2.2" stroke-linecap="round"/>
-
-  <!-- Active arc (200° → 305°, 105° CW) -->
-  <path d="M 6.6 13.8 A 10 10 0 0 1 21.7 9.0"
-        fill="none" stroke="#F59E0B" stroke-width="2.2" stroke-linecap="round"/>
-
-  <!-- Needle -->
-  <line x1="16" y1="17" x2="21" y2="9.8"
-        stroke="#F1F5F9" stroke-width="1.5" stroke-linecap="round"/>
-
-  <!-- Center hub -->
-  <circle cx="16" cy="17" r="2.2" fill="#F59E0B"/>
-  <circle cx="16" cy="17" r="1"   fill="#0A0F1E"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-label="Fuelog">
+  <!-- Nocturne mark: fuel drop on the dark ground -->
+  <rect width="64" height="64" rx="14" fill="#161826"/>
+  <path d="M32,10.24 C32,10.24 17.28,33.28 17.28,40.32 A14.72,14.72 0 0 0 46.72,40.32 C46.72,33.28 32,10.24 32,10.24 Z" fill="#9184d9"/>
 </svg>

--- a/src/components/AuthenticatedApp.tsx
+++ b/src/components/AuthenticatedApp.tsx
@@ -67,8 +67,8 @@ const PageLoader = () => {
   const { t } = useTranslation();
   return (
     <div className="flex flex-col justify-center items-center min-h-[60vh] space-y-4">
-      <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-amber-500"></div>
-      <p className="text-gray-500 dark:text-gray-400 text-sm font-mono animate-pulse tracking-widest uppercase text-xs">{t('common.loading')}</p>
+      <div className="animate-spin rounded-full h-12 w-12 border-2 border-gray-200 dark:border-gray-700 border-t-brand-primary"></div>
+      <p className="text-gray-500 dark:text-gray-400 animate-pulse tracking-widest uppercase text-xs">{t('common.loading')}</p>
     </div>
   );
 };
@@ -82,9 +82,9 @@ function AuthenticatedApp(): JSX.Element {
   const isFullBleed = FULL_BLEED_PATHS.has(currentPath);
 
   const getNavLinkClass = (path: string): string => {
-    const baseClass = "px-3 py-1.5 text-sm font-bold rounded-xl transition-all duration-200";
-    const activeClass = "bg-brand-primary text-white shadow-md shadow-brand-primary/20 scale-105";
-    const inactiveClass = "text-gray-600 dark:text-gray-400 hover:text-brand-primary dark:hover:text-brand-primary hover:bg-gray-100 dark:hover:bg-gray-800";
+    const baseClass = "px-2 py-1.5 text-sm font-medium rounded-md transition-colors duration-200";
+    const activeClass = "text-brand-primary-hover dark:text-brand-primary";
+    const inactiveClass = "text-gray-600 dark:text-gray-300 hover:text-brand-primary-hover dark:hover:text-brand-primary";
     return `${baseClass} ${location.pathname === path ? activeClass : inactiveClass}`;
   };
 
@@ -93,18 +93,23 @@ function AuthenticatedApp(): JSX.Element {
       {/* Brand Glass Header */}
       <header className="glass-header">
         <nav className="container mx-auto px-4 sm:px-6 lg:px-8 py-3 flex justify-between items-center">
-          <Link to="/" className="font-display text-2xl font-bold tracking-tight hover:opacity-80 transition-opacity flex-shrink-0" style={{ letterSpacing: '-0.03em' }}>
-            <span className="text-amber-500">fuel</span><span className="text-gray-400 dark:text-gray-600">og</span>
+          <Link to="/" className="inline-flex items-center gap-2 flex-shrink-0 hover:opacity-80 transition-opacity">
+            <span className="w-6 h-6 rounded-md bg-amber-200 dark:bg-amber-800 inline-flex items-center justify-center flex-none">
+              <svg width="13" height="13" viewBox="0 0 256 256" className="fill-amber-700 dark:fill-amber-200" aria-hidden="true">
+                <path d="M128,24S64,112,64,157a64,64,0,0,0,128,0C192,112,128,24,128,24Z" />
+              </svg>
+            </span>
+            <span className="font-display text-lg font-medium tracking-tight text-gray-900 dark:text-gray-100">fuelog</span>
           </Link>
-          
+
           {/* Desktop Navigation */}
           <div className="hidden sm:flex items-center space-x-2">
             <Link to="/" className={getNavLinkClass("/")}>{t('nav.log')}</Link>
             <Link to="/dashboard" className={getNavLinkClass("/dashboard")}>{t('nav.dashboard')}</Link>
             <Link to="/history" className={getNavLinkClass("/history")}>{t('nav.history')}</Link>
-            <Link to="/profile" className={getNavLinkClass("/profile")}>{t('nav.profile')}</Link>
             <Link to="/map" className={getNavLinkClass("/map")}>{t('nav.map')}</Link>
             <Link to="/stations" className={getNavLinkClass("/stations")}>{t('nav.stations')}</Link>
+            <Link to="/profile" className={getNavLinkClass("/profile")}>{t('nav.profile')}</Link>
           </div>
 
           <div className="flex items-center space-x-3 sm:space-x-4 flex-shrink-0">
@@ -155,7 +160,7 @@ function AuthenticatedApp(): JSX.Element {
         </ErrorBoundary>
       </main>
 
-      <footer className="hidden sm:block relative z-30 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 py-4 mb-0">
+      <footer className="hidden sm:block relative z-30 bg-transparent border-t border-gray-200 dark:border-gray-700/60 py-4 mb-0">
           <div className="container mx-auto px-4 sm:px-6 lg:px-8 text-center text-sm text-gray-500 dark:text-gray-400">
                {t('footer.copyright', { year: new Date().getFullYear() })} | {' '}
                <Link to="/about" className="hover:text-amber-600 dark:hover:text-amber-400 underline underline-offset-2">

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -31,16 +31,14 @@ const BottomNav = (): JSX.Element => {
             <Link
               key={item.path}
               to={item.path}
-              className={`flex flex-col items-center justify-center w-full h-full transition-all duration-300 active:scale-90 ${
+              className={`flex flex-col items-center justify-center gap-0.5 w-full h-full transition-colors duration-200 active:scale-95 ${
                 isActive
-                  ? 'text-brand-primary'
-                  : 'text-gray-400 dark:text-gray-500 hover:text-brand-primary'
+                  ? 'text-brand-primary-hover dark:text-brand-primary'
+                  : 'text-gray-500 hover:text-brand-primary-hover dark:hover:text-brand-primary'
               }`}
             >
-              <div className={`p-1.5 rounded-xl transition-all duration-300 ${isActive ? 'bg-brand-primary/10' : ''}`}>
-                <Icon size={22} strokeWidth={isActive ? 2.5 : 1.75} className={isActive ? 'animate-in zoom-in duration-300' : ''} />
-              </div>
-              <span className={"text-[9px] mt-0.5 px-1 w-full text-center uppercase font-black tracking-widest transition-all truncate " + (isActive ? "opacity-100" : "opacity-50")}>
+              <Icon size={18} strokeWidth={isActive ? 2.5 : 2} />
+              <span className="text-[8px] px-1 w-full text-center uppercase font-bold tracking-wider truncate">
                 {item.label}
               </span>
             </Link>

--- a/src/components/FuelMapPage.tsx
+++ b/src/components/FuelMapPage.tsx
@@ -146,15 +146,15 @@ const FuelMapPage: React.FC = () => {
 
   if (loading) {
     return (
-      <div className="fixed inset-x-0 top-0 bottom-16 sm:bottom-0 z-0 flex justify-center items-center bg-gray-50 dark:bg-gray-900">
-        <Loader className="w-8 h-8 animate-spin text-amber-500" />
+      <div className="fixed inset-x-0 top-0 bottom-16 sm:bottom-0 z-0 flex justify-center items-center bg-gray-50 dark:bg-brand-dark-surface">
+        <Loader className="w-8 h-8 animate-spin text-brand-primary" />
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="fixed inset-x-0 top-0 bottom-16 sm:bottom-0 z-0 flex flex-col justify-center items-center bg-gray-50 dark:bg-gray-900 text-red-500 dark:text-red-400">
+      <div className="fixed inset-x-0 top-0 bottom-16 sm:bottom-0 z-0 flex flex-col justify-center items-center bg-gray-50 dark:bg-brand-dark-surface text-red-500 dark:text-red-400">
         <AlertCircle className="w-12 h-12 mb-2" />
         <p>{error}</p>
       </div>
@@ -174,17 +174,17 @@ const FuelMapPage: React.FC = () => {
            </div>
        )}
 
-       <div className="absolute top-20 right-4 z-[1000] bg-white dark:bg-gray-800 rounded-md shadow-md border border-gray-200 dark:border-gray-700 flex overflow-hidden">
+       <div className="absolute top-20 right-4 z-[1000] bg-white/90 dark:bg-gray-800/90 backdrop-blur rounded-lg shadow-md border border-gray-200 dark:border-gray-700/60 flex overflow-hidden">
          <button 
            onClick={() => setViewMode('cluster')}
-           className={`px-3 py-1.5 text-sm font-medium flex items-center ${viewMode === 'cluster' ? 'bg-indigo-50 text-indigo-600 dark:bg-indigo-900/50 dark:text-indigo-400' : 'text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700'}`}
+           className={`px-3 py-1.5 text-sm font-medium flex items-center ${viewMode === 'cluster' ? 'text-brand-primary-hover dark:text-brand-primary shadow-[inset_0_0_0_1px_var(--color-brand-primary)]' : 'text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700'}`}
          >
            <Layers className="w-4 h-4 mr-1.5" />
            {t('map.clusters', 'Clusters')}
          </button>
          <button 
            onClick={() => setViewMode('heatmap')}
-           className={`px-3 py-1.5 text-sm font-medium flex items-center ${viewMode === 'heatmap' ? 'bg-indigo-50 text-indigo-600 dark:bg-indigo-900/50 dark:text-indigo-400' : 'text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700'}`}
+           className={`px-3 py-1.5 text-sm font-medium flex items-center ${viewMode === 'heatmap' ? 'text-brand-primary-hover dark:text-brand-primary shadow-[inset_0_0_0_1px_var(--color-brand-primary)]' : 'text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700'}`}
          >
            <Activity className="w-4 h-4 mr-1.5" />
            {t('map.heatmap', 'Heatmap')}

--- a/src/components/LogCard.tsx
+++ b/src/components/LogCard.tsx
@@ -106,35 +106,35 @@ function LogCard({ log, onEdit, onDelete, vehicleName, stationName }: LogCardPro
       <div className={`relative w-full h-full transition-all duration-500 preserve-3d cursor-pointer ${isFlipped ? 'rotate-y-180' : ''}`}>
 
         {/* FRONT: Log Details */}
-        <div className="absolute inset-0 backface-hidden bg-white dark:bg-gray-800 shadow-md rounded-2xl p-4 sm:p-5 border border-gray-100 dark:border-gray-700/50 flex flex-col overflow-y-auto">
+        <div className="absolute inset-0 backface-hidden nocturne-card rounded-2xl p-4 sm:p-5 flex flex-col overflow-y-auto">
           {/* Header */}
           <div className="flex justify-between items-start mb-3">
             <div className="space-y-0.5 min-w-0 flex-grow">
               <div className="flex items-center space-x-1.5">
-                <p className="text-[10px] font-bold text-brand-primary uppercase tracking-widest truncate">
+                <p className="text-[10px] font-bold text-amber-700 dark:text-amber-300 uppercase tracking-widest truncate">
                     {log.timestamp?.toDate() ? formatDate(log.timestamp.toDate()) : 'N/A'}
                 </p>
                 {hasGeo && <MapPin size={10} className="text-brand-primary shrink-0 animate-pulse" />}
               </div>
-              <h4 className="text-lg font-black tracking-tight text-gray-900 dark:text-white leading-tight truncate">
+              <h4 className="text-lg font-semibold tracking-tight text-gray-900 dark:text-gray-100 leading-tight truncate">
                 {stationName || log.brand || t('logCard.unknownStation')}
               </h4>
               {vehicleName && (
-                <span className="inline-block bg-brand-primary/5 text-brand-primary text-[10px] px-2 py-0.5 rounded-full font-bold mt-1 border border-brand-primary/10">
+                <span className="nocturne-tag-neutral mt-1">
                   {vehicleName}
                 </span>
               )}
             </div>
 
             <div className="text-right shrink-0 ml-2">
-              <p className="text-xl font-black text-gray-900 dark:text-white font-mono leading-none">{homeCurrencySymbol}{costValue}</p>
+              <p className="text-xl font-bold text-gray-900 dark:text-gray-100 font-mono leading-none">{homeCurrencySymbol}{costValue}</p>
               {originalCostInfo && (
                 <p className="text-[9px] text-gray-400 font-bold italic font-mono mt-1 uppercase">{originalCostInfo}</p>
               )}
             </div>
           </div>
 {/* Metrics Grid */}
-<div className="grid grid-cols-2 gap-3 py-3 border-y border-gray-50 dark:border-gray-700/50 mb-3">
+<div className="grid grid-cols-2 gap-3 py-3 border-y border-gray-200 dark:border-gray-700/60 mb-3">
   {odometerInputEnabled && log.odometerKm !== undefined && log.odometerKm !== null ? (
     <>
       {renderMetric(t('history.table.odometer'), log.odometerKm.toFixed(0), " Km")}
@@ -175,7 +175,7 @@ function LogCard({ log, onEdit, onDelete, vehicleName, stationName }: LogCardPro
           )}
 
           {/* Footer Actions */}
-          <div className="flex justify-between items-center pt-3 border-t border-gray-50 dark:border-gray-700/50 mt-auto">
+          <div className="flex justify-between items-center pt-3 border-t border-gray-200 dark:border-gray-700/60 mt-auto">
             <span className="text-[9px] font-black text-gray-400 uppercase tracking-widest">
                 {hasGeo ? t('logCard.tapToViewMap') : t('logCard.noLocation')}
             </span>
@@ -199,7 +199,7 @@ function LogCard({ log, onEdit, onDelete, vehicleName, stationName }: LogCardPro
         </div>
 
         {/* BACK: Map View */}
-        <div className="absolute inset-0 rotate-y-180 backface-hidden bg-white dark:bg-gray-800 shadow-md rounded-2xl overflow-hidden border border-gray-100 dark:border-gray-700/50 flex flex-col">
+        <div className="absolute inset-0 rotate-y-180 backface-hidden nocturne-card rounded-2xl overflow-hidden flex flex-col">
           <div className="flex-grow relative bg-gray-100 dark:bg-gray-900">
             {isFlipped && hasGeo && (
               <MapContainer center={center} zoom={15} zoomControl={false} dragging={false} touchZoom={false} scrollWheelZoom={false} style={{ height: '100%', width: '100%' }}>

--- a/src/components/ReceiptAISection.tsx
+++ b/src/components/ReceiptAISection.tsx
@@ -34,8 +34,8 @@ const ReceiptAISection: React.FC<ReceiptAISectionProps> = ({
   if (!receiptDigitizationEnabled) return null;
 
   return (
-    <div className="bg-gray-50 dark:bg-gray-900/40 p-4 rounded-xl border border-gray-100 dark:border-gray-700 space-y-4">
-      <h3 className="text-xs font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider">{t('quickLog.sections.receipt')}</h3>
+    <div className="border-[1.5px] border-dashed border-gray-300 dark:border-gray-700 bg-brand-primary/[0.04] p-4 rounded-xl space-y-4">
+      <h3 className="text-[11px] font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-0">{t('quickLog.sections.receipt')}</h3>
       <ImageUpload
         onFileSelect={(file) => {
           setReceiptFile(file);
@@ -50,11 +50,11 @@ const ReceiptAISection: React.FC<ReceiptAISectionProps> = ({
               type="button"
               onClick={handleExtractData}
               disabled={isExtracting}
-              className="w-full flex items-center justify-center gap-2 py-2 px-4 border border-indigo-200 dark:border-indigo-800 rounded-lg text-sm font-medium text-indigo-700 dark:text-indigo-300 bg-indigo-50 hover:bg-indigo-100 dark:bg-indigo-900/30 dark:hover:bg-indigo-900/50 transition-colors disabled:opacity-50"
+              className="brand-button-primary w-full text-sm"
             >
               {isExtracting ? (
                 <>
-                  <svg className="animate-spin h-4 w-4 text-indigo-600 dark:text-indigo-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                  <svg className="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                     <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
                     <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                   </svg>
@@ -68,8 +68,8 @@ const ReceiptAISection: React.FC<ReceiptAISectionProps> = ({
               )}
             </button>
           ) : (
-            <div className="bg-white dark:bg-gray-800 p-3 rounded-lg border border-indigo-100 dark:border-indigo-800 shadow-sm text-sm">
-              <p className="font-semibold text-gray-700 dark:text-gray-300 mb-2">{t('receipt.extractionResults')}</p>
+            <div className="nocturne-card p-3 text-sm">
+              <div className="mb-2"><span className="nocturne-tag">{t('receipt.extractionResults')}</span></div>
               <ul className="space-y-1 mb-3 text-gray-600 dark:text-gray-400">
                 <li><span className="font-medium">{t('receipt.cost')}:</span> {extractedData.cost !== null ? extractedData.cost : t('receipt.notFound')}</li>
                 <li><span className="font-medium">{t('receipt.litres')}:</span> {extractedData.fuelAmountLiters !== null ? extractedData.fuelAmountLiters : t('receipt.notFound')}</li>
@@ -81,14 +81,14 @@ const ReceiptAISection: React.FC<ReceiptAISectionProps> = ({
                 <button
                   type="button"
                   onClick={handleConfirmExtraction}
-                  className="flex-1 py-1.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-md font-medium transition-colors"
+                  className="brand-button-primary flex-1 py-1.5 text-sm"
                 >
                   {t('receipt.useValues')}
                 </button>
                 <button
                   type="button"
                   onClick={handleCancelExtraction}
-                  className="flex-1 py-1.5 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-800 dark:text-gray-200 rounded-md font-medium transition-colors"
+                  className="brand-button-secondary flex-1 py-1.5 text-sm"
                 >
                   {t('receipt.discard')}
                 </button>

--- a/src/components/StationDetail.tsx
+++ b/src/components/StationDetail.tsx
@@ -133,7 +133,7 @@ const StationDetail: React.FC<StationDetailProps> = ({ stationId }) => {
 
     if (loading) {
         return (
-            <div className="flex flex-col items-center justify-center h-64 text-gray-500 dark:text-gray-400 bg-white dark:bg-gray-800 rounded-lg shadow-md border border-gray-100 dark:border-gray-700">
+            <div className="flex flex-col items-center justify-center h-64 text-gray-500 dark:text-gray-400 nocturne-card">
                 <Loader className="w-8 h-8 animate-spin mb-2" data-testid="loader-icon" />
                 <p>{t('stationDetail.loading')}</p>
             </div>
@@ -151,15 +151,15 @@ const StationDetail: React.FC<StationDetailProps> = ({ stationId }) => {
 
     if (!station) {
         return (
-            <div className="flex flex-col items-center justify-center h-64 text-gray-500 dark:text-gray-400 bg-white dark:bg-gray-800 rounded-lg shadow-md border border-gray-100 dark:border-gray-700">
+            <div className="flex flex-col items-center justify-center h-64 text-gray-500 dark:text-gray-400 nocturne-card">
                 <p>{t('stationDetail.noData')}</p>
             </div>
         );
     }
 
     return (
-        <div className="bg-white dark:bg-gray-800 shadow-md rounded-lg p-6 border border-gray-100 dark:border-gray-700 h-full">
-            <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2 flex items-center">
+        <div className="nocturne-card p-6 h-full">
+            <h2 className="text-2xl font-medium tracking-tight text-gray-900 dark:text-gray-100 mb-2 flex items-center">
                 <MapPin className="w-6 h-6 mr-2 text-brand-primary" />
                 {station.name}
             </h2>

--- a/src/components/StationTable.tsx
+++ b/src/components/StationTable.tsx
@@ -122,8 +122,8 @@ const StationTable: React.FC<StationTableProps> = ({ stations, onSelectStation, 
   };
 
   return (
-    <div className="bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-700">
-      <div className="flex flex-wrap items-center gap-1.5 p-3 border-b border-gray-100 dark:border-gray-700">
+    <div className="nocturne-card">
+      <div className="flex flex-wrap items-center gap-1.5 p-3 border-b border-gray-200 dark:border-gray-700/60">
         <span className="text-xs font-medium text-gray-500 dark:text-gray-400 mr-1">
           {t('stationTable.sortBy')}
         </span>
@@ -149,7 +149,7 @@ const StationTable: React.FC<StationTableProps> = ({ stations, onSelectStation, 
         })}
       </div>
 
-      <ul className="divide-y divide-gray-100 dark:divide-gray-700">
+      <ul className="divide-y divide-gray-200 dark:divide-gray-700/60">
         {sortedStations.map((station) => {
           const isSelected = selectedStationId === station.id;
           const tier = priceTiers.get(station.id);
@@ -159,7 +159,7 @@ const StationTable: React.FC<StationTableProps> = ({ stations, onSelectStation, 
                 type="button"
                 onClick={() => onSelectStation(station.id)}
                 aria-current={isSelected ? 'true' : undefined}
-                className={`w-full flex items-center gap-3 px-3 py-3 text-left transition-colors hover:bg-gray-50 dark:hover:bg-gray-700 ${
+                className={`w-full flex items-center gap-3 px-3 py-3 text-left transition-colors hover:bg-gray-50 dark:hover:bg-gray-100/[0.04] ${
                   isSelected ? 'bg-amber-50 dark:bg-amber-900/20' : ''
                 }`}
               >

--- a/src/index.css
+++ b/src/index.css
@@ -6,18 +6,66 @@
 @variant dark (&:where(.dark, .dark *));
 
 @theme {
-  /* Colors: Fuelog Forecourt Palette — amber like a petrol price board */
-  --color-brand-primary: #D97706;          /* amber-600: light-mode buttons & active states */
-  --color-brand-primary-hover: #B45309;    /* amber-700 */
-  --color-brand-primary-glow: #FBBF24;     /* amber-400: dark-mode accents & glows */
+  /*
+   * Nocturne design system — a quiet, compact dark interface.
+   * Near-neutral blue-grey ground, Inter at medium weight, soft radii and
+   * a single blurple accent used as a line and a glow rather than a flood.
+   * Tonal ramps generated in OKLCH on a shared perceptual lightness scale.
+   */
+
+  /* Brand roles — the accent is an outline/glow colour, never a flood */
+  --color-brand-primary: #9184d9;          /* Nocturne accent (blurple) */
+  --color-brand-primary-hover: #796cbf;    /* accent-600 */
+  --color-brand-primary-glow: #b5abfc;     /* accent-400: dark-ground accents */
   --color-brand-success: #10b981;
   --color-brand-danger: #EF4444;
-  --color-brand-dark-surface: #0A0F1E;     /* petroleum blue-black — richer than pure #000 */
+  --color-brand-dark-surface: #161826;     /* Nocturne ground */
+  --color-surface: #232532;                /* Nocturne raised surface */
 
-  /* Typography: Forecourt Pair */
-  --font-display: "Space Grotesk", "Inter", system-ui, sans-serif;
+  /* Neutral ramp — Nocturne blue-grey neutrals replace Tailwind's gray.
+     800 doubles as the dark surface fill, 700 as the dark edge/border. */
+  --color-gray-50: #f8f9fd;
+  --color-gray-100: #f3f5fe;
+  --color-gray-200: #e4e7f5;
+  --color-gray-300: #cfd3e5;
+  --color-gray-400: #b2b6ca;
+  --color-gray-500: #9397ab;
+  --color-gray-600: #75798c;
+  --color-gray-700: #454857;
+  --color-gray-800: #232532;
+  --color-gray-900: #1b1d29;
+  --color-gray-950: #131521;
+
+  /* Accent ramp — Nocturne blurple replaces amber (and indigo below) so
+     every existing accent resolves into the one accent role. */
+  --color-amber-50: #faf9ff;
+  --color-amber-100: #f5f4ff;
+  --color-amber-200: #e7e5fe;
+  --color-amber-300: #d2cefd;
+  --color-amber-400: #b5abfc;
+  --color-amber-500: #9184d9;
+  --color-amber-600: #796cbf;
+  --color-amber-700: #5d5294;
+  --color-amber-800: #423a6a;
+  --color-amber-900: #2b2741;
+  --color-amber-950: #201d33;
+
+  --color-indigo-50: #faf9ff;
+  --color-indigo-100: #f5f4ff;
+  --color-indigo-200: #e7e5fe;
+  --color-indigo-300: #d2cefd;
+  --color-indigo-400: #b5abfc;
+  --color-indigo-500: #9184d9;
+  --color-indigo-600: #796cbf;
+  --color-indigo-700: #5d5294;
+  --color-indigo-800: #423a6a;
+  --color-indigo-900: #2b2741;
+  --color-indigo-950: #201d33;
+
+  /* Typography: Inter carries both headings and body; data stays mono */
+  --font-display: "Inter", system-ui, sans-serif;
   --font-sans: "Inter", system-ui, sans-serif;
-  --font-mono: "Space Mono", "JetBrains Mono", ui-monospace, monospace;
+  --font-mono: ui-monospace, "SF Mono", "Cascadia Mono", Menlo, monospace;
 
   /* Custom Transitions */
   --animate-squish: squish 0.2s cubic-bezier(0.4, 0, 0.2, 1);
@@ -43,25 +91,103 @@
     -webkit-tap-highlight-color: transparent;
     scroll-behavior: smooth;
   }
-  
+
   body {
     @apply antialiased text-gray-900 bg-gray-50 dark:text-gray-100 dark:bg-brand-dark-surface transition-colors duration-300;
   }
+
+  /* Nocturne: the accent as a glow — one soft radial wash on the dark ground */
+  .dark body {
+    background-image: radial-gradient(
+      1200px 600px at 15% -10%,
+      color-mix(in srgb, var(--color-brand-primary) 8%, transparent),
+      transparent
+    );
+    background-attachment: fixed;
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    @apply font-medium tracking-tight;
+  }
+
+  /* Interaction states are themed, never browser defaults */
+  :focus-visible {
+    outline: 2px solid var(--color-brand-primary);
+    outline-offset: 2px;
+  }
+  ::selection {
+    background: color-mix(in srgb, var(--color-brand-primary) 30%, transparent);
+  }
+
+  ::-webkit-scrollbar { width: 8px; height: 8px; }
+  ::-webkit-scrollbar-thumb {
+    background: var(--color-gray-300);
+    border-radius: 4px;
+  }
+  .dark ::-webkit-scrollbar-thumb { background: var(--color-gray-700); }
 }
 
-/* Glassmorphism & Brand Components */
+/* Nocturne component layer */
 @layer components {
   .glass-header {
-    @apply sticky top-0 z-40 bg-white/80 dark:bg-brand-dark-surface/80 backdrop-blur-md border-b border-gray-200 dark:border-gray-800 shadow-sm;
+    @apply sticky top-0 z-40 bg-white/85 dark:bg-brand-dark-surface/85 backdrop-blur-md border-b border-gray-200 dark:border-gray-700/60;
   }
 
   .glass-nav {
-    @apply fixed bottom-0 left-0 right-0 z-50 bg-white/90 dark:bg-brand-dark-surface/90 backdrop-blur-lg border-t border-gray-200 dark:border-gray-800 pb-safe;
+    @apply fixed bottom-0 left-0 right-0 z-50 bg-white/95 dark:bg-gray-800/95 backdrop-blur-lg border-t border-gray-200 dark:border-gray-700/60 pb-safe;
   }
 
-  /* Buttons: dark text on amber — mirrors LED price board digits */
+  /* Primary action: an accent outline, never a fill */
   .brand-button-primary {
-    @apply inline-flex items-center justify-center px-4 py-2.5 rounded-xl font-bold transition-all bg-brand-primary text-gray-950 hover:bg-brand-primary-hover shadow-md shadow-amber-500/20 hover:shadow-amber-600/30 active:scale-95 disabled:opacity-50 disabled:pointer-events-none;
+    @apply inline-flex items-center justify-center gap-1.5 px-4 py-2.5 rounded-lg font-medium text-brand-primary-hover dark:text-brand-primary border border-brand-primary-hover dark:border-brand-primary bg-transparent transition-colors hover:bg-brand-primary/10 active:bg-brand-primary/20 disabled:opacity-45 disabled:pointer-events-none;
+  }
+
+  /* Secondary action: hairline divider outline */
+  .brand-button-secondary {
+    @apply inline-flex items-center justify-center gap-1.5 px-4 py-2.5 rounded-lg font-medium text-gray-700 dark:text-gray-200 border border-gray-300 dark:border-gray-700 bg-transparent transition-colors hover:bg-gray-900/5 dark:hover:bg-gray-100/5 active:bg-gray-900/10 dark:active:bg-gray-100/10 disabled:opacity-45 disabled:pointer-events-none;
+  }
+
+  /* Surface-filled content card */
+  .nocturne-card {
+    @apply bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700/60 shadow-sm;
+  }
+
+  /* Form input on a native element */
+  .nocturne-input {
+    @apply w-full min-h-9 px-3 py-2 text-sm font-medium bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg text-gray-900 dark:text-gray-100 caret-brand-primary transition-colors hover:border-gray-400 dark:hover:border-gray-600 focus:outline-none focus:border-brand-primary focus:ring-1 focus:ring-brand-primary placeholder-gray-400 dark:placeholder-gray-500 disabled:opacity-45;
+  }
+
+  .nocturne-label {
+    @apply block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1.5;
+  }
+
+  /* Small tinted label from the accent ramp */
+  .nocturne-tag {
+    @apply inline-flex items-center text-[11px] tracking-wide px-2.5 py-0.5 rounded-md bg-amber-100 text-amber-700 dark:bg-amber-800 dark:text-amber-100;
+  }
+
+  .nocturne-tag-neutral {
+    @apply inline-flex items-center text-[11px] tracking-wide px-2.5 py-0.5 rounded-md bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-100;
+  }
+
+  /* Segmented control (radiogroup of .nocturne-seg-opt labels) */
+  .nocturne-seg {
+    @apply inline-flex overflow-hidden border border-gray-300 dark:border-gray-700 rounded-lg;
+  }
+  .nocturne-seg-opt {
+    @apply inline-flex items-center gap-1.5 px-3 py-1.5 text-[13px] cursor-pointer transition-colors;
+  }
+  .nocturne-seg-opt + .nocturne-seg-opt {
+    @apply border-l border-gray-300 dark:border-gray-700;
+  }
+  .nocturne-seg-opt:has(input:checked) {
+    @apply text-brand-primary-hover dark:text-brand-primary shadow-[inset_0_0_0_1px_var(--color-brand-primary)];
+  }
+  .nocturne-seg-opt:not(:has(input:checked)):hover {
+    @apply bg-gray-900/5 dark:bg-gray-100/5;
+  }
+  .nocturne-seg-opt input {
+    @apply absolute opacity-0 w-0 h-0 pointer-events-none;
   }
 
   /* Data display: tabular, monospaced, tight tracking */
@@ -78,9 +204,9 @@
 /* Dark mode popup styles */
 .dark .leaflet-popup-content-wrapper,
 .dark .leaflet-popup-tip {
-    background-color: #0f172a; /* slate-900 */
-    color: #f3f4f6; /* gray-100 */
-    border: 1px solid #1e293b;
+    background-color: #232532; /* Nocturne surface */
+    color: #e9e9ed;
+    border: 1px solid #3f424d;
 }
 
 /* Card Flip Animations */

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -5,7 +5,6 @@ import { collection, query, where, getDocs, Timestamp } from 'firebase/firestore
 import {
     BarChart, Bar, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
 } from 'recharts';
-import { Banknote, Droplets, Gauge, Route, Fuel } from 'lucide-react';
 import { db } from '../firebase/config';
 import { useAuth } from '../context/AuthContext';
 import { useTheme } from '../context/ThemeContext';
@@ -187,7 +186,7 @@ function DashboardPage(): JSX.Element {
     if (isLoading) {
         return (
             <div className="text-center py-8">
-                <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-indigo-600 mx-auto"></div>
+                <div className="animate-spin rounded-full h-10 w-10 border-2 border-gray-200 dark:border-gray-700 border-t-brand-primary mx-auto"></div>
                 <p className="mt-2 text-sm text-gray-500 animate-pulse">{t('dashboard.loading', { defaultValue: 'Loading dashboard...' })}</p>
             </div>
         );
@@ -204,7 +203,7 @@ function DashboardPage(): JSX.Element {
     return (
         <div className="container mx-auto max-w-3xl px-4 space-y-6">
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-                <h2 className="text-2xl font-bold text-gray-800 dark:text-white">{t('dashboard.title', { defaultValue: 'Dashboard' })}</h2>
+                <h2 className="text-2xl font-medium tracking-tight text-gray-900 dark:text-gray-100">{t('dashboard.title', { defaultValue: 'Dashboard' })}</h2>
 
                 {vehicles.length > 1 && (
                     <div className="w-full sm:w-56">
@@ -213,7 +212,7 @@ function DashboardPage(): JSX.Element {
                             id="dashboard-vehicle"
                             value={selectedVehicleId}
                             onChange={(e) => setSelectedVehicleId(e.target.value)}
-                            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:focus:ring-indigo-400 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                            className="nocturne-input cursor-pointer"
                         >
                             <option value="">{t('dashboard.fields.allVehicles', { defaultValue: 'All Vehicles' })}</option>
                             {vehicles.map(v => (
@@ -232,53 +231,44 @@ function DashboardPage(): JSX.Element {
             ) : (
                 <>
                     <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-                        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-4 flex flex-col items-center gap-2">
-                            <div className="p-2 rounded-lg bg-brand-primary/10 text-brand-primary">
-                                <Banknote size={18} />
-                            </div>
-                            <p className="text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider text-center">{t('dashboard.cards.monthSpend', { defaultValue: 'This Month' })}</p>
-                            <p className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white font-mono tracking-tighter">
+                        <div className="nocturne-card p-4 flex flex-col items-center gap-1.5">
+                            <p className="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider text-center">{t('dashboard.cards.monthSpend', { defaultValue: 'This Month' })}</p>
+                            <p className="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-gray-100 font-mono tracking-tighter">
                                 {homeCurrencySymbol}{(currentMonth?.totalCost ?? 0).toFixed(2)}
                             </p>
                         </div>
-                        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-4 flex flex-col items-center gap-2">
-                            <div className="p-2 rounded-lg bg-brand-primary/10 text-brand-primary">
-                                <Droplets size={18} />
-                            </div>
-                            <p className="text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider text-center">{t('dashboard.cards.monthLitres', { defaultValue: 'Litres This Month' })}</p>
-                            <p className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white font-mono tracking-tighter">
+                        <div className="nocturne-card p-4 flex flex-col items-center gap-1.5">
+                            <p className="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider text-center">{t('dashboard.cards.monthLitres', { defaultValue: 'Litres This Month' })}</p>
+                            <p className="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-gray-100 font-mono tracking-tighter">
                                 {(currentMonth?.totalLitres ?? 0).toFixed(1)}L
                             </p>
                         </div>
-                        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-4 flex flex-col items-center gap-2">
-                            <div className="p-2 rounded-lg bg-brand-primary/10 text-brand-primary">
-                                <Gauge size={18} />
-                            </div>
-                            <p className="text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider text-center">{t('dashboard.cards.avgPrice', { defaultValue: 'Avg Price/Litre' })}</p>
-                            <p className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white font-mono tracking-tighter">
+                        <div className="nocturne-card p-4 flex flex-col items-center gap-1.5">
+                            <p className="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider text-center">{t('dashboard.cards.avgPrice', { defaultValue: 'Avg Price/Litre' })}</p>
+                            <p className="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-gray-100 font-mono tracking-tighter">
                                 {currentMonthAvgPrice !== null ? `${homeCurrencySymbol}${currentMonthAvgPrice.toFixed(3)}` : 'N/A'}
                             </p>
                         </div>
                     </div>
 
-                    <div className="bg-white dark:bg-gray-800 shadow-lg rounded-xl p-4 sm:p-6 border border-gray-200 dark:border-gray-700">
-                        <h3 className="text-lg font-medium text-gray-700 dark:text-gray-300 mb-4">{t('dashboard.charts.monthlySpend', { defaultValue: 'Monthly Spend (Last 6 Months)' })}</h3>
+                    <div className="nocturne-card p-4 sm:p-6">
+                        <h3 className="text-base font-medium text-gray-800 dark:text-gray-200 mb-4">{t('dashboard.charts.monthlySpend', { defaultValue: 'Monthly Spend (Last 6 Months)' })}</h3>
                         <ResponsiveContainer width="100%" height={300}>
                             <BarChart data={chartData} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
-                                <CartesianGrid strokeDasharray="3 3" stroke={theme === 'dark' ? '#4A5568' : '#e0e0e0'} />
-                                <XAxis dataKey="month" tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }} />
-                                <YAxis tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }} />
+                                <CartesianGrid strokeDasharray="3 3" stroke={theme === 'dark' ? '#3f424d' : '#e4e7f5'} />
+                                <XAxis dataKey="month" tick={{ fill: theme === 'dark' ? '#9397ab' : '#75798c', fontSize: 12 }} />
+                                <YAxis tick={{ fill: theme === 'dark' ? '#9397ab' : '#75798c', fontSize: 12 }} />
                                 <Tooltip
                                     contentStyle={{
                                         fontSize: '12px',
                                         padding: '5px',
-                                        backgroundColor: theme === 'dark' ? '#2D3748' : 'white',
+                                        backgroundColor: theme === 'dark' ? '#232532' : 'white',
                                         color: theme === 'dark' ? 'white' : 'black',
-                                        border: theme === 'dark' ? '1px solid #4A5568' : '1px solid #e0e0e0'
+                                        border: theme === 'dark' ? '1px solid #3f424d' : '1px solid #e4e7f5'
                                     }}
                                     formatter={(value: number) => `${homeCurrencySymbol}${value.toFixed(2)}`}
                                 />
-                                <Bar dataKey="cost" name={t('dashboard.charts.spend', { defaultValue: 'Spend' })} fill="#8884d8" radius={[4, 4, 0, 0]} />
+                                <Bar dataKey="cost" name={t('dashboard.charts.spend', { defaultValue: 'Spend' })} fill="#5d5294" radius={[4, 4, 0, 0]} />
                             </BarChart>
                         </ResponsiveContainer>
                     </div>
@@ -286,37 +276,25 @@ function DashboardPage(): JSX.Element {
                     {/* --- Lifetime Stats (Server-side aggregation, no full data download) --- */}
                     {lifetimeStats && (
                         <div>
-                            <p className="text-xs font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider mb-3">
+                            <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-3">
                                 {t('history.lifetimeStats.heading', { defaultValue: 'Lifetime Totals' })}
                             </p>
                             <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-                                <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-4 flex flex-col items-center gap-2 hover:shadow-md transition-all duration-200">
-                                    <div className="p-2 rounded-lg bg-brand-primary/10 text-brand-primary">
-                                        <Banknote size={18} />
-                                    </div>
-                                    <p className="text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider text-center">{t('history.lifetimeStats.totalSpent', { defaultValue: 'Total Spent' })}</p>
-                                    <p className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white font-mono tracking-tighter">{homeCurrencySymbol}{lifetimeStats.totalCost.toFixed(2)}</p>
+                                <div className="nocturne-card p-4 flex flex-col items-center gap-1.5">
+                                    <p className="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider text-center">{t('history.lifetimeStats.totalSpent', { defaultValue: 'Total Spent' })}</p>
+                                    <p className="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-gray-100 font-mono tracking-tighter">{homeCurrencySymbol}{lifetimeStats.totalCost.toFixed(2)}</p>
                                 </div>
-                                <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-4 flex flex-col items-center gap-2 hover:shadow-md transition-all duration-200">
-                                    <div className="p-2 rounded-lg bg-brand-primary/10 text-brand-primary">
-                                        <Droplets size={18} />
-                                    </div>
-                                    <p className="text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider text-center">{t('history.lifetimeStats.totalLitres', { defaultValue: 'Total Litres' })}</p>
-                                    <p className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white font-mono tracking-tighter">{lifetimeStats.totalLitres.toFixed(1)}L</p>
+                                <div className="nocturne-card p-4 flex flex-col items-center gap-1.5">
+                                    <p className="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider text-center">{t('history.lifetimeStats.totalLitres', { defaultValue: 'Total Litres' })}</p>
+                                    <p className="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-gray-100 font-mono tracking-tighter">{lifetimeStats.totalLitres.toFixed(1)}L</p>
                                 </div>
-                                <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-4 flex flex-col items-center gap-2 hover:shadow-md transition-all duration-200">
-                                    <div className="p-2 rounded-lg bg-brand-primary/10 text-brand-primary">
-                                        <Route size={18} />
-                                    </div>
-                                    <p className="text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider text-center">{t('history.lifetimeStats.totalDistance', { defaultValue: 'Total Distance' })}</p>
-                                    <p className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white font-mono tracking-tighter">{lifetimeStats.totalDistanceKm.toFixed(0)}km</p>
+                                <div className="nocturne-card p-4 flex flex-col items-center gap-1.5">
+                                    <p className="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider text-center">{t('history.lifetimeStats.totalDistance', { defaultValue: 'Total Distance' })}</p>
+                                    <p className="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-gray-100 font-mono tracking-tighter">{lifetimeStats.totalDistanceKm.toFixed(0)}km</p>
                                 </div>
-                                <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-4 flex flex-col items-center gap-2 hover:shadow-md transition-all duration-200">
-                                    <div className="p-2 rounded-lg bg-brand-primary/10 text-brand-primary">
-                                        <Fuel size={18} />
-                                    </div>
-                                    <p className="text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider text-center">{t('history.lifetimeStats.logCount', { defaultValue: 'Fill-ups' })}</p>
-                                    <p className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white font-mono tracking-tighter">{lifetimeStats.logCount}</p>
+                                <div className="nocturne-card p-4 flex flex-col items-center gap-1.5">
+                                    <p className="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider text-center">{t('history.lifetimeStats.logCount', { defaultValue: 'Fill-ups' })}</p>
+                                    <p className="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-gray-100 font-mono tracking-tighter">{lifetimeStats.logCount}</p>
                                 </div>
                             </div>
                         </div>
@@ -324,28 +302,28 @@ function DashboardPage(): JSX.Element {
 
                     {/* --- MPG / Price Trend Chart --- */}
                     {trendChartData.length > 1 && (
-                        <div className="bg-white dark:bg-gray-800 shadow-lg rounded-xl p-4 sm:p-6 border border-gray-200 dark:border-gray-700">
-                            <h3 className="text-lg font-medium text-gray-700 dark:text-gray-300 mb-4">{t('history.charts.mpgOverTime')}</h3>
+                        <div className="nocturne-card p-4 sm:p-6">
+                            <h3 className="text-base font-medium text-gray-800 dark:text-gray-200 mb-4">{t('history.charts.mpgOverTime')}</h3>
                             <ResponsiveContainer width="100%" height={300}>
                                 <LineChart data={trendChartData} margin={{ top: 5, right: 20, left: -10, bottom: 5 }}>
-                                    <CartesianGrid strokeDasharray="3 3" stroke={theme === 'dark' ? '#4A5568' : '#e0e0e0'} />
-                                    <XAxis dataKey="date" tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }} angle={-30} textAnchor="end" height={50} interval="preserveStartEnd" />
-                                    <YAxis yAxisId="left" tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }} domain={['auto', 'auto']} label={{ value: 'MPG (UK)', angle: -90, position: 'insideLeft', offset: 10, style: { fontSize: '12px', fill: theme === 'dark' ? '#cbd5e0' : '#6b7280' } }} />
+                                    <CartesianGrid strokeDasharray="3 3" stroke={theme === 'dark' ? '#3f424d' : '#e4e7f5'} />
+                                    <XAxis dataKey="date" tick={{ fill: theme === 'dark' ? '#9397ab' : '#75798c', fontSize: 12 }} angle={-30} textAnchor="end" height={50} interval="preserveStartEnd" />
+                                    <YAxis yAxisId="left" tick={{ fill: theme === 'dark' ? '#9397ab' : '#75798c', fontSize: 12 }} domain={['auto', 'auto']} label={{ value: 'MPG (UK)', angle: -90, position: 'insideLeft', offset: 10, style: { fontSize: '12px', fill: theme === 'dark' ? '#9397ab' : '#75798c' } }} />
                                     <YAxis
                                         yAxisId="right"
                                         orientation="right"
-                                        tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }}
+                                        tick={{ fill: theme === 'dark' ? '#9397ab' : '#75798c', fontSize: 12 }}
                                         domain={['auto', 'auto']}
                                         tickFormatter={(value: number) => value.toFixed(3)}
-                                        label={{ value: `${t('history.charts.pricePerLitre')} (${homeCurrencySymbol})`, angle: 90, position: 'insideRight', offset: 10, style: { fontSize: '12px', fill: theme === 'dark' ? '#cbd5e0' : '#6b7280' } }}
+                                        label={{ value: `${t('history.charts.pricePerLitre')} (${homeCurrencySymbol})`, angle: 90, position: 'insideRight', offset: 10, style: { fontSize: '12px', fill: theme === 'dark' ? '#9397ab' : '#75798c' } }}
                                     />
                                     <Tooltip
                                         contentStyle={{
                                             fontSize: '12px',
                                             padding: '5px',
-                                            backgroundColor: theme === 'dark' ? '#2D3748' : 'white',
+                                            backgroundColor: theme === 'dark' ? '#232532' : 'white',
                                             color: theme === 'dark' ? 'white' : 'black',
-                                            border: theme === 'dark' ? '1px solid #4A5568' : '1px solid #e0e0e0'
+                                            border: theme === 'dark' ? '1px solid #3f424d' : '1px solid #e4e7f5'
                                         }}
                                         formatter={(value: number, name: string) => name === t('history.charts.pricePerLitre')
                                             ? `${homeCurrencySymbol}${value.toFixed(3)}`
@@ -355,8 +333,8 @@ function DashboardPage(): JSX.Element {
                                         wrapperStyle={{ fontSize: '12px', paddingTop: '10px', color: theme === 'dark' ? 'white' : 'black', cursor: 'pointer' }}
                                         onClick={(e) => toggleChartSeries(e.dataKey as string)}
                                     />
-                                    <Line yAxisId="left" type="monotone" dataKey="mpg" name="MPG (UK)" stroke="#8884d8" strokeWidth={2} activeDot={{ r: 6 }} connectNulls hide={hiddenChartSeries.has('mpg')} />
-                                    <Line yAxisId="right" type="monotone" dataKey="fuelPrice" name={t('history.charts.pricePerLitre')} stroke="#F59E0B" strokeWidth={2} activeDot={{ r: 6 }} connectNulls hide={hiddenChartSeries.has('fuelPrice')} />
+                                    <Line yAxisId="left" type="monotone" dataKey="mpg" name="MPG (UK)" stroke="#9184d9" strokeWidth={2.5} activeDot={{ r: 6 }} connectNulls hide={hiddenChartSeries.has('mpg')} />
+                                    <Line yAxisId="right" type="monotone" dataKey="fuelPrice" name={t('history.charts.pricePerLitre')} stroke="#9397ab" strokeWidth={2} activeDot={{ r: 6 }} connectNulls hide={hiddenChartSeries.has('fuelPrice')} />
                                 </LineChart>
                             </ResponsiveContainer>
                         </div>
@@ -364,24 +342,24 @@ function DashboardPage(): JSX.Element {
 
                     {/* Conditionally render Cost Per Litre Graph if feature flag is enabled and data exists */}
                     {costPerLitreGraphEnabled && trendChartData.length > 1 && (
-                        <div className="bg-white dark:bg-gray-800 shadow-lg rounded-xl p-4 sm:p-6 border border-gray-200 dark:border-gray-700">
-                            <h3 className="text-lg font-medium text-gray-700 dark:text-gray-300 mb-4">{t('history.charts.costPerLitreOverTime')}</h3>
+                        <div className="nocturne-card p-4 sm:p-6">
+                            <h3 className="text-base font-medium text-gray-800 dark:text-gray-200 mb-4">{t('history.charts.costPerLitreOverTime')}</h3>
                             <ResponsiveContainer width="100%" height={300}>
                                 <LineChart data={trendChartData} margin={{ top: 5, right: 20, left: -10, bottom: 5 }}>
-                                    <CartesianGrid strokeDasharray="3 3" stroke={theme === 'dark' ? '#4A5568' : '#e0e0e0'} />
-                                    <XAxis dataKey="date" tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }} angle={-30} textAnchor="end" height={50} interval="preserveStartEnd" />
+                                    <CartesianGrid strokeDasharray="3 3" stroke={theme === 'dark' ? '#3f424d' : '#e4e7f5'} />
+                                    <XAxis dataKey="date" tick={{ fill: theme === 'dark' ? '#9397ab' : '#75798c', fontSize: 12 }} angle={-30} textAnchor="end" height={50} interval="preserveStartEnd" />
                                     <YAxis
-                                        tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }}
+                                        tick={{ fill: theme === 'dark' ? '#9397ab' : '#75798c', fontSize: 12 }}
                                         domain={['auto', 'auto']}
-                                        label={{ value: 'Cost Per Litre (€)', angle: -90, position: 'insideLeft', offset: 10, style: { fontSize: '12px', fill: theme === 'dark' ? '#cbd5e0' : '#6b7280' } }}
+                                        label={{ value: 'Cost Per Litre (€)', angle: -90, position: 'insideLeft', offset: 10, style: { fontSize: '12px', fill: theme === 'dark' ? '#9397ab' : '#75798c' } }}
                                         tickFormatter={(value) => value.toFixed(3)}
                                     />
                                     <Tooltip
-                                        contentStyle={{ fontSize: '12px', padding: '5px', backgroundColor: theme === 'dark' ? '#2D3748' : 'white', color: theme === 'dark' ? 'white' : 'black', border: theme === 'dark' ? '1px solid #4A5568' : '1px solid #e0e0e0' }}
+                                        contentStyle={{ fontSize: '12px', padding: '5px', backgroundColor: theme === 'dark' ? '#232532' : 'white', color: theme === 'dark' ? 'white' : 'black', border: theme === 'dark' ? '1px solid #3f424d' : '1px solid #e4e7f5' }}
                                         formatter={(value: number) => `€${value.toFixed(3)}`}
                                     />
                                     <Legend wrapperStyle={{ fontSize: '12px', paddingTop: '10px', color: theme === 'dark' ? 'white' : 'black' }} />
-                                    <Line type="monotone" dataKey="fuelPrice" name="Cost Per Litre" stroke="#82ca9d" strokeWidth={2} activeDot={{ r: 6 }} connectNulls />
+                                    <Line type="monotone" dataKey="fuelPrice" name="Cost Per Litre" stroke="#9184d9" strokeWidth={2.5} activeDot={{ r: 6 }} connectNulls />
                                 </LineChart>
                             </ResponsiveContainer>
                         </div>
@@ -389,23 +367,23 @@ function DashboardPage(): JSX.Element {
 
                     {/* Multi-vehicle efficiency/cost comparison, behind vehicleComparisonEnabled flag */}
                     {vehicleComparisonEnabled && vehicleComparisonStats.length >= 2 && (
-                        <div className="bg-white dark:bg-gray-800 shadow-lg rounded-xl p-4 sm:p-6 border border-gray-200 dark:border-gray-700">
-                            <h3 className="text-lg font-medium text-gray-700 dark:text-gray-300 mb-4">{t('history.charts.vehicleComparison')}</h3>
+                        <div className="nocturne-card p-4 sm:p-6">
+                            <h3 className="text-base font-medium text-gray-800 dark:text-gray-200 mb-4">{t('history.charts.vehicleComparison')}</h3>
                             <ResponsiveContainer width="100%" height={300}>
                                 <BarChart data={vehicleComparisonStats} margin={{ top: 5, right: 20, left: -10, bottom: 5 }}>
-                                    <CartesianGrid strokeDasharray="3 3" stroke={theme === 'dark' ? '#4A5568' : '#e0e0e0'} />
-                                    <XAxis dataKey="name" tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }} />
+                                    <CartesianGrid strokeDasharray="3 3" stroke={theme === 'dark' ? '#3f424d' : '#e4e7f5'} />
+                                    <XAxis dataKey="name" tick={{ fill: theme === 'dark' ? '#9397ab' : '#75798c', fontSize: 12 }} />
                                     <YAxis
                                         yAxisId="left"
-                                        tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }}
+                                        tick={{ fill: theme === 'dark' ? '#9397ab' : '#75798c', fontSize: 12 }}
                                     />
                                     <YAxis
                                         yAxisId="right"
                                         orientation="right"
-                                        tick={{ fill: theme === 'dark' ? '#cbd5e0' : '#6b7280', fontSize: 12 }}
+                                        tick={{ fill: theme === 'dark' ? '#9397ab' : '#75798c', fontSize: 12 }}
                                     />
                                     <Tooltip
-                                        contentStyle={{ fontSize: '12px', padding: '5px', backgroundColor: theme === 'dark' ? '#2D3748' : 'white', color: theme === 'dark' ? 'white' : 'black', border: theme === 'dark' ? '1px solid #4A5568' : '1px solid #e0e0e0' }}
+                                        contentStyle={{ fontSize: '12px', padding: '5px', backgroundColor: theme === 'dark' ? '#232532' : 'white', color: theme === 'dark' ? 'white' : 'black', border: theme === 'dark' ? '1px solid #3f424d' : '1px solid #e4e7f5' }}
                                         formatter={(value: number, name: string) => name === t('history.charts.totalSpend')
                                             ? `${homeCurrencySymbol}${value.toFixed(2)}`
                                             : name === t('history.charts.avgCostPerLitre')
@@ -413,9 +391,9 @@ function DashboardPage(): JSX.Element {
                                                 : value.toFixed(2)}
                                     />
                                     <Legend wrapperStyle={{ fontSize: '12px', paddingTop: '10px', color: theme === 'dark' ? 'white' : 'black' }} />
-                                    <Bar yAxisId="left" dataKey="avgL100km" name={t('history.charts.avgL100km')} fill="#8884d8" />
-                                    <Bar yAxisId="left" dataKey="avgCostPerLitre" name={t('history.charts.avgCostPerLitre')} fill="#82ca9d" />
-                                    <Bar yAxisId="right" dataKey="totalSpend" name={t('history.charts.totalSpend')} fill="#fbbf24" />
+                                    <Bar yAxisId="left" dataKey="avgL100km" name={t('history.charts.avgL100km')} fill="#9184d9" />
+                                    <Bar yAxisId="left" dataKey="avgCostPerLitre" name={t('history.charts.avgCostPerLitre')} fill="#75798c" />
+                                    <Bar yAxisId="right" dataKey="totalSpend" name={t('history.charts.totalSpend')} fill="#5d5294" />
                                 </BarChart>
                             </ResponsiveContainer>
                         </div>

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -255,20 +255,20 @@ function DashboardPage(): JSX.Element {
                         <h3 className="text-base font-medium text-gray-800 dark:text-gray-200 mb-4">{t('dashboard.charts.monthlySpend', { defaultValue: 'Monthly Spend (Last 6 Months)' })}</h3>
                         <ResponsiveContainer width="100%" height={300}>
                             <BarChart data={chartData} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
-                                <CartesianGrid strokeDasharray="3 3" stroke={theme === 'dark' ? '#3f424d' : '#e4e7f5'} />
-                                <XAxis dataKey="month" tick={{ fill: theme === 'dark' ? '#9397ab' : '#75798c', fontSize: 12 }} />
-                                <YAxis tick={{ fill: theme === 'dark' ? '#9397ab' : '#75798c', fontSize: 12 }} />
+                                <CartesianGrid strokeDasharray="3 3" stroke={theme === 'dark' ? 'var(--color-gray-700)' : 'var(--color-gray-200)'} />
+                                <XAxis dataKey="month" tick={{ fill: theme === 'dark' ? 'var(--color-gray-500)' : 'var(--color-gray-600)', fontSize: 12 }} />
+                                <YAxis tick={{ fill: theme === 'dark' ? 'var(--color-gray-500)' : 'var(--color-gray-600)', fontSize: 12 }} />
                                 <Tooltip
                                     contentStyle={{
                                         fontSize: '12px',
                                         padding: '5px',
-                                        backgroundColor: theme === 'dark' ? '#232532' : 'white',
+                                        backgroundColor: theme === 'dark' ? 'var(--color-surface)' : 'white',
                                         color: theme === 'dark' ? 'white' : 'black',
-                                        border: theme === 'dark' ? '1px solid #3f424d' : '1px solid #e4e7f5'
+                                        border: theme === 'dark' ? '1px solid var(--color-gray-700)' : '1px solid var(--color-gray-200)'
                                     }}
                                     formatter={(value: number) => `${homeCurrencySymbol}${value.toFixed(2)}`}
                                 />
-                                <Bar dataKey="cost" name={t('dashboard.charts.spend', { defaultValue: 'Spend' })} fill="#5d5294" radius={[4, 4, 0, 0]} />
+                                <Bar dataKey="cost" name={t('dashboard.charts.spend', { defaultValue: 'Spend' })} fill="var(--color-amber-700)" radius={[4, 4, 0, 0]} />
                             </BarChart>
                         </ResponsiveContainer>
                     </div>
@@ -306,24 +306,24 @@ function DashboardPage(): JSX.Element {
                             <h3 className="text-base font-medium text-gray-800 dark:text-gray-200 mb-4">{t('history.charts.mpgOverTime')}</h3>
                             <ResponsiveContainer width="100%" height={300}>
                                 <LineChart data={trendChartData} margin={{ top: 5, right: 20, left: -10, bottom: 5 }}>
-                                    <CartesianGrid strokeDasharray="3 3" stroke={theme === 'dark' ? '#3f424d' : '#e4e7f5'} />
-                                    <XAxis dataKey="date" tick={{ fill: theme === 'dark' ? '#9397ab' : '#75798c', fontSize: 12 }} angle={-30} textAnchor="end" height={50} interval="preserveStartEnd" />
-                                    <YAxis yAxisId="left" tick={{ fill: theme === 'dark' ? '#9397ab' : '#75798c', fontSize: 12 }} domain={['auto', 'auto']} label={{ value: 'MPG (UK)', angle: -90, position: 'insideLeft', offset: 10, style: { fontSize: '12px', fill: theme === 'dark' ? '#9397ab' : '#75798c' } }} />
+                                    <CartesianGrid strokeDasharray="3 3" stroke={theme === 'dark' ? 'var(--color-gray-700)' : 'var(--color-gray-200)'} />
+                                    <XAxis dataKey="date" tick={{ fill: theme === 'dark' ? 'var(--color-gray-500)' : 'var(--color-gray-600)', fontSize: 12 }} angle={-30} textAnchor="end" height={50} interval="preserveStartEnd" />
+                                    <YAxis yAxisId="left" tick={{ fill: theme === 'dark' ? 'var(--color-gray-500)' : 'var(--color-gray-600)', fontSize: 12 }} domain={['auto', 'auto']} label={{ value: 'MPG (UK)', angle: -90, position: 'insideLeft', offset: 10, style: { fontSize: '12px', fill: theme === 'dark' ? 'var(--color-gray-500)' : 'var(--color-gray-600)' } }} />
                                     <YAxis
                                         yAxisId="right"
                                         orientation="right"
-                                        tick={{ fill: theme === 'dark' ? '#9397ab' : '#75798c', fontSize: 12 }}
+                                        tick={{ fill: theme === 'dark' ? 'var(--color-gray-500)' : 'var(--color-gray-600)', fontSize: 12 }}
                                         domain={['auto', 'auto']}
                                         tickFormatter={(value: number) => value.toFixed(3)}
-                                        label={{ value: `${t('history.charts.pricePerLitre')} (${homeCurrencySymbol})`, angle: 90, position: 'insideRight', offset: 10, style: { fontSize: '12px', fill: theme === 'dark' ? '#9397ab' : '#75798c' } }}
+                                        label={{ value: `${t('history.charts.pricePerLitre')} (${homeCurrencySymbol})`, angle: 90, position: 'insideRight', offset: 10, style: { fontSize: '12px', fill: theme === 'dark' ? 'var(--color-gray-500)' : 'var(--color-gray-600)' } }}
                                     />
                                     <Tooltip
                                         contentStyle={{
                                             fontSize: '12px',
                                             padding: '5px',
-                                            backgroundColor: theme === 'dark' ? '#232532' : 'white',
+                                            backgroundColor: theme === 'dark' ? 'var(--color-surface)' : 'white',
                                             color: theme === 'dark' ? 'white' : 'black',
-                                            border: theme === 'dark' ? '1px solid #3f424d' : '1px solid #e4e7f5'
+                                            border: theme === 'dark' ? '1px solid var(--color-gray-700)' : '1px solid var(--color-gray-200)'
                                         }}
                                         formatter={(value: number, name: string) => name === t('history.charts.pricePerLitre')
                                             ? `${homeCurrencySymbol}${value.toFixed(3)}`
@@ -333,8 +333,8 @@ function DashboardPage(): JSX.Element {
                                         wrapperStyle={{ fontSize: '12px', paddingTop: '10px', color: theme === 'dark' ? 'white' : 'black', cursor: 'pointer' }}
                                         onClick={(e) => toggleChartSeries(e.dataKey as string)}
                                     />
-                                    <Line yAxisId="left" type="monotone" dataKey="mpg" name="MPG (UK)" stroke="#9184d9" strokeWidth={2.5} activeDot={{ r: 6 }} connectNulls hide={hiddenChartSeries.has('mpg')} />
-                                    <Line yAxisId="right" type="monotone" dataKey="fuelPrice" name={t('history.charts.pricePerLitre')} stroke="#9397ab" strokeWidth={2} activeDot={{ r: 6 }} connectNulls hide={hiddenChartSeries.has('fuelPrice')} />
+                                    <Line yAxisId="left" type="monotone" dataKey="mpg" name="MPG (UK)" stroke="var(--color-brand-primary)" strokeWidth={2.5} activeDot={{ r: 6 }} connectNulls hide={hiddenChartSeries.has('mpg')} />
+                                    <Line yAxisId="right" type="monotone" dataKey="fuelPrice" name={t('history.charts.pricePerLitre')} stroke="var(--color-gray-500)" strokeWidth={2} activeDot={{ r: 6 }} connectNulls hide={hiddenChartSeries.has('fuelPrice')} />
                                 </LineChart>
                             </ResponsiveContainer>
                         </div>
@@ -346,20 +346,20 @@ function DashboardPage(): JSX.Element {
                             <h3 className="text-base font-medium text-gray-800 dark:text-gray-200 mb-4">{t('history.charts.costPerLitreOverTime')}</h3>
                             <ResponsiveContainer width="100%" height={300}>
                                 <LineChart data={trendChartData} margin={{ top: 5, right: 20, left: -10, bottom: 5 }}>
-                                    <CartesianGrid strokeDasharray="3 3" stroke={theme === 'dark' ? '#3f424d' : '#e4e7f5'} />
-                                    <XAxis dataKey="date" tick={{ fill: theme === 'dark' ? '#9397ab' : '#75798c', fontSize: 12 }} angle={-30} textAnchor="end" height={50} interval="preserveStartEnd" />
+                                    <CartesianGrid strokeDasharray="3 3" stroke={theme === 'dark' ? 'var(--color-gray-700)' : 'var(--color-gray-200)'} />
+                                    <XAxis dataKey="date" tick={{ fill: theme === 'dark' ? 'var(--color-gray-500)' : 'var(--color-gray-600)', fontSize: 12 }} angle={-30} textAnchor="end" height={50} interval="preserveStartEnd" />
                                     <YAxis
-                                        tick={{ fill: theme === 'dark' ? '#9397ab' : '#75798c', fontSize: 12 }}
+                                        tick={{ fill: theme === 'dark' ? 'var(--color-gray-500)' : 'var(--color-gray-600)', fontSize: 12 }}
                                         domain={['auto', 'auto']}
-                                        label={{ value: 'Cost Per Litre (€)', angle: -90, position: 'insideLeft', offset: 10, style: { fontSize: '12px', fill: theme === 'dark' ? '#9397ab' : '#75798c' } }}
+                                        label={{ value: 'Cost Per Litre (€)', angle: -90, position: 'insideLeft', offset: 10, style: { fontSize: '12px', fill: theme === 'dark' ? 'var(--color-gray-500)' : 'var(--color-gray-600)' } }}
                                         tickFormatter={(value) => value.toFixed(3)}
                                     />
                                     <Tooltip
-                                        contentStyle={{ fontSize: '12px', padding: '5px', backgroundColor: theme === 'dark' ? '#232532' : 'white', color: theme === 'dark' ? 'white' : 'black', border: theme === 'dark' ? '1px solid #3f424d' : '1px solid #e4e7f5' }}
+                                        contentStyle={{ fontSize: '12px', padding: '5px', backgroundColor: theme === 'dark' ? 'var(--color-surface)' : 'white', color: theme === 'dark' ? 'white' : 'black', border: theme === 'dark' ? '1px solid var(--color-gray-700)' : '1px solid var(--color-gray-200)' }}
                                         formatter={(value: number) => `€${value.toFixed(3)}`}
                                     />
                                     <Legend wrapperStyle={{ fontSize: '12px', paddingTop: '10px', color: theme === 'dark' ? 'white' : 'black' }} />
-                                    <Line type="monotone" dataKey="fuelPrice" name="Cost Per Litre" stroke="#9184d9" strokeWidth={2.5} activeDot={{ r: 6 }} connectNulls />
+                                    <Line type="monotone" dataKey="fuelPrice" name="Cost Per Litre" stroke="var(--color-brand-primary)" strokeWidth={2.5} activeDot={{ r: 6 }} connectNulls />
                                 </LineChart>
                             </ResponsiveContainer>
                         </div>
@@ -371,19 +371,19 @@ function DashboardPage(): JSX.Element {
                             <h3 className="text-base font-medium text-gray-800 dark:text-gray-200 mb-4">{t('history.charts.vehicleComparison')}</h3>
                             <ResponsiveContainer width="100%" height={300}>
                                 <BarChart data={vehicleComparisonStats} margin={{ top: 5, right: 20, left: -10, bottom: 5 }}>
-                                    <CartesianGrid strokeDasharray="3 3" stroke={theme === 'dark' ? '#3f424d' : '#e4e7f5'} />
-                                    <XAxis dataKey="name" tick={{ fill: theme === 'dark' ? '#9397ab' : '#75798c', fontSize: 12 }} />
+                                    <CartesianGrid strokeDasharray="3 3" stroke={theme === 'dark' ? 'var(--color-gray-700)' : 'var(--color-gray-200)'} />
+                                    <XAxis dataKey="name" tick={{ fill: theme === 'dark' ? 'var(--color-gray-500)' : 'var(--color-gray-600)', fontSize: 12 }} />
                                     <YAxis
                                         yAxisId="left"
-                                        tick={{ fill: theme === 'dark' ? '#9397ab' : '#75798c', fontSize: 12 }}
+                                        tick={{ fill: theme === 'dark' ? 'var(--color-gray-500)' : 'var(--color-gray-600)', fontSize: 12 }}
                                     />
                                     <YAxis
                                         yAxisId="right"
                                         orientation="right"
-                                        tick={{ fill: theme === 'dark' ? '#9397ab' : '#75798c', fontSize: 12 }}
+                                        tick={{ fill: theme === 'dark' ? 'var(--color-gray-500)' : 'var(--color-gray-600)', fontSize: 12 }}
                                     />
                                     <Tooltip
-                                        contentStyle={{ fontSize: '12px', padding: '5px', backgroundColor: theme === 'dark' ? '#232532' : 'white', color: theme === 'dark' ? 'white' : 'black', border: theme === 'dark' ? '1px solid #3f424d' : '1px solid #e4e7f5' }}
+                                        contentStyle={{ fontSize: '12px', padding: '5px', backgroundColor: theme === 'dark' ? 'var(--color-surface)' : 'white', color: theme === 'dark' ? 'white' : 'black', border: theme === 'dark' ? '1px solid var(--color-gray-700)' : '1px solid var(--color-gray-200)' }}
                                         formatter={(value: number, name: string) => name === t('history.charts.totalSpend')
                                             ? `${homeCurrencySymbol}${value.toFixed(2)}`
                                             : name === t('history.charts.avgCostPerLitre')
@@ -391,9 +391,9 @@ function DashboardPage(): JSX.Element {
                                                 : value.toFixed(2)}
                                     />
                                     <Legend wrapperStyle={{ fontSize: '12px', paddingTop: '10px', color: theme === 'dark' ? 'white' : 'black' }} />
-                                    <Bar yAxisId="left" dataKey="avgL100km" name={t('history.charts.avgL100km')} fill="#9184d9" />
-                                    <Bar yAxisId="left" dataKey="avgCostPerLitre" name={t('history.charts.avgCostPerLitre')} fill="#75798c" />
-                                    <Bar yAxisId="right" dataKey="totalSpend" name={t('history.charts.totalSpend')} fill="#5d5294" />
+                                    <Bar yAxisId="left" dataKey="avgL100km" name={t('history.charts.avgL100km')} fill="var(--color-brand-primary)" />
+                                    <Bar yAxisId="left" dataKey="avgCostPerLitre" name={t('history.charts.avgCostPerLitre')} fill="var(--color-gray-600)" />
+                                    <Bar yAxisId="right" dataKey="totalSpend" name={t('history.charts.totalSpend')} fill="var(--color-amber-700)" />
                                 </BarChart>
                             </ResponsiveContainer>
                         </div>

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -420,10 +420,10 @@ function HistoryPage(): JSX.Element {
     // --- Render Logic ---
     return (
         <div className={`space-y-8 ${theme === 'dark' ? 'dark' : ''}`}> {/* Vertical spacing between sections */}
-            <h2 className="text-2xl sm:text-3xl font-semibold text-gray-800 dark:text-white">{t('history.pageTitle')}</h2>
+            <h2 className="text-2xl sm:text-3xl font-medium tracking-tight text-gray-900 dark:text-gray-100">{t('history.pageTitle')}</h2>
 
             {/* --- Filter Controls Section --- */}
-            <div className="p-4 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm">
+            <div className="nocturne-card p-4">
                 <h3 className="text-md font-medium text-gray-700 dark:text-gray-300 mb-3">{t('history.filters.heading')}</h3>
                 {/* Grid layout for filter controls */}
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4 items-end ">
@@ -434,7 +434,7 @@ function HistoryPage(): JSX.Element {
                             id="filterVehicle" 
                             value={filterVehicleId} 
                             onChange={(e) => setFilterVehicleId(e.target.value)} 
-                            className="w-full px-3 py-1.5 border border-gray-300 dark:border-gray-700 rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm bg-white dark:bg-gray-700 dark:text-gray-300"
+                            className="nocturne-input cursor-pointer"
                         >
                             <option value="">{t('history.filters.allVehicles')}</option>
                             {vehicles.map(v => (
@@ -447,17 +447,17 @@ function HistoryPage(): JSX.Element {
                     {/* Start Date Input */}
                     <div>
                         <label htmlFor="filterStartDate" className="block text-sm font-medium text-gray-700 mb-1 dark:text-gray-300">{t('history.filters.startDate')}</label>
-                        <input type="date" id="filterStartDate" value={filterStartDate} onChange={(e) => setFilterStartDate(e.target.value)} className="w-full px-3 py-1.5 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:[color-scheme:dark]" />
+                        <input type="date" id="filterStartDate" value={filterStartDate} onChange={(e) => setFilterStartDate(e.target.value)} className="nocturne-input dark:[color-scheme:dark]" />
                     </div>
                     {/* End Date Input */}
                     <div>
                         <label htmlFor="filterEndDate" className="block text-sm font-medium text-gray-700 mb-1 dark:text-gray-300">{t('history.filters.endDate')}</label>
-                        <input type="date" id="filterEndDate" value={filterEndDate} onChange={(e) => setFilterEndDate(e.target.value)} className="w-full px-3 py-1.5 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:[color-scheme:dark]" />
+                        <input type="date" id="filterEndDate" value={filterEndDate} onChange={(e) => setFilterEndDate(e.target.value)} className="nocturne-input dark:[color-scheme:dark]" />
                     </div>
                     {/* Brand Select Dropdown */}
                     <div>
                         <label htmlFor="filterBrand" className="block text-sm font-medium text-gray-700 mb-1">{t('history.filters.brand')}</label>
-                        <select id="filterBrand" value={filterBrand} onChange={(e) => setFilterBrand(e.target.value)} className="w-full px-3 py-1.5 border border-gray-300 dark:border-gray-700 rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm bg-white dark:bg-gray-700 dark:text-gray-300 appearance-none"> {/* Added appearance-none */}
+                        <select id="filterBrand" value={filterBrand} onChange={(e) => setFilterBrand(e.target.value)} className="nocturne-input cursor-pointer appearance-none"> {/* Added appearance-none */}
                             <option value="">{t('history.filters.allBrands')}</option>
                             {/* Populate options from uniqueBrands state */}
                             {uniqueBrands.map(brand => <option key={brand} value={brand}>{brand}</option>)}
@@ -467,7 +467,7 @@ function HistoryPage(): JSX.Element {
                     <div className="flex justify-end">
                         <button
                             onClick={() => setViewMode(prev => prev === 'table' ? 'cards' : 'table')}
-                            className="px-3 py-1.5 text-sm font-medium rounded-md shadow-sm transition duration-150 ease-in-out bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-indigo-500"
+                            className="brand-button-secondary px-3 py-1.5 text-sm"
                             title={viewMode === 'table' ? t('history.viewToggle.switchToCards') : t('history.viewToggle.switchToTable')}
                         >
                             {viewMode === 'table' ? t('history.viewToggle.viewCards') : t('history.viewToggle.viewTable')}
@@ -481,26 +481,26 @@ function HistoryPage(): JSX.Element {
                 <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
                     {/* Total Spent */}
                     {totalSpentDisplayEnabled && (
-                        <div className="bg-white dark:bg-gray-800 shadow-lg rounded-xl p-4 sm:p-6 border border-gray-200 dark:border-gray-700">
+                        <div className="nocturne-card p-4 sm:p-6">
                             <h3 className="text-md font-medium text-gray-700 dark:text-gray-300 mb-1 text-center">{t('history.metrics.totalSpent')}</h3>
-                            <p className="text-2xl sm:text-3xl font-bold text-brand-primary font-mono tracking-tighter text-center">
+                            <p className="text-2xl sm:text-3xl font-semibold text-gray-900 dark:text-gray-100 font-mono tracking-tighter text-center">
                                 {homeCurrencySymbol}{summaryMetrics.totalCost.toFixed(2)}
                             </p>
                         </div>
                     )}
 
                     {/* Average MPG (UK) */}
-                    <div className="bg-white dark:bg-gray-800 shadow-lg rounded-xl p-4 sm:p-6 border border-gray-200 dark:border-gray-700">
+                    <div className="nocturne-card p-4 sm:p-6">
                         <h3 className="text-md font-medium text-gray-700 dark:text-gray-300 mb-1 text-center">{t('history.metrics.avgMpg')}</h3>
-                        <p className="text-2xl sm:text-3xl font-bold text-brand-primary font-mono tracking-tighter text-center">
+                        <p className="text-2xl sm:text-3xl font-semibold text-gray-900 dark:text-gray-100 font-mono tracking-tighter text-center">
                             {summaryMetrics.averageMPG}
                         </p>
                     </div>
 
                     {/* Average Cost */}
-                    <div className="bg-white dark:bg-gray-800 shadow-lg rounded-xl p-4 sm:p-6 border border-gray-200 dark:border-gray-700">
+                    <div className="nocturne-card p-4 sm:p-6">
                         <h3 className="text-md font-medium text-gray-700 dark:text-gray-300 mb-1 text-center">{t('history.metrics.avgCostPerLitre')}</h3>
-                        <p className="text-2xl sm:text-3xl font-bold text-brand-primary font-mono tracking-tighter text-center">
+                        <p className="text-2xl sm:text-3xl font-semibold text-gray-900 dark:text-gray-100 font-mono tracking-tighter text-center">
                             {homeCurrencySymbol}{summaryMetrics.averageCost.toFixed(3)}
                         </p>
                     </div>
@@ -513,7 +513,7 @@ function HistoryPage(): JSX.Element {
             )}
 
             {/* --- Table / Cards Section --- */}
-            <div className="bg-white dark:bg-gray-800 shadow-lg rounded-xl p-4 sm:p-6 border border-gray-200 dark:border-gray-700">
+            <div className="nocturne-card p-4 sm:p-6">
                 {/* Section Header with Title (showing filtered count) and Copy Button */}
                 <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-4 sm:mb-6">
                     <h3 className="text-lg font-medium text-gray-700 dark:text-gray-300 mb-2 sm:mb-0">
@@ -540,15 +540,15 @@ function HistoryPage(): JSX.Element {
                 {!isLoading && !error && filteredLogs.length > 0 && (
                     viewMode === 'table' ? (
                         <div className="w-full overflow-x-auto rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
-                            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700/60">
 
-                                <thead className="bg-gray-50 dark:bg-gray-700"><tr><th scope="col" className="px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{t('history.table.date')}</th><th scope="col" className="px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{t('history.table.vehicle')}</th><th scope="col" className="px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{t('history.table.brand')}</th><th scope="col" className="px-3 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{t('history.table.cost', { currency: homeCurrency })}</th>{odometerInputEnabled && <th scope="col" className="px-3 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{t('history.table.odometer')}</th>}<th scope="col" className="px-3 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{t('history.table.distance')}</th><th scope="col" className="px-3 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{t('history.table.fuel')}</th><th scope="col" className="px-3 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">km/L</th><th scope="col" className="px-3 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">L/100km</th><th scope="col" className="px-3 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">MPG (UK)</th><th scope="col" className="px-3 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{t('history.table.costPerMile')}</th>{receiptDigitizationEnabled && <th scope="col" className="px-3 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{t('history.table.receipt')}</th>}<th scope="col" className="px-3 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{t('history.table.actions')}</th></tr></thead>
-                                <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                                <thead className="bg-gray-50 dark:bg-gray-900/40"><tr><th scope="col" className="px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{t('history.table.date')}</th><th scope="col" className="px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{t('history.table.vehicle')}</th><th scope="col" className="px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{t('history.table.brand')}</th><th scope="col" className="px-3 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{t('history.table.cost', { currency: homeCurrency })}</th>{odometerInputEnabled && <th scope="col" className="px-3 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{t('history.table.odometer')}</th>}<th scope="col" className="px-3 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{t('history.table.distance')}</th><th scope="col" className="px-3 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{t('history.table.fuel')}</th><th scope="col" className="px-3 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">km/L</th><th scope="col" className="px-3 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">L/100km</th><th scope="col" className="px-3 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">MPG (UK)</th><th scope="col" className="px-3 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{t('history.table.costPerMile')}</th>{receiptDigitizationEnabled && <th scope="col" className="px-3 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{t('history.table.receipt')}</th>}<th scope="col" className="px-3 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{t('history.table.actions')}</th></tr></thead>
+                                <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700/60">
                                     {/* Map over filteredLogs for table rows */}
                                     {filteredLogs.map((log) => (
-                                        <tr key={log.id} className="hover:bg-gray-50 dark:hover:bg-gray-700 transition duration-150 ease-in-out">
+                                        <tr key={log.id} className="hover:bg-gray-50 dark:hover:bg-gray-100/[0.04] transition duration-150 ease-in-out">
                                             <td className="px-3 py-3 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">{log.timestamp?.toDate() ? formatDate(log.timestamp.toDate()) : 'N/A'}</td>
-                                            <td className="px-3 py-3 whitespace-nowrap text-sm font-medium text-brand-primary font-mono tracking-tighter">{vehicleMap[log.vehicleId || ''] || '-'}</td>
+                                            <td className="px-3 py-3 whitespace-nowrap text-sm font-medium text-gray-700 dark:text-gray-200 font-mono tracking-tighter">{vehicleMap[log.vehicleId || ''] || '-'}</td>
                                             <td className="px-3 py-3 whitespace-nowrap text-sm text-gray-900 dark:text-gray-200">
                                                 {stations.find(s => s.id === log.stationId)?.name || log.brand}
                                             </td>

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -185,7 +185,7 @@ function ProfilePage(): JSX.Element {
   const archivedVehicles = vehicles.filter(v => v.isArchived);
 
   const renderVehicleCard = (v: Vehicle) => (
-    <div key={v.id} className={`group relative bg-white dark:bg-gray-800 rounded-2xl border transition-all duration-300 overflow-hidden shadow-sm hover:shadow-md ${v.isDefault ? 'border-brand-primary ring-1 ring-brand-primary/20' : 'border-gray-100 dark:border-gray-700'}`}>
+    <div key={v.id} className={`group relative bg-white dark:bg-gray-800 rounded-xl border transition-all duration-300 overflow-hidden ${v.isDefault ? 'border-brand-primary' : 'border-gray-200 dark:border-gray-700/60'}`}>
       <div className="p-5 flex items-start space-x-4">
         {/* Car Icon Accent */}
         <div className={`p-3 rounded-xl transition-colors ${v.isDefault ? 'bg-brand-primary/10 text-brand-primary' : 'bg-gray-50 dark:bg-gray-900 text-gray-400'}`}>
@@ -194,9 +194,9 @@ function ProfilePage(): JSX.Element {
 
         <div className="flex-grow min-w-0">
           <div className="flex justify-between items-start">
-            <h4 className="text-lg font-black tracking-tight truncate text-gray-900 dark:text-white">{v.name}</h4>
+            <h4 className="text-lg font-semibold tracking-tight truncate text-gray-900 dark:text-white">{v.name}</h4>
             {v.isDefault && (
-              <span className="shrink-0 flex items-center text-[10px] font-black uppercase tracking-widest text-brand-primary bg-brand-primary/10 px-2 py-0.5 rounded-full">
+              <span className="nocturne-tag shrink-0">
                 {t('profile.vehicleCard.primary')}
               </span>
             )}
@@ -221,7 +221,7 @@ function ProfilePage(): JSX.Element {
         {!v.isArchived && !v.isDefault && (
           <button
             onClick={() => handleSetDefault(v)}
-            className="flex-1 py-3 text-[10px] font-black uppercase tracking-widest text-gray-500 hover:text-brand-primary hover:bg-brand-primary/5 transition-all flex items-center justify-center space-x-1.5"
+            className="flex-1 py-3 text-[10px] font-bold uppercase tracking-wider text-gray-500 hover:text-brand-primary hover:bg-brand-primary/5 transition-all flex items-center justify-center space-x-1.5"
           >
             <CheckCircle2 size={12} />
             <span>{t('profile.vehicleCard.makeDefault')}</span>
@@ -229,7 +229,7 @@ function ProfilePage(): JSX.Element {
         )}
         <button
           onClick={() => handleArchiveVehicle(v)}
-          className="flex-1 py-3 text-[10px] font-black uppercase tracking-widest text-gray-500 hover:text-amber-600 hover:bg-amber-50 dark:hover:bg-amber-900/10 transition-all flex items-center justify-center space-x-1.5"
+          className="flex-1 py-3 text-[10px] font-bold uppercase tracking-wider text-gray-500 hover:text-amber-600 hover:bg-amber-50 dark:hover:bg-amber-900/10 transition-all flex items-center justify-center space-x-1.5"
           title={v.isArchived ? t('profile.vehicleCard.restore') : t('profile.vehicleCard.archive')}
         >
           <Archive size={12} />
@@ -237,7 +237,7 @@ function ProfilePage(): JSX.Element {
         </button>
         <button
           onClick={() => handleDeleteVehicle(v.id)}
-          className="flex-1 py-3 text-[10px] font-black uppercase tracking-widest text-gray-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/10 transition-all flex items-center justify-center space-x-1.5"
+          className="flex-1 py-3 text-[10px] font-bold uppercase tracking-wider text-gray-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/10 transition-all flex items-center justify-center space-x-1.5"
         >
           <Trash2 size={12} />
           <span>{t('profile.vehicleCard.delete')}</span>
@@ -249,19 +249,19 @@ function ProfilePage(): JSX.Element {
   return (
     <div className="container mx-auto max-w-4xl px-4 space-y-10 pb-12 text-gray-900 dark:text-gray-100">
       {/* App Preferences Section */}
-      <div className="bg-white dark:bg-gray-800 shadow-xl rounded-3xl p-6 sm:p-10 border border-gray-100 dark:border-gray-700/50">
+      <div className="nocturne-card rounded-2xl p-6 sm:p-8">
         <div className="flex items-center space-x-3 mb-8">
           <div className="bg-brand-primary/10 p-2 rounded-lg text-brand-primary">
             <Settings size={20} />
           </div>
-          <h3 className="text-xl font-black tracking-tight">{t('profile.appPreferences')}</h3>
+          <h3 className="text-xl font-medium tracking-tight">{t('profile.appPreferences')}</h3>
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
           <div className="space-y-4">
             <div className="flex items-center space-x-2 text-brand-primary">
               <Coins size={18} />
-              <h4 className="text-sm font-black uppercase tracking-widest">{t('profile.homeCurrency')}</h4>
+              <h4 className="text-xs font-medium uppercase tracking-wider">{t('profile.homeCurrency')}</h4>
             </div>
             <p className="text-xs text-gray-500 font-medium leading-relaxed">
               {t('profile.homeCurrencyDesc')}
@@ -269,7 +269,7 @@ function ProfilePage(): JSX.Element {
             <select
               value={profile?.homeCurrency || 'EUR'}
               onChange={(e) => updateProfile({ homeCurrency: e.target.value })}
-              className="w-full px-4 py-3 bg-gray-50 dark:bg-gray-900 border-none rounded-xl focus:ring-2 focus:ring-brand-primary/20 transition-all font-bold text-gray-900 dark:text-white"
+              className="nocturne-input"
             >
               {COMMON_CURRENCIES.map((curr) => (
                 <option key={curr.code} value={curr.code}>
@@ -282,7 +282,7 @@ function ProfilePage(): JSX.Element {
           <div className="space-y-4">
             <div className="flex items-center space-x-2 text-brand-primary">
               <Wallet size={18} />
-              <h4 className="text-sm font-black uppercase tracking-widest">{t('profile.monthlyBudget')}</h4>
+              <h4 className="text-xs font-medium uppercase tracking-wider">{t('profile.monthlyBudget')}</h4>
             </div>
             <p className="text-xs text-gray-500 font-medium leading-relaxed">
               {t('profile.monthlyBudgetDesc')}
@@ -296,14 +296,14 @@ function ProfilePage(): JSX.Element {
               onChange={(e) => setBudgetInput(e.target.value)}
               onBlur={handleBudgetBlur}
               placeholder={t('profile.monthlyBudgetPlaceholder')}
-              className="w-full px-4 py-3 bg-gray-50 dark:bg-gray-900 border-none rounded-xl focus:ring-2 focus:ring-brand-primary/20 transition-all font-bold text-gray-900 dark:text-white"
+              className="nocturne-input"
             />
           </div>
 
           <div className="space-y-4">
             <div className="flex items-center space-x-2 text-brand-primary">
               <Settings size={18} />
-              <h4 className="text-sm font-black uppercase tracking-widest">{t('language.label')}</h4>
+              <h4 className="text-xs font-medium uppercase tracking-wider">{t('language.label')}</h4>
             </div>
             <p className="text-xs text-gray-500 font-medium leading-relaxed">
               {t('language.en')} / {t('language.ga')}
@@ -317,7 +317,7 @@ function ProfilePage(): JSX.Element {
         <div className="mt-8 opacity-40 grayscale pointer-events-none">
           <div className="flex items-center space-x-2 text-gray-400">
             <Settings size={18} />
-            <h4 className="text-sm font-black uppercase tracking-widest">{t('profile.measurementUnits')}</h4>
+            <h4 className="text-xs font-medium uppercase tracking-wider">{t('profile.measurementUnits')}</h4>
           </div>
           <p className="text-xs text-gray-400 font-medium mt-4 italic">{t('profile.measurementUnitsSoon')}</p>
         </div>
@@ -326,13 +326,13 @@ function ProfilePage(): JSX.Element {
       <div>
         <div className="flex justify-between items-end mb-6">
           <div>
-            <h2 className="text-3xl font-black tracking-tighter text-gray-900 dark:text-white">{t('profile.vehicleFleet')}</h2>
+            <h2 className="text-3xl font-medium tracking-tight text-gray-900 dark:text-white">{t('profile.vehicleFleet')}</h2>
             <p className="text-sm font-medium text-gray-500">{t('profile.vehicleFleetSubtext')}</p>
           </div>
           {archivedVehicles.length > 0 && (
             <button
               onClick={() => setShowArchived(!showArchived)}
-              className="text-xs font-black uppercase tracking-widest text-brand-primary hover:underline"
+              className="text-xs font-medium uppercase tracking-wider text-amber-700 dark:text-amber-300 hover:underline"
             >
               {showArchived ? t('profile.hideArchived') : t('profile.showArchived', { count: archivedVehicles.length })}
             </button>
@@ -363,7 +363,7 @@ function ProfilePage(): JSX.Element {
         {/* Archived Vehicle Grid */}
         {showArchived && archivedVehicles.length > 0 && (
           <div className="mt-10 animate-in fade-in slide-in-from-top-4">
-            <h3 className="text-xs font-black uppercase tracking-[0.2em] text-gray-400 mb-4 flex items-center">
+            <h3 className="text-xs font-medium uppercase tracking-[0.2em] text-gray-500 dark:text-gray-400 mb-4 flex items-center">
               <Archive size={14} className="mr-2" /> {t('profile.archivedFleet')}
             </h3>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6 opacity-60 grayscale hover:grayscale-0 hover:opacity-100 transition-all">
@@ -374,35 +374,35 @@ function ProfilePage(): JSX.Element {
       </div>
 
       {/* Add Vehicle Section */}
-      <div className="bg-white dark:bg-gray-800 shadow-xl rounded-3xl p-6 sm:p-10 border border-gray-100 dark:border-gray-700/50">
+      <div className="nocturne-card rounded-2xl p-6 sm:p-8">
         <div className="flex items-center space-x-3 mb-8">
           <div className="bg-brand-primary/10 p-2 rounded-lg text-brand-primary">
             <PlusCircle size={20} />
           </div>
-          <h3 className="text-xl font-black tracking-tight">{t('profile.addNewVehicle')}</h3>
+          <h3 className="text-xl font-medium tracking-tight">{t('profile.addNewVehicle')}</h3>
         </div>
 
         <form onSubmit={handleAddVehicle} className="space-y-6">
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
             <div className="sm:col-span-2">
-              <label className="block text-xs font-black uppercase tracking-widest text-gray-400 mb-2">{t('profile.vehicleForm.nickname')}</label>
-              <input type="text" name="name" value={formData.name} onChange={handleInputChange} required placeholder={t('profile.vehicleForm.nicknamePlaceholder')} className="w-full px-4 py-3 bg-gray-50 dark:bg-gray-900 border-none rounded-xl focus:ring-2 focus:ring-brand-primary/20 transition-all font-bold text-gray-900 dark:text-white" />
+              <label className="block nocturne-label uppercase tracking-wider">{t('profile.vehicleForm.nickname')}</label>
+              <input type="text" name="name" value={formData.name} onChange={handleInputChange} required placeholder={t('profile.vehicleForm.nicknamePlaceholder')} className="nocturne-input" />
             </div>
             <div>
-              <label className="block text-xs font-black uppercase tracking-widest text-gray-400 mb-2">{t('profile.vehicleForm.make')}</label>
-              <input type="text" name="make" value={formData.make} onChange={handleInputChange} required placeholder={t('profile.vehicleForm.makePlaceholder')} className="w-full px-4 py-3 bg-gray-50 dark:bg-gray-900 border-none rounded-xl focus:ring-2 focus:ring-brand-primary/20 transition-all font-bold text-gray-900 dark:text-white" />
+              <label className="block nocturne-label uppercase tracking-wider">{t('profile.vehicleForm.make')}</label>
+              <input type="text" name="make" value={formData.make} onChange={handleInputChange} required placeholder={t('profile.vehicleForm.makePlaceholder')} className="nocturne-input" />
             </div>
             <div>
-              <label className="block text-xs font-black uppercase tracking-widest text-gray-400 mb-2">{t('profile.vehicleForm.model')}</label>
-              <input type="text" name="model" value={formData.model} onChange={handleInputChange} required placeholder={t('profile.vehicleForm.modelPlaceholder')} className="w-full px-4 py-3 bg-gray-50 dark:bg-gray-900 border-none rounded-xl focus:ring-2 focus:ring-brand-primary/20 transition-all font-bold text-gray-900 dark:text-white" />
+              <label className="block nocturne-label uppercase tracking-wider">{t('profile.vehicleForm.model')}</label>
+              <input type="text" name="model" value={formData.model} onChange={handleInputChange} required placeholder={t('profile.vehicleForm.modelPlaceholder')} className="nocturne-input" />
             </div>
             <div>
-              <label className="block text-xs font-black uppercase tracking-widest text-gray-400 mb-2">{t('profile.vehicleForm.year')}</label>
-              <input type="number" name="year" value={formData.year} onChange={handleInputChange} required className="w-full px-4 py-3 bg-gray-50 dark:bg-gray-900 border-none rounded-xl focus:ring-2 focus:ring-brand-primary/20 transition-all font-bold text-gray-900 dark:text-white" />
+              <label className="block nocturne-label uppercase tracking-wider">{t('profile.vehicleForm.year')}</label>
+              <input type="number" name="year" value={formData.year} onChange={handleInputChange} required className="nocturne-input" />
             </div>
             <div>
-              <label className="block text-xs font-black uppercase tracking-widest text-gray-400 mb-2">{t('profile.vehicleForm.fuelType')}</label>
-              <select name="fuelType" value={formData.fuelType} onChange={handleInputChange} className="w-full px-4 py-3 bg-gray-50 dark:bg-gray-900 border-none rounded-xl focus:ring-2 focus:ring-brand-primary/20 transition-all font-bold text-gray-900 dark:text-white">
+              <label className="block nocturne-label uppercase tracking-wider">{t('profile.vehicleForm.fuelType')}</label>
+              <select name="fuelType" value={formData.fuelType} onChange={handleInputChange} className="nocturne-input">
                 <option value="Petrol">{t('profile.vehicleForm.fuelTypes.petrol')}</option>
                 <option value="Diesel">{t('profile.vehicleForm.fuelTypes.diesel')}</option>
                 <option value="Hybrid">{t('profile.vehicleForm.fuelTypes.hybrid')}</option>
@@ -438,12 +438,12 @@ function ProfilePage(): JSX.Element {
       </div>
 
       {/* Notifications Section */}
-      <div className="bg-white dark:bg-gray-900 rounded-3xl p-6 sm:p-8 shadow-sm border border-gray-100 dark:border-gray-800">
+      <div className="nocturne-card rounded-2xl p-6 sm:p-8">
         <div className="flex items-center gap-3 mb-6">
           <div className="w-10 h-10 rounded-2xl bg-yellow-50 dark:bg-yellow-900/20 flex items-center justify-center">
             <Bell className="w-5 h-5 text-yellow-500" />
           </div>
-          <h3 className="text-xl font-black tracking-tight">{t('profile.notifications.heading', { defaultValue: 'Notifications' })}</h3>
+          <h3 className="text-xl font-medium tracking-tight">{t('profile.notifications.heading', { defaultValue: 'Notifications' })}</h3>
         </div>
         <div className="flex items-center justify-between">
           <div>
@@ -473,18 +473,18 @@ function ProfilePage(): JSX.Element {
       </div>
 
       {/* Data Import Section */}
-      <div className="bg-white dark:bg-gray-900 rounded-3xl p-6 sm:p-8 shadow-sm border border-gray-100 dark:border-gray-800">
+      <div className="nocturne-card rounded-2xl p-6 sm:p-8">
         <div className="flex items-center gap-3 mb-6">
           <div className="w-10 h-10 rounded-2xl bg-indigo-50 dark:bg-indigo-900/20 flex items-center justify-center">
             <UploadCloud className="w-5 h-5 text-indigo-500" />
           </div>
-          <h3 className="text-xl font-black tracking-tight">{t('profile.dataImport.heading')}</h3>
+          <h3 className="text-xl font-medium tracking-tight">{t('profile.dataImport.heading')}</h3>
         </div>
         <div className="flex items-center justify-between">
           <p className="text-sm text-gray-500 dark:text-gray-400 max-w-md">{t('profile.dataImport.description')}</p>
           <Link
             to="/import"
-            className="flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-bold transition-colors bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-400 hover:bg-indigo-200 dark:hover:bg-indigo-900/50 shrink-0"
+            className="brand-button-primary px-4 py-2 text-sm shrink-0"
           >
             <UploadCloud className="w-4 h-4" />
             {t('profile.dataImport.cta')}
@@ -496,17 +496,17 @@ function ProfilePage(): JSX.Element {
       <ApiTokenManager />
 
       {/* Maintenance Section */}
-      <div className="bg-white dark:bg-gray-800 shadow-xl rounded-3xl p-6 sm:p-8 border border-gray-100 dark:border-gray-700/50">
+      <div className="nocturne-card rounded-2xl p-6 sm:p-8">
         <div className="flex items-center space-x-3 mb-6">
           <div className="bg-amber-500/10 p-2 rounded-lg text-amber-500">
             <RefreshCw size={20} />
           </div>
-          <h3 className="text-xl font-black tracking-tight">{t('profile.maintenance.heading')}</h3>
+          <h3 className="text-xl font-medium tracking-tight">{t('profile.maintenance.heading')}</h3>
         </div>
 
         <div className="flex flex-col md:flex-row md:items-center justify-between gap-6">
           <div className="space-y-2">
-            <h4 className="text-sm font-black uppercase tracking-widest text-gray-900 dark:text-white">{t('profile.maintenance.migrateStations')}</h4>
+            <h4 className="text-xs font-medium uppercase tracking-wider text-gray-900 dark:text-white">{t('profile.maintenance.migrateStations')}</h4>
             <p className="text-xs text-gray-500 font-medium leading-relaxed max-w-md">
               {t('profile.maintenance.migrateStationsDesc')}
             </p>
@@ -514,7 +514,7 @@ function ProfilePage(): JSX.Element {
           {!isMigrating ? (
             <button
               onClick={handleMigrateStations}
-              className="flex items-center justify-center space-x-2 px-6 py-3 rounded-xl text-sm font-bold transition-all shadow-md bg-amber-500 hover:bg-amber-600 text-white shadow-amber-500/20"
+              className="brand-button-primary px-6 py-3 text-sm"
             >
               <RefreshCw size={16} />
               <span>{t('profile.maintenance.migrateStationsButton')}</span>
@@ -527,7 +527,7 @@ function ProfilePage(): JSX.Element {
               </div>
               <div className="w-full h-1.5 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden">
                 <div 
-                  className="h-full bg-amber-500 transition-all duration-300 ease-out" 
+                  className="h-full bg-brand-primary transition-all duration-300 ease-out" 
                   style={{ width: `${migrationProgress ? (migrationProgress.current / migrationProgress.total) * 100 : 0}%` }}
                 ></div>
               </div>

--- a/src/pages/QuickLogPage.tsx
+++ b/src/pages/QuickLogPage.tsx
@@ -662,7 +662,7 @@ function QuickLogPage(): JSX.Element {
                               defaultValue: '{{lat}}, {{lng}}',
                             })}
                       </span>
-                      <span className={`text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-md ${locationMode === 'manual' ? 'bg-amber-100 text-amber-700 dark:bg-amber-800 dark:text-amber-100' : 'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-100'}`}>
+                      <span className={`font-bold uppercase ${locationMode === 'manual' ? 'nocturne-tag' : 'nocturne-tag-neutral'}`}>
                         {locationMode === 'manual'
                           ? t('quickLog.location.manualBadge', { defaultValue: 'Pinned' })
                           : t('quickLog.location.gpsBadge', { defaultValue: 'GPS' })}

--- a/src/pages/QuickLogPage.tsx
+++ b/src/pages/QuickLogPage.tsx
@@ -556,45 +556,30 @@ function QuickLogPage(): JSX.Element {
   const homeCurrencySymbol = COMMON_CURRENCIES.find(c => c.code === homeCurrency)?.symbol || homeCurrency;
 
   return (
-    <div className="min-h-screen pb-24 pt-6 px-4 bg-gray-50 dark:bg-brand-dark-surface relative overflow-hidden transition-colors duration-500">
-      {/* Decorative ambient background glows */}
-      <div className="absolute top-[-10%] left-[-10%] w-96 h-96 bg-brand-primary/20 dark:bg-brand-primary-glow/10 rounded-full mix-blend-multiply dark:mix-blend-screen filter blur-[100px] animate-pulse transform-gpu pointer-events-none" style={{ animationDuration: '8s' }}></div>
-      <div className="absolute bottom-[20%] right-[-10%] w-80 h-80 bg-amber-400/20 dark:bg-amber-500/10 rounded-full mix-blend-multiply dark:mix-blend-screen filter blur-[80px] animate-pulse transform-gpu pointer-events-none" style={{ animationDuration: '10s' }}></div>
-      
+    <div className="min-h-screen pb-24 pt-6 px-4 relative transition-colors duration-500">
       <div className="container mx-auto max-w-lg relative z-10">
-        <div className="bg-white/80 dark:bg-white/[0.02] backdrop-blur-2xl shadow-[0_8px_30px_rgb(0,0,0,0.08)] dark:shadow-[0_8px_30px_rgb(0,0,0,0.2)] rounded-3xl p-6 sm:p-8 border border-white/60 dark:border-white/10 ring-1 ring-black/5 dark:ring-white/10 transition-all duration-500 hover:shadow-[0_20px_40px_rgb(0,0,0,0.12)]">
-          
-          <div className="flex flex-col items-center justify-center gap-2 mb-8">
-            <div className="w-12 h-12 bg-gradient-to-br from-brand-primary to-amber-400 rounded-2xl flex items-center justify-center shadow-lg shadow-brand-primary/30 rotate-3 transform transition-transform hover:rotate-6 hover:scale-110 duration-300">
-              <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-white transform -rotate-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M13 10V3L4 14h7v7l9-11h-7z" />
-              </svg>
-            </div>
-            <h2 className="text-3xl font-display font-bold text-transparent bg-clip-text bg-gradient-to-r from-gray-900 to-gray-600 dark:from-white dark:to-gray-300 tracking-tight text-center">
-              {t('quickLog.title')}
-            </h2>
-          </div>
+        <div>
+          <h2 className="text-2xl font-display font-medium tracking-tight text-gray-900 dark:text-gray-100 mb-6">
+            {t('quickLog.title')}
+          </h2>
 
           {isLoadingVehicles ? (
             <div className="text-center py-12 flex flex-col items-center">
-              <div className="relative w-16 h-16">
-                <div className="absolute inset-0 rounded-full border-4 border-brand-primary/20 dark:border-brand-primary-glow/20"></div>
-                <div className="absolute inset-0 rounded-full border-4 border-brand-primary dark:border-brand-primary-glow border-t-transparent animate-spin"></div>
-              </div>
+              <div className="w-12 h-12 rounded-full border-2 border-gray-200 dark:border-gray-700 border-t-brand-primary animate-spin"></div>
               <p className="mt-4 text-sm font-medium text-gray-500 dark:text-gray-400 animate-pulse">{t('quickLog.loadingVehicles')}</p>
             </div>
           ) : vehicles.length === 0 ? (
-            <div className="bg-amber-50/80 dark:bg-amber-900/10 backdrop-blur-sm border border-amber-200/50 dark:border-amber-500/20 rounded-2xl p-8 text-center space-y-5 mb-6 transition-transform hover:scale-[1.02] duration-300">
-              <div className="bg-white dark:bg-gray-800 shadow-md w-16 h-16 rounded-full flex items-center justify-center mx-auto text-amber-500 dark:text-amber-400 ring-4 ring-amber-50 dark:ring-amber-900/30">
-                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-8 h-8 animate-bounce" style={{ animationDuration: '2s' }}>
+            <div className="border-[1.5px] border-dashed border-gray-300 dark:border-gray-700 bg-brand-primary/[0.04] rounded-xl p-8 text-center space-y-5 mb-6">
+              <div className="bg-white dark:bg-gray-800 w-14 h-14 rounded-lg flex items-center justify-center mx-auto text-amber-600 dark:text-amber-300 border border-gray-200 dark:border-gray-700">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-7 h-7">
                   <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 18.75a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m3 0h6m-9 0H3.375a1.125 1.125 0 0 1-1.125-1.125V14.25m17.25 4.5a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m3 0h1.125c.621 0 1.129-.504 1.091-1.124l-.303-4.919a1.125 1.125 0 0 0-1.121-1.056H11.25m9 4.5H16.5m-9-4.5V3.375c0-.621.504-1.125 1.125-1.125h9.75c.621 0 1.125.504 1.125 1.125V9.75M8.25 14.25h11.25M8.25 14.25 5.25 9.75" />
                 </svg>
               </div>
               <div className="space-y-1">
-                <p className="text-amber-900 dark:text-amber-300 font-bold text-lg tracking-tight">{t('quickLog.noVehicles.heading')}</p>
-                <p className="text-amber-700/80 dark:text-amber-400/80 text-sm">{t('quickLog.noVehicles.subtext')}</p>
+                <p className="text-gray-900 dark:text-gray-100 font-medium text-lg tracking-tight">{t('quickLog.noVehicles.heading')}</p>
+                <p className="text-gray-600 dark:text-gray-400 text-sm">{t('quickLog.noVehicles.subtext')}</p>
               </div>
-              <Link to="/profile" className="block w-full bg-gradient-to-r from-amber-500 to-amber-600 hover:from-amber-600 hover:to-amber-700 text-white font-bold py-3.5 px-4 rounded-xl transition-all duration-300 shadow-lg shadow-amber-500/30 hover:shadow-amber-500/50 hover:-translate-y-0.5 active:translate-y-0">
+              <Link to="/profile" className="brand-button-primary w-full">
                 {t('quickLog.noVehicles.cta')}
               </Link>
             </div>
@@ -602,54 +587,57 @@ function QuickLogPage(): JSX.Element {
             <form onSubmit={handleSubmit} noValidate className="space-y-6">
 
               {/* Section 1: Vehicle & Station */}
-              <div className="group bg-white/40 dark:bg-white/[0.02] p-5 rounded-2xl border border-gray-100 dark:border-white/5 shadow-sm hover:shadow-md transition-all duration-300 backdrop-blur-md">
-                <div className="flex items-center gap-2 mb-4">
-                  <div className="w-1.5 h-4 bg-brand-primary rounded-full"></div>
-                  <h3 className="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-widest">{t('quickLog.sections.vehicleStation')}</h3>
-                </div>
-
-                <div className="space-y-4">
-                  <div>
-                    <label htmlFor="vehicle" className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1.5">{t('quickLog.fields.vehicle')}</label>
+              <div className="space-y-4">
+                <div>
+                  <label htmlFor={vehicles.length > 3 ? 'vehicle' : undefined} className="nocturne-label">{t('quickLog.fields.vehicle')}</label>
+                  {vehicles.length <= 3 ? (
+                    <div className="nocturne-seg" role="radiogroup" aria-label={t('quickLog.fields.vehicle')}>
+                      {vehicles.map((v) => (
+                        <label key={v.id} className="nocturne-seg-opt relative">
+                          <input
+                            type="radio"
+                            name="vehicle"
+                            value={v.id}
+                            checked={selectedVehicleId === v.id}
+                            onChange={() => setSelectedVehicleId(v.id)}
+                            disabled={isSaving}
+                          />
+                          {v.name}
+                        </label>
+                      ))}
+                    </div>
+                  ) : (
                     <div className="relative">
                       {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-                      <select id="vehicle" value={selectedVehicleId} onChange={handleInputChange(setSelectedVehicleId as any)} className="w-full px-4 py-3.5 bg-gray-50/50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-xl shadow-inner focus:outline-none focus:ring-2 focus:ring-brand-primary/50 dark:focus:ring-brand-primary-glow/50 focus:border-brand-primary text-gray-900 dark:text-gray-100 transition-all duration-300 hover:bg-white dark:hover:bg-gray-800 appearance-none font-medium cursor-pointer" disabled={isSaving}>
+                      <select id="vehicle" value={selectedVehicleId} onChange={handleInputChange(setSelectedVehicleId as any)} className="nocturne-input appearance-none cursor-pointer" disabled={isSaving}>
                         {vehicles.map((v) => ( <option key={v.id} value={v.id}>{v.name} ({v.make})</option> ))}
                       </select>
-                      <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-4 text-gray-500 dark:text-gray-400">
+                      <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3 text-gray-500 dark:text-gray-400">
                         <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7"></path></svg>
                       </div>
                     </div>
-                  </div>
+                  )}
+                </div>
 
-                  <div>
-                    <label htmlFor="brand" className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1.5 flex items-center justify-between">
-                      <span>{t('quickLog.fields.fillingStation')}</span>
-                      <span className="text-gray-400 font-normal text-xs bg-gray-100 dark:bg-gray-800 px-2 py-0.5 rounded-full">{t('quickLog.fields.fillingStationOptional')}</span>
-                    </label>
-                    <div className="relative">
-                      <div className="absolute inset-y-0 left-0 pl-3.5 flex items-center pointer-events-none">
-                        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" /><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" /></svg>
-                      </div>
-                      <input type="text" id="brand" value={brand} onChange={handleInputChange(setBrand)} placeholder={t('quickLog.fields.fillingStationPlaceholder')} className="w-full pl-10 pr-4 py-3 bg-gray-50/50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-xl shadow-inner focus:outline-none focus:ring-2 focus:ring-brand-primary/50 dark:focus:ring-brand-primary-glow/50 focus:border-brand-primary text-gray-900 dark:text-gray-100 transition-all duration-300 hover:bg-white dark:hover:bg-gray-800 placeholder-gray-400 font-medium" disabled={isSaving || isLoadingBrands} list="brand-suggestions" autoComplete="off" />
-                    </div>
-                    <datalist id="brand-suggestions">{knownBrands.map((b) => ( <option key={b} value={b} /> ))}</datalist>
-                  </div>
+                <div>
+                  <label htmlFor="brand" className="nocturne-label flex items-center justify-between">
+                    <span>{t('quickLog.fields.fillingStation')}</span>
+                    <span className="text-gray-400 dark:text-gray-500 font-normal">{t('quickLog.fields.fillingStationOptional')}</span>
+                  </label>
+                  <input type="text" id="brand" value={brand} onChange={handleInputChange(setBrand)} placeholder={t('quickLog.fields.fillingStationPlaceholder')} className="nocturne-input" disabled={isSaving || isLoadingBrands} list="brand-suggestions" autoComplete="off" />
+                  <datalist id="brand-suggestions">{knownBrands.map((b) => ( <option key={b} value={b} /> ))}</datalist>
                 </div>
               </div>
 
               {/* Section: Where (location) */}
-              <div className="group bg-white/40 dark:bg-white/[0.02] p-5 rounded-2xl border border-gray-100 dark:border-white/5 shadow-sm hover:shadow-md transition-all duration-300 backdrop-blur-md">
-                <div className="flex items-center justify-between gap-2 mb-4">
-                  <div className="flex items-center gap-2">
-                    <div className="w-1.5 h-4 bg-brand-primary rounded-full"></div>
-                    <h3 className="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-widest">{t('quickLog.sections.location', { defaultValue: 'Location' })}</h3>
-                  </div>
+              <div className="nocturne-card p-4">
+                <div className="flex items-center justify-between gap-2 mb-3">
+                  <span className="text-[11px] font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{t('quickLog.sections.location', { defaultValue: 'Location' })}</span>
                   <button
                     type="button"
                     onClick={() => setShowMap(s => !s)}
                     disabled={isSaving}
-                    className="text-xs font-semibold text-brand-primary dark:text-brand-primary-glow hover:underline disabled:opacity-50"
+                    className="text-xs font-medium text-amber-700 dark:text-amber-300 hover:text-brand-primary-hover dark:hover:text-brand-primary disabled:opacity-50"
                   >
                     {showMap
                       ? t('quickLog.location.hideMap', { defaultValue: 'Hide map' })
@@ -674,7 +662,7 @@ function QuickLogPage(): JSX.Element {
                               defaultValue: '{{lat}}, {{lng}}',
                             })}
                       </span>
-                      <span className={`text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full ${locationMode === 'manual' ? 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300' : 'bg-brand-primary/10 text-brand-primary dark:text-brand-primary-glow'}`}>
+                      <span className={`text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-md ${locationMode === 'manual' ? 'bg-amber-100 text-amber-700 dark:bg-amber-800 dark:text-amber-100' : 'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-100'}`}>
                         {locationMode === 'manual'
                           ? t('quickLog.location.manualBadge', { defaultValue: 'Pinned' })
                           : t('quickLog.location.gpsBadge', { defaultValue: 'GPS' })}
@@ -695,41 +683,35 @@ function QuickLogPage(): JSX.Element {
               </div>
 
               {/* Section 2: Transaction Details */}
-              <div className="group bg-white/40 dark:bg-white/[0.02] p-5 rounded-2xl border border-gray-100 dark:border-white/5 shadow-sm hover:shadow-md transition-all duration-300 backdrop-blur-md">
-                <div className="flex items-center gap-2 mb-4">
-                  <div className="w-1.5 h-4 bg-amber-400 rounded-full"></div>
-                  <h3 className="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-widest">{t('quickLog.sections.fuelCost')}</h3>
-                </div>
-
-                <div className="space-y-5">
+              <div className="space-y-4">
                   <div>
-                    <label htmlFor="loggedAt" className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1.5">{t('quickLog.fields.dateTime', { defaultValue: 'Date & time of fuelling' })}</label>
+                    <label htmlFor="loggedAt" className="nocturne-label">{t('quickLog.fields.dateTime', { defaultValue: 'Date & time of fuelling' })}</label>
                     <input
                       type="datetime-local"
                       id="loggedAt"
                       value={loggedAt}
                       max={toDatetimeLocal(new Date())}
                       onChange={(e) => setLoggedAt(e.target.value)}
-                      className="w-full px-4 py-3 bg-gray-50/50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-xl shadow-inner focus:outline-none focus:ring-2 focus:ring-amber-400/50 focus:border-amber-400 text-gray-900 dark:text-gray-100 transition-all duration-300 hover:bg-white dark:hover:bg-gray-800 font-medium"
+                      className="nocturne-input"
                       disabled={isSaving}
                     />
                   </div>
 
                   <div className="grid grid-cols-5 gap-3">
                     <div className="col-span-3">
-                      <label htmlFor="cost" className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1.5">{t('quickLog.fields.totalCost')}</label>
+                      <label htmlFor="cost" className="nocturne-label">{t('quickLog.fields.totalCost')}</label>
                       <div className="relative">
-                        <div className="absolute inset-y-0 left-0 pl-3.5 flex items-center pointer-events-none">
-                          <span className="text-gray-500 dark:text-gray-400 font-medium">{homeCurrencySymbol}</span>
+                        <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                          <span className="text-gray-500 dark:text-gray-400 text-sm font-medium">{homeCurrencySymbol}</span>
                         </div>
-                        <input type="number" inputMode="decimal" id="cost" value={cost} onChange={handleInputChange(setCost)} placeholder="0.00" step="0.01" min="0.01" required className="w-full pl-8 pr-4 py-3 text-lg bg-gray-50/50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-xl shadow-inner focus:outline-none focus:ring-2 focus:ring-amber-400/50 focus:border-amber-400 text-gray-900 dark:text-gray-100 transition-all duration-300 hover:bg-white dark:hover:bg-gray-800 fuel-numeral font-bold placeholder-gray-300 dark:placeholder-gray-600" disabled={isSaving} />
+                        <input type="number" inputMode="decimal" id="cost" value={cost} onChange={handleInputChange(setCost)} placeholder="0.00" step="0.01" min="0.01" required className="nocturne-input pl-8 fuel-numeral" disabled={isSaving} />
                       </div>
                     </div>
                     <div className="col-span-2">
-                      <label htmlFor="currency" className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1.5">{t('quickLog.fields.currency')}</label>
+                      <label htmlFor="currency" className="nocturne-label">{t('quickLog.fields.currency')}</label>
                       <div className="relative">
                         {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-                        <select id="currency" value={currency} onChange={handleInputChange(setCurrency as any)} className="w-full px-3 py-3.5 text-sm bg-gray-50/50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-xl shadow-inner focus:outline-none focus:ring-2 focus:ring-brand-primary/50 focus:border-brand-primary text-gray-900 dark:text-gray-100 transition-all duration-300 hover:bg-white dark:hover:bg-gray-800 appearance-none font-semibold cursor-pointer" disabled={isSaving}>
+                        <select id="currency" value={currency} onChange={handleInputChange(setCurrency as any)} className="nocturne-input appearance-none cursor-pointer" disabled={isSaving}>
                           {COMMON_CURRENCIES.map((curr) => ( <option key={curr.code} value={curr.code}>{curr.code}</option> ))}
                         </select>
                         <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3 text-gray-500">
@@ -740,19 +722,15 @@ function QuickLogPage(): JSX.Element {
                   </div>
 
                   {currency !== homeCurrency && (
-                    <div className="bg-gradient-to-r from-brand-primary/5 to-amber-400/5 dark:from-brand-primary/10 dark:to-amber-500/10 p-4 rounded-xl border border-brand-primary/20 dark:border-brand-primary/30 space-y-3 relative overflow-hidden">
-                      <div className="absolute top-0 right-0 w-16 h-16 bg-brand-primary/10 rounded-full filter blur-xl transform translate-x-1/2 -translate-y-1/2"></div>
-                      <div className="flex justify-between items-center relative z-10">
-                        <label htmlFor="exchangeRate" className="block text-xs font-bold text-brand-primary-hover dark:text-brand-primary-glow uppercase tracking-wider">
+                    <div className="nocturne-card p-4 space-y-3">
+                      <div className="flex justify-between items-center">
+                        <label htmlFor="exchangeRate" className="block text-[11px] font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                           {t('quickLog.fields.exchangeRate', { currency, homeCurrency })}
                         </label>
-                        {isFetchingRate && <span className="text-[10px] bg-brand-primary/10 text-brand-primary dark:text-brand-primary-glow px-2 py-0.5 rounded-full animate-pulse">{t('quickLog.fields.fetching')}</span>}
+                        {isFetchingRate && <span className="text-[10px] bg-amber-100 dark:bg-amber-800 text-amber-700 dark:text-amber-100 px-2 py-0.5 rounded-md animate-pulse">{t('quickLog.fields.fetching')}</span>}
                       </div>
-                      <div className="relative z-10">
-                        <input type="number" inputMode="decimal" id="exchangeRate" value={exchangeRate} onChange={handleRateChange} step="0.0001" min="0.0001" className="w-full px-4 py-2.5 bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm border border-brand-primary/30 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-primary focus:border-brand-primary text-gray-900 dark:text-gray-100 text-sm fuel-numeral font-medium transition-all duration-300" disabled={isSaving} />
-                      </div>
-                      <p className="text-xs text-brand-primary-hover dark:text-brand-primary-glow font-bold relative z-10 flex items-center gap-1">
-                        <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" /></svg>
+                      <input type="number" inputMode="decimal" id="exchangeRate" value={exchangeRate} onChange={handleRateChange} step="0.0001" min="0.0001" className="nocturne-input fuel-numeral" disabled={isSaving} />
+                      <p className="text-xs text-amber-700 dark:text-amber-300 font-medium flex items-center gap-1 mb-0">
                         {t('quickLog.fields.converted', { symbol: homeCurrencySymbol, amount: (parseFloat(cost || '0') * exchangeRate).toFixed(2) })}
                       </p>
                     </div>
@@ -760,37 +738,35 @@ function QuickLogPage(): JSX.Element {
 
                   <div className="grid grid-cols-3 gap-3 pt-2">
                     {odometerInputEnabled && (
-                      <div className="group/input">
-                        <label htmlFor="odometer" className="block text-[10px] font-bold text-gray-500 dark:text-gray-400 mb-1.5 uppercase tracking-widest">{t('quickLog.fields.odometer')}</label>
-                        <div className="relative">
-                          <input type="number" inputMode="decimal" id="odometer" value={odometerKmInput} onChange={handleOdometerChange} placeholder="0" step="1" min="0" className="w-full px-3 py-3 bg-gray-50/50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-xl shadow-inner focus:outline-none focus:ring-2 focus:ring-brand-primary/50 focus:border-brand-primary text-gray-900 dark:text-gray-100 text-sm transition-all duration-300 hover:bg-white dark:hover:bg-gray-800 fuel-numeral font-bold group-hover/input:border-gray-300 dark:group-hover/input:border-gray-600" disabled={isSaving} />
-                        </div>
+                      <div>
+                        <label htmlFor="odometer" className="nocturne-label text-[10px]">{t('quickLog.fields.odometer')}</label>
+                        <input type="number" inputMode="decimal" id="odometer" value={odometerKmInput} onChange={handleOdometerChange} placeholder="0" step="1" min="0" className="nocturne-input fuel-numeral" disabled={isSaving} />
                       </div>
                     )}
-                    <div className={odometerInputEnabled ? "group/input" : "col-span-2 group/input"}>
-                      <label htmlFor="distance" className="block text-[10px] font-bold text-gray-500 dark:text-gray-400 mb-1.5 uppercase tracking-widest">{t('quickLog.fields.distance')}</label>
+                    <div className={odometerInputEnabled ? "" : "col-span-2"}>
+                      <label htmlFor="distance" className="nocturne-label text-[10px]">{t('quickLog.fields.distance')}</label>
                       <div className="relative">
-                        <input type="number" inputMode="decimal" id="distance" value={distanceKmInput} onChange={handleInputChange(setDistanceKmInput)} placeholder="0.0" step="0.1" min="0.1" required className="w-full px-3 py-3 bg-gray-50/50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-xl shadow-inner focus:outline-none focus:ring-2 focus:ring-brand-primary/50 focus:border-brand-primary text-gray-900 dark:text-gray-100 text-sm transition-all duration-300 hover:bg-white dark:hover:bg-gray-800 fuel-numeral font-bold group-hover/input:border-gray-300 dark:group-hover/input:border-gray-600" disabled={isSaving} />
+                        <input type="number" inputMode="decimal" id="distance" value={distanceKmInput} onChange={handleInputChange(setDistanceKmInput)} placeholder="0.0" step="0.1" min="0.1" required className="nocturne-input fuel-numeral pr-9" disabled={isSaving} />
                         <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
-                          <span className="text-[10px] text-gray-400 font-bold uppercase">km</span>
+                          <span className="text-[10px] text-gray-400 dark:text-gray-500 font-bold uppercase">km</span>
                         </div>
                       </div>
                     </div>
-                    <div className="group/input">
-                      <label htmlFor="fuelAmount" className="block text-[10px] font-bold text-gray-500 dark:text-gray-400 mb-1.5 uppercase tracking-widest">{t('quickLog.fields.fuel')}</label>
+                    <div>
+                      <label htmlFor="fuelAmount" className="nocturne-label text-[10px]">{t('quickLog.fields.fuel')}</label>
                       <div className="relative">
-                        <input type="number" inputMode="decimal" id="fuelAmount" value={fuelAmountLiters} onChange={handleInputChange(setFuelAmountLiters)} placeholder="0.00" step="0.01" min="0.01" required className="w-full px-3 py-3 bg-gray-50/50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-xl shadow-inner focus:outline-none focus:ring-2 focus:ring-brand-primary/50 focus:border-brand-primary text-gray-900 dark:text-gray-100 text-sm transition-all duration-300 hover:bg-white dark:hover:bg-gray-800 fuel-numeral font-bold group-hover/input:border-gray-300 dark:group-hover/input:border-gray-600" disabled={isSaving} />
+                        <input type="number" inputMode="decimal" id="fuelAmount" value={fuelAmountLiters} onChange={handleInputChange(setFuelAmountLiters)} placeholder="0.00" step="0.01" min="0.01" required className="nocturne-input fuel-numeral pr-7" disabled={isSaving} />
                         <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
-                          <span className="text-[10px] text-gray-400 font-bold uppercase">L</span>
+                          <span className="text-[10px] text-gray-400 dark:text-gray-500 font-bold uppercase">L</span>
                         </div>
                       </div>
                     </div>
                   </div>
 
                   {odometerInputEnabled && odometerKmInput && (
-                    <div className="mt-2 bg-gray-50/50 dark:bg-gray-800/30 rounded-lg p-2.5 border border-gray-100 dark:border-gray-700/50">
+                    <div className="mt-2">
                       {lastOdometerReading === null ? (
-                        <p className="text-[11px] text-amber-600 dark:text-amber-400 font-medium flex items-center gap-1.5">
+                        <p className="text-[11px] text-amber-700 dark:text-amber-300 font-medium flex items-center gap-1.5">
                           <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" /></svg>
                           {t('quickLog.fields.odometerHintBaseline')}
                         </p>
@@ -808,11 +784,10 @@ function QuickLogPage(): JSX.Element {
                       )}
                     </div>
                   )}
-                </div>
               </div>
 
               {/* Section 3: Receipt Digitization */}
-              <div className="transform transition-all duration-300 hover:-translate-y-0.5">
+              <div>
                 <ReceiptAISection
                   receiptDigitizationEnabled={receiptDigitizationEnabled}
                   receiptAutoFillEnabled={receiptAutoFillEnabled}
@@ -828,15 +803,14 @@ function QuickLogPage(): JSX.Element {
               </div>
 
               {/* Submit Button */}
-              <div className="pt-2 relative group">
-                <div className="absolute -inset-1 bg-gradient-to-r from-brand-primary to-amber-400 rounded-2xl blur opacity-20 group-hover:opacity-40 transition duration-300"></div>
-                <button type="submit" disabled={isSaving || isLoadingBrands} className="relative w-full brand-button-primary py-4 text-lg font-bold rounded-2xl overflow-hidden shadow-xl shadow-brand-primary/20 hover:shadow-brand-primary/40 transform transition-all active:scale-[0.98]">
+              <div className="pt-2 relative">
+                <button type="submit" disabled={isSaving || isLoadingBrands} className="relative w-full brand-button-primary py-3 text-base">
                     <span className={`flex items-center justify-center gap-2 ${isSaving ? 'opacity-0' : 'opacity-100'} transition-opacity duration-300`}>
                       <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" /></svg>
                       {t('quickLog.submit.save')}
                     </span>
                     {isSaving && (
-                      <span className="absolute inset-0 flex items-center justify-center gap-2 text-white">
+                      <span className="absolute inset-0 flex items-center justify-center gap-2">
                         <svg className="animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle><path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>
                         {t(`quickLog.submit.${savingStep}`)}
                       </span>

--- a/src/pages/StationsPage.tsx
+++ b/src/pages/StationsPage.tsx
@@ -80,10 +80,10 @@ const StationsPage: React.FC = () => {
 
     return (
         <div className="p-4 sm:p-6 lg:p-8">
-            <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-6">{t('stations.title')}</h1>
+            <h1 className="text-2xl sm:text-3xl font-medium tracking-tight text-gray-900 dark:text-gray-100 mb-6">{t('stations.title')}</h1>
             
             {stations.length === 0 ? (
-                <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md border border-gray-100 dark:border-gray-700 text-center text-gray-600 dark:text-gray-300">
+                <div className="nocturne-card p-6 text-center text-gray-600 dark:text-gray-300">
                     <p>{t('stations.noStationsFound')}</p>
                 </div>
             ) : (
@@ -100,7 +100,7 @@ const StationsPage: React.FC = () => {
                         {selectedStationId ? (
                             <StationDetail stationId={selectedStationId} />
                         ) : (
-                            <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md border border-gray-100 dark:border-gray-700 text-center text-gray-600 dark:text-gray-300">
+                            <div className="nocturne-card p-6 text-center text-gray-600 dark:text-gray-300">
                                 <p>{t('stations.selectStationPrompt')}</p>
                             </div>
                         )}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,8 +21,8 @@ export default defineConfig({
         name: 'Fuelog',
         short_name: 'Fuelog',
         description: 'Track vehicle fuel consumption and costs.',
-        theme_color: '#D97706',
-        background_color: '#ffffff',
+        theme_color: '#161826',
+        background_color: '#161826',
         display: 'standalone',
         orientation: 'portrait-primary',
         icons: [


### PR DESCRIPTION
## 📋 Description
Implements the **Fuelog.dc.html** redesign from the Claude Design project (Nocturne design system): a quiet, compact dark interface on a near-neutral blue-grey ground (`#161826`), Inter typography, soft radii, and a single blurple accent (`#9184d9`) used as a line and a glow rather than a flood. Contrast comes from tonal ramps, not saturation. The existing light/dark theme toggle keeps working — dark mode is now full Nocturne, and light mode uses the same blue-tinted neutrals and accent.

## 🚀 Proposed Changes
- Remapped the Tailwind `gray` ramp to Nocturne's blue-grey neutral ramp and the `amber`/`indigo` ramps to the Nocturne accent ramp in `src/index.css`, so every screen resolves into the new palette with a small diff
- Swapped Space Grotesk / Space Mono for **Inter** (headings + body) with system mono for data numerals; updated `index.html` fonts and PWA `theme_color` / `background_color`
- Converted primary actions to the Nocturne **outlined-accent** button style (`brand-button-primary`), added `brand-button-secondary`, `nocturne-card`, `nocturne-input`, `nocturne-label`, `nocturne-tag`, and a `nocturne-seg` segmented control, plus themed focus rings, selection, and scrollbars
- App shell: new drop-mark logo + lowercase `fuelog` brand, flat accent-on-active desktop nav links in the design's order (Log / Dashboard / History / Map / Stations / Profile), restyled bottom nav and footer, accent loaders, and the design's radial accent glow on the dark ground
- **Quick Log**: left-aligned flat form (no glass card), segmented vehicle control for ≤3 vehicles (select beyond that), Nocturne fields, location card, and a dashed accent-tinted AI receipt drop zone
- **Dashboard**: flat centered stat tiles with mono numerals (icon chips removed per design), Nocturne chart palette for Recharts (accent bars/lines, surface tooltips, ramp gridlines)
- **History / Stations / Map / Profile**: surface cards, medium heading weights, neutral/accent tags, Nocturne filter inputs, restyled map controls and dark Leaflet popups
- New Nocturne favicon (drop mark on the dark ground)

## 🛡️ Checklist
- [x] I have verified that all unit tests pass locally (`npm run test`) — 240/240 passing
- [x] I have verified that the build succeeds locally (`npm run build`)
- [ ] I have added/updated unit tests for my changes (visual-only restyle; existing tests cover the touched components)
- [x] I have followed the project's coding standards and naming conventions.
- [ ] I have updated the documentation (`docs/`) if necessary.
- [ ] New features are gated behind a Remote Config flag (visual restyle, no new behaviour; existing flags untouched)

## 📸 Screenshots (if applicable)
Verified by rendering the built CSS in dark mode: Nocturne ground/surfaces, outlined accent primary button, segmented control, stat tiles with mono numerals, and header nav all match the design screens.

## 🔗 Related Issues/PRs
Design source: Claude Design project `Fuelog.dc.html` (Nocturne redesign — Quick Log, Dashboard, History, Stations, Map, Profile screens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9BU66feaHpTFxfBN84x96

---
_Generated by [Claude Code](https://claude.ai/code/session_01F9BU66feaHpTFxfBN84x96)_